### PR TITLE
Feature/minimize to tray

### DIFF
--- a/GammaLauncher.vl
+++ b/GammaLauncher.vl
@@ -899,7 +899,7 @@
               <Overlay Id="Ka9EJQtE6iuLav0iXGSYfz" Name="Kill vvvv" Bounds="516,413,238,160">
                 <p:ColorIndex p:Type="Int32">11</p:ColorIndex>
               </Overlay>
-              <Node Bounds="793,721,45,26" Id="RfIjPh87mLDPR101kb3WlO">
+              <Node Bounds="789,670,45,26" Id="RfIjPh87mLDPR101kb3WlO">
                 <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -909,8 +909,8 @@
                 <Pin Id="Syzqkl0HK4nPlML2BktVBu" Name="Output" Kind="StateOutputPin" />
                 <Pin Id="QhfgOtOp5tLMaw6g4rwZfc" Name="Value" Kind="OutputPin" />
               </Node>
-              <Pad Id="KxGEaJfEPT6OLecP6XsESj" SlotId="Akp67GlzwwxMh9VTt1Ee9U" Bounds="795,703" />
-              <Node Bounds="829,751,153,26" Id="GM9o60aBvUVO9PBJ2DyuSi">
+              <Pad Id="KxGEaJfEPT6OLecP6XsESj" SlotId="Akp67GlzwwxMh9VTt1Ee9U" Bounds="791,652" />
+              <Node Bounds="829,706,153,26" Id="GM9o60aBvUVO9PBJ2DyuSi">
                 <p:NodeReference LastCategoryFullName="Main.Model.SettingsTabModel" LastDependency="GammaLauncher.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="SettingsTabModel" />
@@ -952,19 +952,19 @@
                   </Node>
                 </Patch>
               </Node>
-              <Node Bounds="943,998,184,120" Id="MLvPtGEO3nrLblDLZieWLd">
+              <Node Bounds="962,1000,184,137" Id="MLvPtGEO3nrLblDLZieWLd">
                 <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
                   <CategoryReference Kind="Category" Name="Primitive" />
                 </p:NodeReference>
                 <Pin Id="QAFXw1dvO1DPNx0uKALjUN" Name="Break" Kind="OutputPin" />
-                <ControlPoint Id="RseAy4LpSQ9Lu3BZexmLaD" Bounds="1020,1004" Alignment="Top" />
+                <ControlPoint Id="RseAy4LpSQ9Lu3BZexmLaD" Bounds="1039,1006" Alignment="Top" />
                 <Patch Id="CYuhNkrsJvxOSUOt1VKu3x" ManuallySortedPins="true">
                   <Patch Id="TfORVhJWDPeLy9IjcLFwu1" Name="Create" ManuallySortedPins="true" />
                   <Patch Id="KtJn584cLJHO6CUlOqnHJl" Name="Update" ManuallySortedPins="true" />
                   <Patch Id="Ly3JOaJ8YasLlEOPdxWYSc" Name="Dispose" ManuallySortedPins="true" />
-                  <Node Bounds="966,1018,149,80" Id="R3XeTEQhAlVPRLvowcu8AP">
+                  <Node Bounds="985,1020,149,97" Id="R3XeTEQhAlVPRLvowcu8AP">
                     <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                       <Choice Kind="ApplicationStatefulRegion" Name="If" />
@@ -974,7 +974,7 @@
                     <Patch Id="DiMMLWDlrfOLr5lHl3wvsE" ManuallySortedPins="true">
                       <Patch Id="G1ymGK1dpEELj0GoSnWmu5" Name="Create" ManuallySortedPins="true" />
                       <Patch Id="T3SxHPVnhFdMHO8yIiBzcf" Name="Then" ManuallySortedPins="true" />
-                      <Node Bounds="978,1050,125,19" Id="NShCxbjmyv4N4MUfpS84vM">
+                      <Node Bounds="997,1078,125,19" Id="NShCxbjmyv4N4MUfpS84vM">
                         <p:NodeReference LastCategoryFullName="System" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="Executor" />
@@ -999,18 +999,27 @@
                         <Pin Id="HcwwsBKLGlUPpSkZ7T1x0J" Name="IsRunning" Kind="OutputPin" />
                         <Pin Id="CpaUIX8B97yQSHL7GHls2p" Name="Exit Code" Kind="OutputPin" />
                       </Node>
+                      <Node Bounds="1037,1043,70,26" Id="Qk9tZ1YO9AcLw4AqirDVef">
+                        <p:NodeReference LastCategoryFullName="Primitive.Tuple (2 Items)" LastDependency="VL.CoreLib.vl">
+                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                          <CategoryReference Kind="ClassType" Name="Tuple (2 Items)" />
+                          <Choice Kind="OperationCallFlag" Name="Item2" />
+                        </p:NodeReference>
+                        <Pin Id="D4cR37dA7wSNQmHymlIwjv" Name="Input" Kind="StateInputPin" />
+                        <Pin Id="VxcDjYspWqNO1haDYxPl4F" Name="Item 2" Kind="OutputPin" />
+                      </Node>
                     </Patch>
                   </Node>
                 </Patch>
               </Node>
-              <Node Bounds="817,798,75,136" Id="VtGyt88yU6DLneUawUyF07">
+              <Node Bounds="817,753,94,181" Id="VtGyt88yU6DLneUawUyF07">
                 <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
                   <CategoryReference Kind="Category" Name="Primitive" />
                 </p:NodeReference>
                 <Pin Id="UVXrkBaz3UnPtSsnZXG7fv" Name="Break" Kind="OutputPin" />
-                <ControlPoint Id="BflrzoV52bbNyaG58xCUEi" Bounds="831,804" Alignment="Top" />
+                <ControlPoint Id="BflrzoV52bbNyaG58xCUEi" Bounds="831,759" Alignment="Top" />
                 <ControlPoint Id="Scc1ZMbXQsoNffjFvToVrr" Bounds="831,928" Alignment="Bottom" />
                 <Patch Id="I0a72v0d69nNqhCrKMcob0" ManuallySortedPins="true">
                   <Patch Id="Ulvz3qo388ANFcKJQqJgei" Name="Create" ManuallySortedPins="true" />
@@ -1046,9 +1055,18 @@
                     <Pin Id="AoQ868NaSQeMRQzSITAl21" Name="New Value" Kind="InputPin" />
                     <Pin Id="O7hPf2niQAlPkUptAGyzdC" Name="Output" Kind="StateOutputPin" />
                   </Node>
+                  <Node Bounds="829,778,70,26" Id="Nj17zWBSdgaM1dPhg2ANaN">
+                    <p:NodeReference LastCategoryFullName="Primitive.Tuple (2 Items)" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="ClassType" Name="Tuple (2 Items)" />
+                      <Choice Kind="OperationCallFlag" Name="Item2" />
+                    </p:NodeReference>
+                    <Pin Id="VIuvJMoXa5NMT83LZx1qev" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="Lqklgk7WQIaLXFA8e1DTMQ" Name="Item 2" Kind="OutputPin" />
+                  </Node>
                 </Patch>
               </Node>
-              <Node Bounds="966,951,50,26" Id="CR2bDvFZYcxOo7vChSOoMD">
+              <Node Bounds="985,958,50,26" Id="CR2bDvFZYcxOo7vChSOoMD">
                 <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="AND (Spectral)" />
@@ -1081,7 +1099,7 @@
                   </Node>
                 </Patch>
               </Node>
-              <Overlay Id="NefjVx56wI1QUre2PhWdfx" Name="Show package repositories folders" Bounds="643,652,537,498">
+              <Overlay Id="NefjVx56wI1QUre2PhWdfx" Name="Show package repositories folders" Bounds="643,608,537,542">
                 <p:ColorIndex p:Type="Int32">11</p:ColorIndex>
               </Overlay>
               <Node Bounds="843,1325,104,26" Id="UgIP9o7aqIIMrE6mGKcW1M">
@@ -1778,9 +1796,7 @@
             <Link Id="L8LETii9otCPBMAF4Md6OR" Ids="QhfgOtOp5tLMaw6g4rwZfc,VhlqJytu655OuNhQeVLuDA" />
             <Link Id="SDdkZ1FJEbCNIPzuYkNQSw" Ids="UBN7WoYvl8oLTd8WqjOKT1,BflrzoV52bbNyaG58xCUEi" />
             <Link Id="VNLCE8N7TjPQMHR8bUFadk" Ids="UBN7WoYvl8oLTd8WqjOKT1,RseAy4LpSQ9Lu3BZexmLaD" />
-            <Link Id="GVOJK2b2fjUOR5P2KavAuY" Ids="RseAy4LpSQ9Lu3BZexmLaD,FzBZBPhsvELO5tUbi3be6o" />
             <Link Id="MQji4Rg8rXOP0JAuPmo0lN" Ids="KRTSUBh222gNslLh4EbLzA,QbRPLxpQsJ2MVroszfACxB" />
-            <Link Id="S0XKJnUkVB8M9zUuLrmoo6" Ids="BflrzoV52bbNyaG58xCUEi,QMxH6fEfjy5OPAiPBOFkvL" />
             <Link Id="TLTrMSgZWF9OIQS8LKhIZY" Ids="LW5ZFZb2TzIP1yeBiUBFUD,Scc1ZMbXQsoNffjFvToVrr" />
             <Link Id="S33VFZOeWquMBz8UOzmmTB" Ids="Scc1ZMbXQsoNffjFvToVrr,J6p6OBcl4OELi6vM6i1uTO" />
             <Link Id="E1iGBnM3UrjPnNJ6S8GFZR" Ids="NMD6jm0X6DgMrOT9XiUMFa,Q6kkLtYSfPSNZ6YPTi9udv" IsHidden="true" />
@@ -1887,6 +1903,10 @@
             <Link Id="AdDdPw2EbmnLwFNzkvM9rc" Ids="OVglyiJB3puMlSOVk078mA,B48YfeKqgF7OPs7BkuCyPU" />
             <Patch Id="IzXwv77O7wiNFgqGHJRCiJ" Name="SetSelectedVersionToEmptyString" ParticipatingElements="KDlLilTikyjO0dtna1ylKY,CpvlgDPLLSIOYQekKDAhVx,HqYGrDfsXQdP8Lye0ayfMK,AdDdPw2EbmnLwFNzkvM9rc" />
             <Link Id="E9fSGWDi6rXPVAx8iwklZo" Ids="ERJ4OdnUgQwLWPDtdWejmT,TTw4m4vABwyPBIyYNaj7ek" />
+            <Link Id="VRrUBPUtWC9NfipPZAtEJ0" Ids="BflrzoV52bbNyaG58xCUEi,VIuvJMoXa5NMT83LZx1qev" />
+            <Link Id="CQF4fO4Hkq9M99CvIPQOgS" Ids="Lqklgk7WQIaLXFA8e1DTMQ,QMxH6fEfjy5OPAiPBOFkvL" />
+            <Link Id="Lukpwptov4TLZDaqS07IY5" Ids="RseAy4LpSQ9Lu3BZexmLaD,D4cR37dA7wSNQmHymlIwjv" />
+            <Link Id="QbEfB3NHB5BMgkZQBoobOK" Ids="VxcDjYspWqNO1haDYxPl4F,FzBZBPhsvELO5tUbi3be6o" />
           </Patch>
         </Node>
         <!--
@@ -2729,7 +2749,7 @@
                   </Pad>
                 </Patch>
               </Node>
-              <Node Bounds="1323,1246,101,19" Id="Hcmr4FCk5CONNXouoJ8GGR">
+              <Node Bounds="1323,1246,101,26" Id="Hcmr4FCk5CONNXouoJ8GGR">
                 <p:NodeReference LastCategoryFullName="Downloader.DownloadConfiguration" LastDependency="Downloader.dll">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="AssemblyCategory" Name="DownloadConfiguration" />
@@ -2737,7 +2757,7 @@
                 </p:NodeReference>
                 <Pin Id="SbPQJVAgLjBLpNLKw0AJGD" Name="Output" Kind="StateOutputPin" />
               </Node>
-              <Node Bounds="1323,1295,77,19" Id="TzAHwOmFOtsPFDo8LxgHlv">
+              <Node Bounds="1323,1295,77,26" Id="TzAHwOmFOtsPFDo8LxgHlv">
                 <p:NodeReference LastCategoryFullName="Downloader.DownloadService" LastDependency="Downloader.dll" OverloadStrategy="AllPinsThatAreNotCommon">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="AssemblyCategory" Name="DownloadService" />
@@ -2747,7 +2767,7 @@
                 <Pin Id="MSf7ZdjDCAENiH5jf5PVHW" Name="Options" Kind="InputPin" />
                 <Pin Id="LRDby3h3FkGQAI4TdKUo3P" Name="Output" Kind="StateOutputPin" />
               </Node>
-              <Node Bounds="1591,1547,141,19" Id="RpPEwkY2bvkNHUf1rSMC9w">
+              <Node Bounds="1591,1547,141,26" Id="RpPEwkY2bvkNHUf1rSMC9w">
                 <p:NodeReference LastCategoryFullName="Downloader.DownloadService" LastDependency="Downloader.dll">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="AssemblyCategory" Name="DownloadService" />
@@ -2756,7 +2776,7 @@
                 <Pin Id="TpYQzIA2doOPDMRu1bYFhR" Name="Input" Kind="StateInputPin" />
                 <Pin Id="IeWlAiqAbQjMq5P6elujU8" Name="Result" Kind="OutputPin" />
               </Node>
-              <Node Bounds="1323,1547,94,19" Id="QiCJxLOK87cLpDqjgEczX3">
+              <Node Bounds="1323,1547,94,26" Id="QiCJxLOK87cLpDqjgEczX3">
                 <p:NodeReference LastCategoryFullName="Downloader.DownloadService" LastDependency="Downloader.dll">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="AssemblyCategory" Name="DownloadService" />
@@ -2765,7 +2785,7 @@
                 <Pin Id="MLvWm5FMlzMLv2u6hwp2Wy" Name="Input" Kind="StateInputPin" />
                 <Pin Id="RKy3d8ji5xnMvKhjIc52SA" Name="Result" Kind="OutputPin" />
               </Node>
-              <Node Bounds="1894,1546,127,19" Id="C6qXUYELD1BLUOs9AW2tAu">
+              <Node Bounds="1894,1546,127,26" Id="C6qXUYELD1BLUOs9AW2tAu">
                 <p:NodeReference LastCategoryFullName="Downloader.DownloadService" LastDependency="Downloader.dll">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="AssemblyCategory" Name="DownloadService" />
@@ -2849,7 +2869,7 @@
                       </p:TypeAnnotation>
                     </Pin>
                   </Patch>
-                  <Node Bounds="1603,1683,150,19" Id="B0CKUlopaNcNjcdfEZtZzw">
+                  <Node Bounds="1603,1683,150,26" Id="B0CKUlopaNcNjcdfEZtZzw">
                     <p:NodeReference LastCategoryFullName="Downloader.DownloadProgressChangedEventArgs" LastDependency="Downloader.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="DownloadProgressChangedEventArgs" />
@@ -3011,7 +3031,7 @@
                 <Patch Id="AoKokANyBY0MLkoS1bBlNK" ManuallySortedPins="true">
                   <ControlPoint Id="RJNnAJSoqijNEPARO9H8Si" Bounds="1522,1172" />
                   <ControlPoint Id="QPJmj8ncB3kQGkC7KTr0si" Bounds="1487,1423" />
-                  <Node Bounds="1481,1368,125,19" Id="VvE4ub1XAnaLAuJFUguBhV">
+                  <Node Bounds="1481,1368,125,26" Id="VvE4ub1XAnaLAuJFUguBhV">
                     <p:NodeReference LastCategoryFullName="Downloader.DownloadService" LastDependency="Downloader.dll" OverloadStrategy="AllPinsThatAreNotCommon">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="DownloadService" />
@@ -6409,7 +6429,7 @@
                               </p:NodeReference>
                               <Patch Id="VgWLqzqil3xOredHUdNsmP">
                                 <Canvas Id="IWtwn1Xk9QBNbfsa24Ojz8" CanvasType="Group">
-                                  <Node Bounds="385,767,59,19" Id="HyH2uK2JdKTLGpQUf4eksO">
+                                  <Node Bounds="739,1483,59,19" Id="HyH2uK2JdKTLGpQUf4eksO">
                                     <p:NodeReference LastCategoryFullName="ImGui.Commands" LastDependency="VL.ImGui.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <Choice Kind="ProcessNode" Name="SameLine" />
@@ -6419,7 +6439,7 @@
                                     <Pin Id="DeHV193rd0EQNyb2fraPbw" Name="Spacing" Kind="InputPin" />
                                     <Pin Id="AMEE0afzrvnN3HxParTztk" Name="Context" Kind="OutputPin" />
                                   </Node>
-                                  <Node Bounds="385,863,85,19" Id="Ic7ZG7UkqDgMn0XWYxw1mc">
+                                  <Node Bounds="739,1579,85,19" Id="Ic7ZG7UkqDgMn0XWYxw1mc">
                                     <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <CategoryReference Kind="Category" Name="Widgets" NeedsToBeDirectParent="true" />
@@ -6433,7 +6453,7 @@
                                     <Pin Id="VHZk8cZwE8nNmlcj01knRe" Name="Context" Kind="OutputPin" />
                                     <Pin Id="LUl2hfwnnOaLnZ3XRV7xKf" Name="Bang" Kind="OutputPin" />
                                   </Node>
-                                  <Node Bounds="415,378,43,19" Id="CXUcgFrTjugOuEFATUx5Zu">
+                                  <Node Bounds="362,395,43,19" Id="CXUcgFrTjugOuEFATUx5Zu">
                                     <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <Choice Kind="ProcessAppFlag" Name="Select (ByPath)" />
@@ -6442,8 +6462,7 @@
                                     <Pin Id="EdcSlJIxm0BQdS4lPrStcd" Name="Path" Kind="InputPin" DefaultValue="Package Repositories Folder[0]" />
                                     <Pin Id="OYpd9PUrLqvM9fN3YiIuAi" Name="Output" Kind="OutputPin" />
                                   </Node>
-                                  <ControlPoint Id="PL8YnZCTdXdQZmcyyQoc7y" Bounds="708,283" />
-                                  <Node Bounds="473,310,55,19" Id="QFneJvRXglTLUxRbME1bES">
+                                  <Node Bounds="420,327,55,19" Id="QFneJvRXglTLUxRbME1bES">
                                     <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <Choice Kind="OperationCallFlag" Name="ToString" />
@@ -6451,7 +6470,7 @@
                                     <Pin Id="D76MwrN1gMcL3Gd3VjfPzN" Name="Input" Kind="InputPin" />
                                     <Pin Id="JoXRgkOe8rAPE1YIbka91n" Name="Result" Kind="OutputPin" />
                                   </Node>
-                                  <Node Bounds="465,937,257,164" Id="C9jGj1gRlyANzkpiki02QU">
+                                  <Node Bounds="819,1653,257,164" Id="C9jGj1gRlyANzkpiki02QU">
                                     <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                       <CategoryReference Kind="Category" Name="Primitive" />
@@ -6461,7 +6480,7 @@
                                     <Patch Id="KmHancQIpXTMnEyyUNS66h" ManuallySortedPins="true">
                                       <Patch Id="BdNLL2P3aE2MUYyETKIKE6" Name="Create" ManuallySortedPins="true" />
                                       <Patch Id="PKmbmfuuIjfMOAbTHGO31y" Name="Then" ManuallySortedPins="true" />
-                                      <Node Bounds="527,1010,183,26" Id="AkHKY1KwAwhLyIQ2t1qFel">
+                                      <Node Bounds="881,1726,183,26" Id="AkHKY1KwAwhLyIQ2t1qFel">
                                         <p:NodeReference LastCategoryFullName="Main.Model.SettingsTabModel" LastDependency="GammaLauncher.vl">
                                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                           <Choice Kind="OperationCallFlag" Name="RemoveEditablePackage" />
@@ -6470,7 +6489,7 @@
                                         <Pin Id="Qj4yDHdE3ghNKzP1pCinrH" Name="Index" Kind="InputPin" />
                                         <Pin Id="VEZ6pF6yIKRN3ygLSFqcDb" Name="Output" Kind="StateOutputPin" />
                                       </Node>
-                                      <Node Bounds="477,960,45,26" Id="NxCT4t2rOZXOo9MYS73jBO">
+                                      <Node Bounds="831,1676,45,26" Id="NxCT4t2rOZXOo9MYS73jBO">
                                         <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                           <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -6480,7 +6499,7 @@
                                         <Pin Id="LSlHHg2yO1xNTjJxnYSKKt" Name="Output" Kind="StateOutputPin" />
                                         <Pin Id="N7jmFqwmWdWOBJx2p2DLxc" Name="Value" Kind="OutputPin" />
                                       </Node>
-                                      <Node Bounds="477,1055,55,26" Id="C2qqTQuF8kgM6K5iLMGwFe">
+                                      <Node Bounds="831,1771,55,26" Id="C2qqTQuF8kgM6K5iLMGwFe">
                                         <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                           <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -6492,7 +6511,7 @@
                                       </Node>
                                     </Patch>
                                   </Node>
-                                  <Node Bounds="444,421,85,19" Id="P1HMUyr32oKLExSdO3K7X2">
+                                  <Node Bounds="794,691,85,19" Id="P1HMUyr32oKLExSdO3K7X2">
                                     <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
@@ -6505,7 +6524,7 @@
                                     <Pin Id="Ta6MnZowTWIO9UGyNjz33d" Name="Input 4" Kind="InputPin" />
                                     <Pin Id="FJoSyFOcw4XLxitTqKcuSg" Name="Output" Kind="StateOutputPin" />
                                   </Node>
-                                  <Node Bounds="425,830,85,19" Id="DKrM12aIwjpM8JkhSDafPX">
+                                  <Node Bounds="779,1546,85,19" Id="DKrM12aIwjpM8JkhSDafPX">
                                     <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
@@ -6518,7 +6537,7 @@
                                     <Pin Id="NjEg91VP2EFLQbwN2W00ep" Name="Input 4" Kind="InputPin" />
                                     <Pin Id="AUrrhjNzOauLyyAV9QXcJC" Name="Output" Kind="StateOutputPin" />
                                   </Node>
-                                  <Node Bounds="453,347,85,19" Id="VXezhgnPedRPPkaMtCWW3e">
+                                  <Node Bounds="400,364,85,19" Id="VXezhgnPedRPPkaMtCWW3e">
                                     <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
@@ -6531,13 +6550,13 @@
                                     <Pin Id="Fl3alLBdUxXMtDvJgrZiqq" Name="Input 4" Kind="InputPin" />
                                     <Pin Id="QAMeE5WShtuLBNh7gbgWAg" Name="Output" Kind="StateOutputPin" />
                                   </Node>
-                                  <ControlPoint Id="L4SkuufLtFJOwO5mvvGFkG" Bounds="386,-71" />
-                                  <ControlPoint Id="MWyxPwPgl3uL4uUyz767c3" Bounds="388,1160" />
-                                  <ControlPoint Id="EGuiimVG0CUQcXqJXu28Fp" Bounds="479,909" />
-                                  <ControlPoint Id="QVDzwzdGD3uMUMvG56Fjbf" Bounds="417,334" />
-                                  <ControlPoint Id="UpKC5nqLilcMdizUY5Viz6" Bounds="783,281" />
-                                  <ControlPoint Id="L4B6cH7bFqVOfiOPD6Iypa" Bounds="892,282" />
-                                  <Node Bounds="384,79,162,19" Id="To7sKRtRcZkNnl42ePwpLy">
+                                  <ControlPoint Id="L4SkuufLtFJOwO5mvvGFkG" Bounds="740,483" />
+                                  <ControlPoint Id="MWyxPwPgl3uL4uUyz767c3" Bounds="742,1876" />
+                                  <ControlPoint Id="EGuiimVG0CUQcXqJXu28Fp" Bounds="833,1625" />
+                                  <ControlPoint Id="QVDzwzdGD3uMUMvG56Fjbf" Bounds="364,351" />
+                                  <ControlPoint Id="UpKC5nqLilcMdizUY5Viz6" Bounds="883,1239" />
+                                  <ControlPoint Id="L4B6cH7bFqVOfiOPD6Iypa" Bounds="821,1487" />
+                                  <Node Bounds="738,540,162,19" Id="To7sKRtRcZkNnl42ePwpLy">
                                     <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <Choice Kind="ProcessNode" Name="Checkbox" />
@@ -6550,7 +6569,7 @@
                                     <Pin Id="Vbi1kY66HUINfdG0FNIFrM" Name="Bang" Kind="OutputPin" />
                                     <Pin Id="HXEbwmPQVoPO2WpASHnEX9" Name="Value" Kind="OutputPin" />
                                   </Node>
-                                  <Node Bounds="384,163,59,19" Id="LeSkaeL7SzNPL4uYqKZMS5">
+                                  <Node Bounds="738,624,59,19" Id="LeSkaeL7SzNPL4uYqKZMS5">
                                     <p:NodeReference LastCategoryFullName="ImGui.Commands" LastDependency="VL.ImGui.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <Choice Kind="ProcessNode" Name="SameLine" />
@@ -6560,7 +6579,7 @@
                                     <Pin Id="B34u149FZg6OYo0RGJaCvi" Name="Spacing" Kind="InputPin" />
                                     <Pin Id="NJVd60Gfe5WPD07t4m7DpN" Name="Context" Kind="OutputPin" />
                                   </Node>
-                                  <Node Bounds="541,212,37,19" Id="OIZgR2fxF3BNtsqTdLfKWZ">
+                                  <Node Bounds="895,673,37,19" Id="OIZgR2fxF3BNtsqTdLfKWZ">
                                     <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <Choice Kind="OperationCallFlag" Name="NOT" />
@@ -6568,7 +6587,7 @@
                                     <Pin Id="NAbis79HkCHO2RZhiy6ro2" Name="Input" Kind="StateInputPin" />
                                     <Pin Id="SYDFhV7EwLqNZftUQ3KAkd" Name="Output" Kind="StateOutputPin" />
                                   </Node>
-                                  <Node Bounds="541,50,97,19" Id="Ecapph7ZLncNapF9PS8cY8">
+                                  <Node Bounds="895,511,97,19" Id="Ecapph7ZLncNapF9PS8cY8">
                                     <p:NodeReference LastCategoryFullName="ImGui.Styling" LastDependency="VL.ImGui.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <Choice Kind="ProcessNode" Name="SetCheckboxStyle" />
@@ -6577,12 +6596,12 @@
                                     <Pin Id="LMXzTAgw98INAibv0wZeDl" Name="Checkmark" Kind="InputPin" />
                                     <Pin Id="Aoizz5Z2tCfLZvAocv4GHL" Name="Output" Kind="OutputPin" />
                                   </Node>
-                                  <Pad Id="JLycEWUhWrPLj7UOKP28ZU" Comment="Checkmark" Bounds="635,29,22,15" ShowValueBox="true" isIOBox="true" Value="0.9411765, 0.7411765, 0.050980393, 1">
+                                  <Pad Id="JLycEWUhWrPLj7UOKP28ZU" Comment="Checkmark" Bounds="989,490,22,15" ShowValueBox="true" isIOBox="true" Value="0.9411765, 0.7411765, 0.050980393, 1">
                                     <p:TypeAnnotation LastCategoryFullName="Color" LastDependency="VL.CoreLib.vl">
                                       <Choice Kind="TypeFlag" Name="RGBA" />
                                     </p:TypeAnnotation>
                                   </Pad>
-                                  <Node Bounds="384,125,284,19" Id="UAIzmS1kgUGNkCOWVEwMtl">
+                                  <Node Bounds="738,586,284,19" Id="UAIzmS1kgUGNkCOWVEwMtl">
                                     <p:NodeReference LastCategoryFullName="ImGui.Queries" LastDependency="VL.ImGui.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <Choice Kind="ProcessNode" Name="IsItemHovered" />
@@ -6592,7 +6611,7 @@
                                     <Pin Id="UPUBLlvNWobQAmPQpgXOjB" Name="Context" Kind="OutputPin" />
                                     <Pin Id="Ga8Md74dZm5MGNVuNmFl3V" Name="Value" Kind="OutputPin" />
                                   </Node>
-                                  <Node Bounds="663,188,82,80" Id="HzYzgJeusDNNKeRW9mygWG">
+                                  <Node Bounds="1017,649,82,80" Id="HzYzgJeusDNNKeRW9mygWG">
                                     <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                       <CategoryReference Kind="Category" Name="Primitive" />
@@ -6602,7 +6621,7 @@
                                     <Patch Id="RvRGHsSEabZLw4M9nakZED" ManuallySortedPins="true">
                                       <Patch Id="R5yBXhUUbIrNqofMcdyQod" Name="Create" ManuallySortedPins="true" />
                                       <Patch Id="RObXpDNoYMTMorWByic4WG" Name="Then" ManuallySortedPins="true" />
-                                      <Node Bounds="681,220,49,19" Id="U1KMuAfHV84QL3hzxB0IG7">
+                                      <Node Bounds="1035,681,49,19" Id="U1KMuAfHV84QL3hzxB0IG7">
                                         <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                           <Choice Kind="ProcessNode" Name="Tooltip (String)" />
@@ -6614,7 +6633,7 @@
                                       </Node>
                                     </Patch>
                                   </Node>
-                                  <Node Bounds="663,155,62,19" Id="RjV8r5D1HlOM4O2i0yL0Pe">
+                                  <Node Bounds="1017,616,62,19" Id="RjV8r5D1HlOM4O2i0yL0Pe">
                                     <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <Choice Kind="ProcessAppFlag" Name="TimerFlop" />
@@ -6625,7 +6644,7 @@
                                     <Pin Id="OwzUtp9BnHYPETHeQfRVBP" Name="Value" Kind="OutputPin" />
                                     <Pin Id="TU5lhSFbpjzQEERpRluZYD" Name="Running" Kind="OutputPin" />
                                   </Node>
-                                  <Node Bounds="375,491,171,86" Id="EPEeM6R7SEOOoVv9iyYeDm">
+                                  <Node Bounds="727,1268,171,86" Id="EPEeM6R7SEOOoVv9iyYeDm">
                                     <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                       <CategoryReference Kind="Category" Name="Widgets" NeedsToBeDirectParent="true" />
@@ -6634,7 +6653,7 @@
                                     <Patch Id="ELh2sIgcpnXMjjR6Pv2f5E" ManuallySortedPins="true">
                                       <Patch Id="PO9ppFHJ1I9LUFR88vOKAA" Name="Create" ManuallySortedPins="true" />
                                       <Patch Id="CLdHbzZGF9wLpce0CsByaH" Name="Update" ManuallySortedPins="true" />
-                                      <Node Bounds="387,527,147,19" Id="GtDKcO5K65TLtBkREllqkS">
+                                      <Node Bounds="739,1302,147,19" Id="GtDKcO5K65TLtBkREllqkS">
                                         <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                           <Choice Kind="ProcessNode" Name="Input (String)" />
@@ -6654,26 +6673,204 @@
                                     <Pin Id="S9asXxmS4MJP2F34qoiIsm" Name="Style" Kind="InputPin" />
                                     <Pin Id="UD7MTEsn0TWOY82GWcQuCt" Name="Apply" Kind="InputPin" />
                                     <Pin Id="Ifnnh3wHFKgP1VL7tKGinM" Name="Context" Kind="OutputPin" />
-                                    <ControlPoint Id="Por9hgUnYNANIOWvelVlcU" Bounds="389,571" Alignment="Bottom" />
+                                    <ControlPoint Id="Por9hgUnYNANIOWvelVlcU" Bounds="741,1348" Alignment="Bottom" />
                                   </Node>
-                                  <ControlPoint Id="D8Lhlt0VTyhPefT5lzAGV2" Bounds="543,14" />
+                                  <ControlPoint Id="D8Lhlt0VTyhPefT5lzAGV2" Bounds="897,475" />
+                                  <Node Bounds="394,1219,240,155" Id="UTj5QKW1TxgPH7LBsq1wgk">
+                                    <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
+                                      <CategoryReference Kind="ClassType" Name="Channel" />
+                                      <Choice Kind="ProcessAppFlag" Name="Merge (Selector)" />
+                                    </p:NodeReference>
+                                    <Pin Id="ODj42BFkhZkML9j7EktII8" Name="Channel A" Kind="InputPin" />
+                                    <Pin Id="OzOGHp7U7bbMKMWyna0ikR" Name="Channel B" Kind="InputPin" />
+                                    <Pin Id="ABh7AImV0eCPhjoUqWzFwT" Name="Initialization" Kind="InputPin" DefaultValue="UseA" />
+                                    <Pin Id="D0ZzUN10SFzQQomd5F4iai" Name="Push Eagerly To" Kind="InputPin" />
+                                    <Patch Id="CuxQY4SgxzENHXMep1NnYP" Name="To B" ManuallySortedPins="true">
+                                      <ControlPoint Id="G83R2SogRDHNbUz8I7YjPt" Bounds="408,1227" />
+                                      <ControlPoint Id="MYdNY7EbnRNOh4SMtQ2gX0" Bounds="408,1367" />
+                                      <Pin Id="RCMFEOQ9IV2QBdtSr437X6" Name="Input" Kind="InputPin">
+                                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                                          <Choice Kind="TypeFlag" Name="Tuple (2 Items)" />
+                                          <p:TypeArguments>
+                                            <TypeReference>
+                                              <Choice Kind="TypeFlag" Name="Boolean" />
+                                            </TypeReference>
+                                            <TypeReference>
+                                              <Choice Kind="TypeFlag" Name="String" />
+                                            </TypeReference>
+                                          </p:TypeArguments>
+                                        </p:TypeAnnotation>
+                                      </Pin>
+                                      <Pin Id="Qp3qBPEHE5AOMbSMwjUAL9" Name="Result" Kind="OutputPin" />
+                                      <Node Bounds="406,1305,70,26" Id="DdZbqjlzYS0OX1j1BdMtgv">
+                                        <p:NodeReference LastCategoryFullName="Primitive.Tuple (2 Items)" LastDependency="VL.CoreLib.vl">
+                                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                          <CategoryReference Kind="ClassType" Name="Tuple (2 Items)" NeedsToBeDirectParent="true" />
+                                          <Choice Kind="OperationCallFlag" Name="Item2" />
+                                        </p:NodeReference>
+                                        <Pin Id="T6YYc0FzJL9NAttlp2wFji" Name="Input" Kind="StateInputPin" />
+                                        <Pin Id="MF9ZrRc3oOWOlrfutEmxT3" Name="Item 2" Kind="OutputPin" />
+                                      </Node>
+                                    </Patch>
+                                    <Patch Id="H7jORdmnP7BQPhqvw0yLoI" Name="To A" ManuallySortedPins="true">
+                                      <Pin Id="JYcaFjbe5DIMw3CrAFJ5TA" Name="Input" Kind="InputPin" />
+                                      <Pin Id="Ia7iSpnKw12Lwu2Ny7aaqW" Name="Result" Kind="OutputPin" />
+                                      <ControlPoint Id="L4BKftPeARMNukA7TC9UVz" Bounds="587,1273" />
+                                      <ControlPoint Id="COlAENjciIbLuKIFDSXA3k" Bounds="499,1367" />
+                                      <Node Bounds="497,1318,93,19" Id="MWs2UNcF6FxM5naByrUd2v">
+                                        <p:NodeReference LastCategoryFullName="Primitive.Tuple (2 Items)" LastDependency="VL.CoreLib.vl">
+                                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                          <CategoryReference Kind="ClassType" Name="Tuple (2 Items)" />
+                                          <Choice Kind="OperationCallFlag" Name="Tuple (Create)" />
+                                        </p:NodeReference>
+                                        <Pin Id="Gvb9ckVkj33LaK3j8uj8Cv" Name="Item 1" Kind="InputPin" />
+                                        <Pin Id="TD4Ad3Shk2mNIeVGXkV7f5" Name="Item 2" Kind="InputPin" />
+                                        <Pin Id="UrjdO72oEOVMHEMPRDSWI4" Name="Output" Kind="StateOutputPin" />
+                                      </Node>
+                                      <Node Bounds="497,1282,70,26" Id="Ok02uNIdBTuMJZUB1Coref">
+                                        <p:NodeReference LastCategoryFullName="Primitive.Tuple (2 Items)" LastDependency="VL.CoreLib.vl">
+                                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                          <CategoryReference Kind="ClassType" Name="Tuple (2 Items)" NeedsToBeDirectParent="true" />
+                                          <Choice Kind="OperationCallFlag" Name="Item1" />
+                                        </p:NodeReference>
+                                        <Pin Id="OTyOija8ag7PAxpX6hCKvB" Name="Input" Kind="StateInputPin" />
+                                        <Pin Id="Hu04Pz0JcrVPQldqQ7FHpq" Name="Item 1" Kind="OutputPin" />
+                                      </Node>
+                                      <Node Bounds="457,1244,45,26" Id="QKnOCvUnlMnL3eN9hGgTSj">
+                                        <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
+                                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                          <CategoryReference Kind="ClassType" Name="Channel" />
+                                          <Choice Kind="OperationCallFlag" Name="Value" />
+                                        </p:NodeReference>
+                                        <Pin Id="NStFs25cZSaN42I2HcPmZx" Name="Input" Kind="StateInputPin" />
+                                        <Pin Id="H47Fkeq98HoLKSl90dIIGf" Name="Output" Kind="StateOutputPin" />
+                                        <Pin Id="Qa5kAhYPzbPPSaNa1n7PHB" Name="Value" Kind="OutputPin" />
+                                      </Node>
+                                    </Patch>
+                                  </Node>
+                                  <Node Bounds="362,537,280,153" Id="UE1naiaImOzLYnMztW1Dxx">
+                                    <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
+                                      <CategoryReference Kind="ClassType" Name="Channel" />
+                                      <Choice Kind="ProcessAppFlag" Name="Merge (Selector)" />
+                                    </p:NodeReference>
+                                    <Pin Id="IUj14351oItNzZ7sv4YVwh" Name="Channel A" Kind="InputPin" />
+                                    <Pin Id="DMZmlEqgE5LMsmn3SV5o1N" Name="Channel B" Kind="InputPin" />
+                                    <Pin Id="UnanNxMx5nTPx9RJTEB2qt" Name="Initialization" Kind="InputPin" DefaultValue="UseA" />
+                                    <Pin Id="A59usIgPX7fLwCgJJIZuZ6" Name="Push Eagerly To" Kind="InputPin" />
+                                    <Patch Id="U3vAYHLuxpvQEjR7CboI07" Name="To B" ManuallySortedPins="true">
+                                      <ControlPoint Id="KqOpfIiBDDlMbNzxB5WCUi" Bounds="376,567" />
+                                      <ControlPoint Id="ERMDRiCE9T7P7TWbcA94NP" Bounds="376,683" />
+                                      <Pin Id="EmNQuYfm5AqLwXfnroo4cE" Name="Input" Kind="InputPin">
+                                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                                          <Choice Kind="TypeFlag" Name="Tuple (2 Items)" />
+                                          <p:TypeArguments>
+                                            <TypeReference>
+                                              <Choice Kind="TypeFlag" Name="Boolean" />
+                                            </TypeReference>
+                                            <TypeReference>
+                                              <Choice Kind="TypeFlag" Name="String" />
+                                            </TypeReference>
+                                          </p:TypeArguments>
+                                        </p:TypeAnnotation>
+                                      </Pin>
+                                      <Pin Id="RrRy13W8P6dOhvCP0oWL8k" Name="Result" Kind="OutputPin" />
+                                      <Node Bounds="374,631,70,26" Id="OGnqXJOOcwoPEHg2Yr83Eq">
+                                        <p:NodeReference LastCategoryFullName="Primitive.Tuple (2 Items)" LastDependency="VL.CoreLib.vl">
+                                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                          <CategoryReference Kind="ClassType" Name="Tuple (2 Items)" NeedsToBeDirectParent="true" />
+                                          <Choice Kind="OperationCallFlag" Name="Item1" />
+                                        </p:NodeReference>
+                                        <Pin Id="M8i0v5QYSZKL2d4qcluRhc" Name="Input" Kind="StateInputPin" />
+                                        <Pin Id="DfC19Dc099LMNJbswRLAjK" Name="Item 1" Kind="OutputPin" />
+                                      </Node>
+                                    </Patch>
+                                    <Patch Id="TyKDa9cjkXfLzqJnfpp0X4" Name="To A" ManuallySortedPins="true">
+                                      <Pin Id="T77FWSEY7M5MGsKab3VK5B" Name="Input" Kind="InputPin" />
+                                      <Pin Id="A5vIIu0Gsd7LZWNC0lLPMb" Name="Result" Kind="OutputPin" />
+                                      <ControlPoint Id="T7AmhnVk3gVQO9T1Bw7gMr" Bounds="467,567" />
+                                      <ControlPoint Id="FVq1OArEQSePwyIXnbpkL9" Bounds="467,683" />
+                                      <Node Bounds="465,631,100,19" Id="BkwwO9SBHuLN9jJDWjA6za">
+                                        <p:NodeReference LastCategoryFullName="Primitive.Tuple (2 Items)" LastDependency="VL.CoreLib.vl">
+                                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                          <CategoryReference Kind="ClassType" Name="Tuple (2 Items)" />
+                                          <Choice Kind="OperationCallFlag" Name="Tuple (Create)" />
+                                        </p:NodeReference>
+                                        <Pin Id="FuHeTWplkFaPw5PumWEpsT" Name="Item 1" Kind="InputPin" />
+                                        <Pin Id="LjYRWoC8bXKPXasyWtak0X" Name="Item 2" Kind="InputPin" />
+                                        <Pin Id="DKIvGLM2uktQUBVaaLrsq6" Name="Output" Kind="StateOutputPin" />
+                                      </Node>
+                                      <Node Bounds="520,560,45,26" Id="MGcMCTJA6oGNQzT3JC3nDv">
+                                        <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
+                                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                          <CategoryReference Kind="ClassType" Name="Channel" />
+                                          <Choice Kind="OperationCallFlag" Name="Value" />
+                                        </p:NodeReference>
+                                        <Pin Id="FYKT20prtYFONXtY1gL632" Name="Input" Kind="StateInputPin" />
+                                        <Pin Id="Fm1kpCHcfVhMXmXKy6jVCf" Name="Output" Kind="StateOutputPin" />
+                                        <Pin Id="MxBWGnglPjWMBo6FFEVFCM" Name="Value" Kind="OutputPin" />
+                                      </Node>
+                                      <Node Bounds="560,601,70,26" Id="U6juJwDDSwGNolWkORoQyi">
+                                        <p:NodeReference LastCategoryFullName="Primitive.Tuple (2 Items)" LastDependency="VL.CoreLib.vl">
+                                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                          <CategoryReference Kind="ClassType" Name="Tuple (2 Items)" NeedsToBeDirectParent="true" />
+                                          <Choice Kind="OperationCallFlag" Name="Item2" />
+                                        </p:NodeReference>
+                                        <Pin Id="BumbToyGjfEPra2pXBi9vf" Name="Input" Kind="StateInputPin" />
+                                        <Pin Id="ADBXVGl51gwQF8xqA3XHBg" Name="Item 2" Kind="OutputPin" />
+                                      </Node>
+                                    </Patch>
+                                  </Node>
+                                  <Overlay Id="JDAhyLrqIVVOVQPNg2l3xv" Name="Was ist das" Bounds="303,269,410,1149" />
+                                  <Pad Id="P4As9WNfKwsL9tqobLeUy3" Bounds="365,856,273,208" ShowValueBox="true" isIOBox="true" Value="Ok, so in our data model, there's a Tuple&lt;Bool,String&gt; to enable/disable items quickly for the UI. But our widgets are only interesting in one of the elements of the tuple. We're using the Merge region to &quot;convert&quot; on the fly from one to the other. We get a Channel&lt;Tuple&gt; from the model that we convert either to Channel&lt;String&gt; or Channel&lt;Bool&gt;, and then do the backward conversion to write stuff to the model again.">
+                                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="TypeFlag" Name="String" />
+                                    </p:TypeAnnotation>
+                                    <p:ValueBoxSettings>
+                                      <p:fontsize p:Type="Int32">9</p:fontsize>
+                                      <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+                                    </p:ValueBoxSettings>
+                                  </Pad>
+                                  <ControlPoint Id="Cc325ufOLZNMguD8WjYTJS" Bounds="422,307" />
+                                  <ControlPoint Id="PZC1EHACwgyMjbHCSTJ7C4" Bounds="816,674" />
+                                  <ControlPoint Id="OZhVCpLB09uLXflDogM21o" Bounds="801,1524" />
+                                  <ControlPoint Id="PnqO0EpEhYHNxRJBG9iP14" Bounds="1060,1620" />
+                                  <Node Bounds="454,404,53,19" Id="KG7T9kRtixBN2G8jwzIQdZ">
+                                    <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
+                                      <Choice Kind="ProcessAppFlag" Name="Channel" />
+                                    </p:NodeReference>
+                                    <Pin Id="SZQWly9QaXAMfjWWyHwQh5" Name="Value" Kind="InputPin" />
+                                    <Pin Id="BQhKuXhszAnOM1sRHKbaC5" Name="Output" Kind="OutputPin" />
+                                    <Pin Id="HM1WM1hPl4kL1Hq7RleIIR" Name="Value" Kind="OutputPin" />
+                                  </Node>
+                                  <ControlPoint Id="TXXyiqxssTRMAtK9ChBUmI" Bounds="261,477" />
+                                  <ControlPoint Id="KqYRy0W2OP6OkHRvag2dTd" Bounds="268,1036" />
+                                  <ControlPoint Id="LADsp2tyO7ELOkQYZnePTS" Bounds="251,1050" />
+                                  <ControlPoint Id="IW4HDAtFFNgM54zWCLh4At" Bounds="248,470" />
+                                  <Node Bounds="478,740,53,19" Id="S4ayXDLz1pLNYfAPMkld3t">
+                                    <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
+                                      <Choice Kind="ProcessAppFlag" Name="Channel" />
+                                    </p:NodeReference>
+                                    <Pin Id="PYvrrN93a6XQVWFXO0KkvF" Name="Value" Kind="InputPin" />
+                                    <Pin Id="JeN4AZaWkkwMciErXEvIk5" Name="Output" Kind="OutputPin" />
+                                    <Pin Id="U6LjfzKwobiPZDH0DeHU6Q" Name="Value" Kind="OutputPin" />
+                                  </Node>
                                 </Canvas>
                                 <ProcessDefinition Id="UpIXeSV5iBzPAZbj6AxPvs">
                                   <Fragment Id="T5haXqutLlnMVCqt5ygI1F" Patch="PXAvzaUQHKGO6cHM208nq1" Enabled="true" />
                                   <Fragment Id="MexavGqpHgNQLtRsiWUjp2" Patch="Um1yf5P7tQCOv2vhgqMWu3" Enabled="true" />
                                 </ProcessDefinition>
                                 <Link Id="EQYpyP60t3oOHRZTTu8TrL" Ids="AMEE0afzrvnN3HxParTztk,MeTBeVs7WG4O7wDyGtmeoV" />
-                                <Link Id="TH1mZ2m6yvMOh3OCtAYGkz" Ids="OYpd9PUrLqvM9fN3YiIuAi,HtyiFWBKLggOnVbMVJItLY" />
-                                <Link Id="I7zCI62N7bZLUUSo28rfNQ" Ids="VVk0XMBGZXqN4MZCs1EH9t,PL8YnZCTdXdQZmcyyQoc7y" IsHidden="true" />
-                                <Link Id="J84usSVOt9mPwJwB3Ax4pm" Ids="PL8YnZCTdXdQZmcyyQoc7y,D76MwrN1gMcL3Gd3VjfPzN" />
                                 <Link Id="Mh9fb7t09uZLzDI9dWDn7c" Ids="LUl2hfwnnOaLnZ3XRV7xKf,MKQwLvRz9tRO0pCC59Dmi0" />
-                                <Link Id="GzGM1uYslIcPfKpmHCEd4N" Ids="PL8YnZCTdXdQZmcyyQoc7y,Qj4yDHdE3ghNKzP1pCinrH" />
                                 <Link Id="FJCGMDg83XbMCtz4GJaG9i" Ids="LSlHHg2yO1xNTjJxnYSKKt,APcOen6jFhJN3YwOKBxd9s" />
                                 <Link Id="FZj2v8DP2vPORLgue2BXaI" Ids="N7jmFqwmWdWOBJx2p2DLxc,TshvaKobAUILpeCa53NTcM" />
                                 <Link Id="K9C4oZoecrBOK65bxpjHMh" Ids="VEZ6pF6yIKRN3ygLSFqcDb,BSWmycZ3NJQPnpa30ixBEt" />
-                                <Link Id="PWJJe1MXkNwPwZGNyvoJmr" Ids="PL8YnZCTdXdQZmcyyQoc7y,VQ7ZhBthdByOT9OdXQh9qw" />
                                 <Link Id="GwUhLNtSXMfLGQkPocCQJ1" Ids="FJoSyFOcw4XLxitTqKcuSg,Iqg092856UQOD1DU7hE2mm" />
-                                <Link Id="UwFi0iRWMMWOxe6j61DBDa" Ids="PL8YnZCTdXdQZmcyyQoc7y,AIoo6WOqSXbOX43V2G06Bn" />
                                 <Link Id="T9Z7MKy6sEWPh7MnINCggO" Ids="AUrrhjNzOauLyyAV9QXcJC,LywqDvJqQxPNlqESViOYPm" />
                                 <Link Id="H5bqOXIX7YpNQmGFnfQ2de" Ids="JoXRgkOe8rAPE1YIbka91n,JRl4elGlvB6MAJVvv0ANjM" />
                                 <Link Id="UKoIytKvHAhOVH31YDmUJA" Ids="QAMeE5WShtuLBNh7gbgWAg,EdcSlJIxm0BQdS4lPrStcd" />
@@ -6711,6 +6908,42 @@
                                 <Link Id="Bt6eF0NSrKyPOHf1qcstDZ" Ids="LfByQmTkoeXOkfrUPr9tnx,D8Lhlt0VTyhPefT5lzAGV2" IsHidden="true" />
                                 <Link Id="Ol9zx5RbAB0L3CUFZKzp9G" Ids="D8Lhlt0VTyhPefT5lzAGV2,I8ApKKIfWK0P6bcstfdajz" />
                                 <Link Id="RBihG74Z5AKNgKEQ2mE7zd" Ids="L4SkuufLtFJOwO5mvvGFkG,A2lptISiR2gOy4alVk4E7Z" />
+                                <Link Id="FGy0QlivS94LXntOD5EyBn" Ids="RCMFEOQ9IV2QBdtSr437X6,G83R2SogRDHNbUz8I7YjPt" IsHidden="true" />
+                                <Link Id="CnJOAUm86eZL5UHyXS6wIH" Ids="MYdNY7EbnRNOh4SMtQ2gX0,Qp3qBPEHE5AOMbSMwjUAL9" IsHidden="true" />
+                                <Link Id="DwjnMTO6TgLOLRg9oMUDnV" Ids="JYcaFjbe5DIMw3CrAFJ5TA,L4BKftPeARMNukA7TC9UVz" IsHidden="true" />
+                                <Link Id="On8HxgsGiajL3Shr3BEXWD" Ids="COlAENjciIbLuKIFDSXA3k,Ia7iSpnKw12Lwu2Ny7aaqW" IsHidden="true" />
+                                <Link Id="L0qhPWtSL3DQCGi8CGiuPD" Ids="G83R2SogRDHNbUz8I7YjPt,T6YYc0FzJL9NAttlp2wFji" />
+                                <Link Id="Uy5lSzKEyigO2i0ZpwGmRw" Ids="MF9ZrRc3oOWOlrfutEmxT3,MYdNY7EbnRNOh4SMtQ2gX0" />
+                                <Link Id="VfvY22wrhWMOUo2ZebW11y" Ids="L4BKftPeARMNukA7TC9UVz,TD4Ad3Shk2mNIeVGXkV7f5" />
+                                <Link Id="O2XjByVOgm0QHLqT7Xu55m" Ids="UrjdO72oEOVMHEMPRDSWI4,COlAENjciIbLuKIFDSXA3k" />
+                                <Link Id="CfYKn6eWTVwLlUOHIHtpTp" Ids="EmNQuYfm5AqLwXfnroo4cE,KqOpfIiBDDlMbNzxB5WCUi" IsHidden="true" />
+                                <Link Id="KCP02WHBC6OL2J0CAChE7P" Ids="ERMDRiCE9T7P7TWbcA94NP,RrRy13W8P6dOhvCP0oWL8k" IsHidden="true" />
+                                <Link Id="MUNQkbKe1ZPLHqQ7JwtVNH" Ids="T77FWSEY7M5MGsKab3VK5B,T7AmhnVk3gVQO9T1Bw7gMr" IsHidden="true" />
+                                <Link Id="IBHTK5ThStKPinfYtonBM7" Ids="FVq1OArEQSePwyIXnbpkL9,A5vIIu0Gsd7LZWNC0lLPMb" IsHidden="true" />
+                                <Link Id="VvAybiMmEyLOQwROYaDOKi" Ids="KqOpfIiBDDlMbNzxB5WCUi,M8i0v5QYSZKL2d4qcluRhc" />
+                                <Link Id="IPAwQKvNPHRMUuLsfeI9MR" Ids="DKIvGLM2uktQUBVaaLrsq6,FVq1OArEQSePwyIXnbpkL9" />
+                                <Link Id="PWwzIYEuk7XNuyrU4bEIyx" Ids="DfC19Dc099LMNJbswRLAjK,ERMDRiCE9T7P7TWbcA94NP" />
+                                <Link Id="GxSuZMqc1k7Ny32sreLiTA" Ids="T7AmhnVk3gVQO9T1Bw7gMr,FuHeTWplkFaPw5PumWEpsT" />
+                                <Link Id="HCucnCAguU2NH9WZAE45SJ" Ids="Hu04Pz0JcrVPQldqQ7FHpq,Gvb9ckVkj33LaK3j8uj8Cv" />
+                                <Link Id="VnzqiWVFJVeQBGOb0v1gfW" Ids="Qa5kAhYPzbPPSaNa1n7PHB,OTyOija8ag7PAxpX6hCKvB" />
+                                <Link Id="MtWKOqf9YjtNKEFd1gQ3dQ" Ids="MxBWGnglPjWMBo6FFEVFCM,BumbToyGjfEPra2pXBi9vf" />
+                                <Link Id="O9oJTEGDTUWQaGL5xP3237" Ids="ADBXVGl51gwQF8xqA3XHBg,LjYRWoC8bXKPXasyWtak0X" />
+                                <Link Id="DJcBcshQ1YSQaToQIUdGCe" Ids="VVk0XMBGZXqN4MZCs1EH9t,Cc325ufOLZNMguD8WjYTJS" IsHidden="true" />
+                                <Link Id="D5Pm1Y7Ir9sMJ0529CYLD8" Ids="Cc325ufOLZNMguD8WjYTJS,D76MwrN1gMcL3Gd3VjfPzN" />
+                                <Link Id="FmlyJr0LtPnNvz4gghd9B1" Ids="VVk0XMBGZXqN4MZCs1EH9t,PZC1EHACwgyMjbHCSTJ7C4" IsHidden="true" />
+                                <Link Id="Slv3CB0ZxdrPRow7QydDw6" Ids="PZC1EHACwgyMjbHCSTJ7C4,VQ7ZhBthdByOT9OdXQh9qw" />
+                                <Link Id="SNwDPe7VLKpNEItO9kjWAK" Ids="VVk0XMBGZXqN4MZCs1EH9t,OZhVCpLB09uLXflDogM21o" IsHidden="true" />
+                                <Link Id="BctixnQ3zcLM0jaNdtTJc4" Ids="OZhVCpLB09uLXflDogM21o,AIoo6WOqSXbOX43V2G06Bn" />
+                                <Link Id="UIMwnt3Esp8LZV3sOWi6PP" Ids="VVk0XMBGZXqN4MZCs1EH9t,PnqO0EpEhYHNxRJBG9iP14" IsHidden="true" />
+                                <Link Id="FBatEow5zHRPv6w4v0d9PV" Ids="PnqO0EpEhYHNxRJBG9iP14,Qj4yDHdE3ghNKzP1pCinrH" />
+                                <Link Id="By8WQYoZ64aL6t9sPAm5Rp" Ids="OYpd9PUrLqvM9fN3YiIuAi,IUj14351oItNzZ7sv4YVwh" />
+                                <Link Id="G4bfitH6XUSP7GjvixUmpx" Ids="BQhKuXhszAnOM1sRHKbaC5,DMZmlEqgE5LMsmn3SV5o1N" />
+                                <Link Id="O8BDDaP9ujNMp3TLoTkpGB" Ids="BQhKuXhszAnOM1sRHKbaC5,D5gMCBPHTchQK7AXCyy0B8" />
+                                <Link Id="OJWuMJG10cWPaCRYhiqIhh" Ids="OYpd9PUrLqvM9fN3YiIuAi,FYKT20prtYFONXtY1gL632" />
+                                <Link Id="AhOQ8BXfpFRMVhogbw3XGY" Ids="OYpd9PUrLqvM9fN3YiIuAi,TXXyiqxssTRMAtK9ChBUmI,KqYRy0W2OP6OkHRvag2dTd,ODj42BFkhZkML9j7EktII8" />
+                                <Link Id="H2MqQsrEqrhOMkU5hDUg6E" Ids="OYpd9PUrLqvM9fN3YiIuAi,IW4HDAtFFNgM54zWCLh4At,LADsp2tyO7ELOkQYZnePTS,NStFs25cZSaN42I2HcPmZx" />
+                                <Link Id="O5dlbK8PMLtPJPNYbyvoYb" Ids="JeN4AZaWkkwMciErXEvIk5,OzOGHp7U7bbMKMWyna0ikR" />
+                                <Link Id="KxL6rlH7jxtPUHsHemcJDS" Ids="JeN4AZaWkkwMciErXEvIk5,HtyiFWBKLggOnVbMVJItLY" />
                               </Patch>
                             </Node>
                             <!--
@@ -6724,7 +6957,7 @@
                               </p:NodeReference>
                               <Patch Id="HgcU4G0wW5gMxx2ERlEZSQ">
                                 <Canvas Id="Ue4stJu4ydzPX2VEaTMASU" CanvasType="Group">
-                                  <Node Bounds="768,726,59,19" Id="OXWuz9J2XxSLR4hyGoXS1F">
+                                  <Node Bounds="818,1269,59,19" Id="OXWuz9J2XxSLR4hyGoXS1F">
                                     <p:NodeReference LastCategoryFullName="ImGui.Commands" LastDependency="VL.ImGui.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <Choice Kind="ProcessNode" Name="SameLine" />
@@ -6734,7 +6967,7 @@
                                     <Pin Id="SXx2hAeinXINq9e3tSr7hR" Name="Spacing" Kind="InputPin" />
                                     <Pin Id="RBZBWxVD7ubLMdIsgVYVoO" Name="Context" Kind="OutputPin" />
                                   </Node>
-                                  <Node Bounds="768,824,85,19" Id="UJh8eUpQBNNLftaX2P8uEE">
+                                  <Node Bounds="818,1367,85,19" Id="UJh8eUpQBNNLftaX2P8uEE">
                                     <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <CategoryReference Kind="Category" Name="Widgets" NeedsToBeDirectParent="true" />
@@ -6748,7 +6981,7 @@
                                     <Pin Id="QCOR9pMZALNOKLEslUnrln" Name="Context" Kind="OutputPin" />
                                     <Pin Id="CJSBi3zKLtxNWAGshg2M1I" Name="Bang" Kind="OutputPin" />
                                   </Node>
-                                  <Node Bounds="788,417,43,19" Id="SKPYNPCUaQeNFHOkEjsSEq">
+                                  <Node Bounds="1046,260,43,19" Id="SKPYNPCUaQeNFHOkEjsSEq">
                                     <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <Choice Kind="ProcessAppFlag" Name="Select (ByPath)" />
@@ -6757,7 +6990,7 @@
                                     <Pin Id="Ga2JV138YmLNWlXRPiJhuG" Name="Path" Kind="InputPin" DefaultValue="Package Repositories Folder[0]" />
                                     <Pin Id="TyJ07eBJG3VM0y7f1nzlCO" Name="Output" Kind="OutputPin" />
                                   </Node>
-                                  <Node Bounds="908,461,85,19" Id="GwUNwIQHSwSOV2tCbJqG3T">
+                                  <Node Bounds="1160,990,85,19" Id="GwUNwIQHSwSOV2tCbJqG3T">
                                     <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
@@ -6770,8 +7003,7 @@
                                     <Pin Id="DVCZD9NnqvKMm4QgITF562" Name="Input 4" Kind="InputPin" />
                                     <Pin Id="AYefMxCcPzPQPj3r5frcOv" Name="Output" Kind="StateOutputPin" />
                                   </Node>
-                                  <ControlPoint Id="UNEgUFSKLYYOyTeC8jwYpg" Bounds="1091,325" />
-                                  <Node Bounds="846,345,55,19" Id="GqMnWr92KvFMUSkAF4pCVK">
+                                  <Node Bounds="1104,188,55,19" Id="GqMnWr92KvFMUSkAF4pCVK">
                                     <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <Choice Kind="OperationCallFlag" Name="ToString" />
@@ -6779,7 +7011,7 @@
                                     <Pin Id="PfRj81shys9O4eFyyMGjNu" Name="Input" Kind="InputPin" />
                                     <Pin Id="AiG5eDyGmyKLQjZHos8uWx" Name="Result" Kind="OutputPin" />
                                   </Node>
-                                  <Node Bounds="848,887,257,149" Id="RU0NQIjnyYzPNeBxNiEQAB">
+                                  <Node Bounds="898,1430,257,149" Id="RU0NQIjnyYzPNeBxNiEQAB">
                                     <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                       <CategoryReference Kind="Category" Name="Primitive" />
@@ -6789,7 +7021,7 @@
                                     <Patch Id="FFgbUAr1NzvPmgne4ZJUtw" ManuallySortedPins="true">
                                       <Patch Id="Ikxd5tY1UhJQZ9YPjTDqsp" Name="Create" ManuallySortedPins="true" />
                                       <Patch Id="V20vv8YXmM6Legr47tLbel" Name="Then" ManuallySortedPins="true" />
-                                      <Node Bounds="910,953,183,26" Id="PhPgca0R2tSQAKL4sN831W">
+                                      <Node Bounds="960,1496,183,26" Id="PhPgca0R2tSQAKL4sN831W">
                                         <p:NodeReference LastCategoryFullName="Main.Model.SettingsTabModel" LastDependency="GammaLauncher.vl">
                                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                           <Choice Kind="OperationCallFlag" Name="RemovePackageRepositoriesFolderAt" />
@@ -6798,7 +7030,7 @@
                                         <Pin Id="ToulhYPrvJEPzPAdWHoY4R" Name="Index" Kind="InputPin" />
                                         <Pin Id="Q26ztZZqftJORCMZwLPtjR" Name="Output" Kind="StateOutputPin" />
                                       </Node>
-                                      <Node Bounds="860,910,45,26" Id="TBXhx6LsbtnQJoxhGhxgu9">
+                                      <Node Bounds="910,1453,45,26" Id="TBXhx6LsbtnQJoxhGhxgu9">
                                         <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                           <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -6808,7 +7040,7 @@
                                         <Pin Id="MZb8C2FatqtPHXVLo8tbnw" Name="Output" Kind="StateOutputPin" />
                                         <Pin Id="Gl0uUNHW9ybNeVwqyjq3SX" Name="Value" Kind="OutputPin" />
                                       </Node>
-                                      <Node Bounds="860,990,55,26" Id="L7O0S1BYjGfPph6gSC7Ny7">
+                                      <Node Bounds="910,1533,55,26" Id="L7O0S1BYjGfPph6gSC7Ny7">
                                         <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                           <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -6820,7 +7052,7 @@
                                       </Node>
                                     </Patch>
                                   </Node>
-                                  <Node Bounds="808,458,85,19" Id="LXa5L8I1BCuL8nUgOhWTPR">
+                                  <Node Bounds="918,1060,85,19" Id="LXa5L8I1BCuL8nUgOhWTPR">
                                     <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
@@ -6833,7 +7065,7 @@
                                     <Pin Id="JSgqBYCZ5X1MNVdC8eHJIg" Name="Input 4" Kind="InputPin" />
                                     <Pin Id="P716jJiGYBWQZxXg3nRqQd" Name="Output" Kind="StateOutputPin" />
                                   </Node>
-                                  <Node Bounds="808,761,85,19" Id="T8xByZ7KDMZMpsRBmnwZX8">
+                                  <Node Bounds="894,1297,85,19" Id="T8xByZ7KDMZMpsRBmnwZX8">
                                     <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
@@ -6846,7 +7078,7 @@
                                     <Pin Id="SnhZWMS6gEFMsZWerpeObK" Name="Input 4" Kind="InputPin" />
                                     <Pin Id="EHxuyU0kVT1QQQgFTb7eQe" Name="Output" Kind="StateOutputPin" />
                                   </Node>
-                                  <Node Bounds="826,382,85,19" Id="AuCzfP9JUdRNaxJ3bjQMxU">
+                                  <Node Bounds="1084,225,85,19" Id="AuCzfP9JUdRNaxJ3bjQMxU">
                                     <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
@@ -6859,11 +7091,11 @@
                                     <Pin Id="ODYY7zGkDz6QUh4d7Fc9BT" Name="Input 4" Kind="InputPin" />
                                     <Pin Id="IsCct5UIfr8PFqVd32JCKq" Name="Output" Kind="StateOutputPin" />
                                   </Node>
-                                  <ControlPoint Id="Hhb0b5wyf8wO7BWvRmgo9i" Bounds="769,13" />
-                                  <ControlPoint Id="Q1ZDRYVN4wlMest07lZa3w" Bounds="768,1147" />
-                                  <ControlPoint Id="KIM2lNxAU2uPhHawFMtywy" Bounds="862,868" />
-                                  <ControlPoint Id="ObBohnL7vWGN0oFDZiuhFp" Bounds="790,307" />
-                                  <Node Bounds="767,103,162,19" Id="HNOOtpcS1htLK1IV88NA05">
+                                  <ControlPoint Id="Hhb0b5wyf8wO7BWvRmgo9i" Bounds="818,190" />
+                                  <ControlPoint Id="Q1ZDRYVN4wlMest07lZa3w" Bounds="818,1690" />
+                                  <ControlPoint Id="KIM2lNxAU2uPhHawFMtywy" Bounds="912,1411" />
+                                  <ControlPoint Id="ObBohnL7vWGN0oFDZiuhFp" Bounds="1050,178" />
+                                  <Node Bounds="816,541,162,19" Id="HNOOtpcS1htLK1IV88NA05">
                                     <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <Choice Kind="ProcessNode" Name="Checkbox" />
@@ -6876,7 +7108,7 @@
                                     <Pin Id="KJ0qRppnfNyLMmS1g1EXC4" Name="Bang" Kind="OutputPin" />
                                     <Pin Id="RXbwbHlm4J2P68AYki1Xzh" Name="Value" Kind="OutputPin" />
                                   </Node>
-                                  <Node Bounds="767,187,59,19" Id="Oph4BC1rUISP4SEUSIijXD">
+                                  <Node Bounds="816,625,59,19" Id="Oph4BC1rUISP4SEUSIijXD">
                                     <p:NodeReference LastCategoryFullName="ImGui.Commands" LastDependency="VL.ImGui.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <Choice Kind="ProcessNode" Name="SameLine" />
@@ -6886,7 +7118,7 @@
                                     <Pin Id="KPuO0LapMhcPDbG8SfYYKh" Name="Spacing" Kind="InputPin" />
                                     <Pin Id="OGHomzRXy54OlsR9ijybye" Name="Context" Kind="OutputPin" />
                                   </Node>
-                                  <Node Bounds="757,563,169,86" Id="O8NzinTteUOK96d3VQn6Wn">
+                                  <Node Bounds="806,1151,372,86" Id="O8NzinTteUOK96d3VQn6Wn">
                                     <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                       <CategoryReference Kind="Category" Name="ImGui" />
@@ -6895,7 +7127,7 @@
                                     <Patch Id="QTBUuGq5YV2LiJfNy1FnxI" ManuallySortedPins="true">
                                       <Patch Id="CVYfnuuwz0GLIzMK0ct2i8" Name="Create" ManuallySortedPins="true" />
                                       <Patch Id="E2uLTiPNTF3PmfuJsKcWSK" Name="Update" ManuallySortedPins="true" />
-                                      <Node Bounds="769,587,145,19" Id="G0eNOsVUy26QPGVA7tT9R7">
+                                      <Node Bounds="818,1175,348,19" Id="G0eNOsVUy26QPGVA7tT9R7">
                                         <p:NodeReference LastCategoryFullName="Main.Utils" LastDependency="GammaLauncher.vl">
                                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                           <CategoryReference Kind="Category" Name="Utils" NeedsToBeDirectParent="true">
@@ -6919,9 +7151,9 @@
                                     <Pin Id="ANrYRyIHxVsMnPnJjpZHgV" Name="Style" Kind="InputPin" />
                                     <Pin Id="EW45IXtJvm3MtmAbuYuX8n" Name="Apply" Kind="InputPin" />
                                     <Pin Id="R1FYFafHPFhLq1qre712iw" Name="Context" Kind="OutputPin" />
-                                    <ControlPoint Id="S5g2QJzKwHTMHO6CJkq3qe" Bounds="771,643" Alignment="Bottom" />
+                                    <ControlPoint Id="S5g2QJzKwHTMHO6CJkq3qe" Bounds="820,1231" Alignment="Bottom" />
                                   </Node>
-                                  <Node Bounds="924,236,37,19" Id="RVdYMxVq7ORM75taZvrb06">
+                                  <Node Bounds="973,674,37,19" Id="RVdYMxVq7ORM75taZvrb06">
                                     <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <Choice Kind="OperationCallFlag" Name="NOT" />
@@ -6929,7 +7161,7 @@
                                     <Pin Id="Urd9ypUVnNRNZ7zTzSm09z" Name="Input" Kind="StateInputPin" />
                                     <Pin Id="KMPs7i1EwLrMqwJJoXuXmg" Name="Output" Kind="StateOutputPin" />
                                   </Node>
-                                  <Node Bounds="924,74,97,19" Id="Qa5YQSqLLU3OYmL9kazZZz">
+                                  <Node Bounds="973,512,97,19" Id="Qa5YQSqLLU3OYmL9kazZZz">
                                     <p:NodeReference LastCategoryFullName="ImGui.Styling" LastDependency="VL.ImGui.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <Choice Kind="ProcessNode" Name="SetCheckboxStyle" />
@@ -6938,16 +7170,16 @@
                                     <Pin Id="RYE20BqwiC9N3hrK0LG09P" Name="Checkmark" Kind="InputPin" />
                                     <Pin Id="IQXqvPx4wibLJd1BqBGsFh" Name="Output" Kind="OutputPin" />
                                   </Node>
-                                  <Pad Id="NqyC82q3ozjPmjtA0FLVrP" Comment="Checkmark" Bounds="1018,53,22,15" ShowValueBox="true" isIOBox="true" Value="0.9411765, 0.7411765, 0.050980393, 1">
+                                  <Pad Id="NqyC82q3ozjPmjtA0FLVrP" Comment="Checkmark" Bounds="1067,491,22,15" ShowValueBox="true" isIOBox="true" Value="0.9411765, 0.7411765, 0.050980393, 1">
                                     <p:TypeAnnotation LastCategoryFullName="Color" LastDependency="VL.CoreLib.vl">
                                       <Choice Kind="TypeFlag" Name="RGBA" />
                                     </p:TypeAnnotation>
                                   </Pad>
-                                  <ControlPoint Id="CXricfyjzNvMIq4yOUgfVt" Bounds="926,53" />
-                                  <ControlPoint Id="V19JY2pEAdTNWQg1NHTHrW" Bounds="871,522" />
-                                  <ControlPoint Id="TJRvKzWfKx5LkE7dF96Wn1" Bounds="891,541" />
-                                  <ControlPoint Id="L8mFPyVbmAzMM9x79UaNFL" Bounds="850,801" />
-                                  <Node Bounds="767,149,284,19" Id="VJ32E9hZLSYMuhHz14MJ8x">
+                                  <ControlPoint Id="CXricfyjzNvMIq4yOUgfVt" Bounds="975,491" />
+                                  <ControlPoint Id="V19JY2pEAdTNWQg1NHTHrW" Bounds="1069,1045" />
+                                  <ControlPoint Id="TJRvKzWfKx5LkE7dF96Wn1" Bounds="1115,1069" />
+                                  <ControlPoint Id="L8mFPyVbmAzMM9x79UaNFL" Bounds="900,1344" />
+                                  <Node Bounds="816,587,284,19" Id="VJ32E9hZLSYMuhHz14MJ8x">
                                     <p:NodeReference LastCategoryFullName="ImGui.Queries" LastDependency="VL.ImGui.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <Choice Kind="ProcessNode" Name="IsItemHovered" />
@@ -6957,7 +7189,7 @@
                                     <Pin Id="RZElBkxCxNcQZD5JxMO0hd" Name="Context" Kind="OutputPin" />
                                     <Pin Id="EdlhaoIaeRBOMOOWrpETwa" Name="Value" Kind="OutputPin" />
                                   </Node>
-                                  <Node Bounds="1046,212,82,80" Id="CVRfDoQosnsM7jzCxO0RSU">
+                                  <Node Bounds="1095,650,82,80" Id="CVRfDoQosnsM7jzCxO0RSU">
                                     <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                       <CategoryReference Kind="Category" Name="Primitive" />
@@ -6967,7 +7199,7 @@
                                     <Patch Id="Q8UZI76QovGMpmOisujblZ" ManuallySortedPins="true">
                                       <Patch Id="MqD3KQZpZ0LNE6GHFEDLeN" Name="Create" ManuallySortedPins="true" />
                                       <Patch Id="N7mLXzpNxvTOlsTsOpfT43" Name="Then" ManuallySortedPins="true" />
-                                      <Node Bounds="1064,244,49,19" Id="CqtkaQdzISULcA8oA1FGzA">
+                                      <Node Bounds="1113,682,49,19" Id="CqtkaQdzISULcA8oA1FGzA">
                                         <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                           <Choice Kind="ProcessNode" Name="Tooltip (String)" />
@@ -6979,7 +7211,7 @@
                                       </Node>
                                     </Patch>
                                   </Node>
-                                  <Node Bounds="1046,179,62,19" Id="DcAY5n4BWZGL8xPmTO5UDG">
+                                  <Node Bounds="1095,617,62,19" Id="DcAY5n4BWZGL8xPmTO5UDG">
                                     <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <Choice Kind="ProcessAppFlag" Name="TimerFlop" />
@@ -6990,25 +7222,207 @@
                                     <Pin Id="Fm5HM85ikmJOTGTVVqZzAM" Name="Value" Kind="OutputPin" />
                                     <Pin Id="FfTiRsAbnTtLQm62Qf3HP7" Name="Running" Kind="OutputPin" />
                                   </Node>
+                                  <Node Bounds="406,1012,240,155" Id="NeVIUi3lB6tO5fxBKovS56">
+                                    <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
+                                      <CategoryReference Kind="ClassType" Name="Channel" />
+                                      <Choice Kind="ProcessAppFlag" Name="Merge (Selector)" />
+                                    </p:NodeReference>
+                                    <Pin Id="R4AE2WgBUd0Omat455ttye" Name="Channel A" Kind="InputPin" />
+                                    <Pin Id="UhpcprSUbWtNC9g6BTGBOz" Name="Channel B" Kind="InputPin" />
+                                    <Pin Id="VxIe8GZB2LCPuIqIoMgVzS" Name="Initialization" Kind="InputPin" DefaultValue="UseA" />
+                                    <Pin Id="PFYJFbZpF8DNgvuAlSnrQN" Name="Push Eagerly To" Kind="InputPin" />
+                                    <Patch Id="BSeO4xtOlB9MvAJS6pf9WG" Name="To B" ManuallySortedPins="true">
+                                      <ControlPoint Id="BeVClM1qqs8PdfTz5thfOz" Bounds="420,1020" />
+                                      <ControlPoint Id="CScsPPnRi1oPJApYm7fHDD" Bounds="420,1160" />
+                                      <Pin Id="QV3LNKVrbiqPV4s0qZLaKM" Name="Input" Kind="InputPin">
+                                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                                          <Choice Kind="TypeFlag" Name="Tuple (2 Items)" />
+                                          <p:TypeArguments>
+                                            <TypeReference>
+                                              <Choice Kind="TypeFlag" Name="Boolean" />
+                                            </TypeReference>
+                                            <TypeReference>
+                                              <Choice Kind="TypeFlag" Name="String" />
+                                            </TypeReference>
+                                          </p:TypeArguments>
+                                        </p:TypeAnnotation>
+                                      </Pin>
+                                      <Pin Id="EvuYI6Yv9KfNeGG6YCclN5" Name="Result" Kind="OutputPin" />
+                                      <Node Bounds="418,1098,70,26" Id="Is5TCwCltCmLK0Ew4zxzBI">
+                                        <p:NodeReference LastCategoryFullName="Primitive.Tuple (2 Items)" LastDependency="VL.CoreLib.vl">
+                                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                          <CategoryReference Kind="ClassType" Name="Tuple (2 Items)" NeedsToBeDirectParent="true" />
+                                          <Choice Kind="OperationCallFlag" Name="Item2" />
+                                        </p:NodeReference>
+                                        <Pin Id="HMkwcFLO8oLOdmj0pSKhMk" Name="Input" Kind="StateInputPin" />
+                                        <Pin Id="Aa5wcpZQCBWMPTf3oIrkxP" Name="Item 2" Kind="OutputPin" />
+                                      </Node>
+                                    </Patch>
+                                    <Patch Id="B5notdtnja3OsjK32VJQOy" Name="To A" ManuallySortedPins="true">
+                                      <Pin Id="NSXp7ug2v0gOvDlnwJbv0u" Name="Input" Kind="InputPin" />
+                                      <Pin Id="BqosmHszk1gMhT7Qb36pcW" Name="Result" Kind="OutputPin" />
+                                      <ControlPoint Id="C1hrdeKZ4jVMzxogUYeHxJ" Bounds="599,1066" />
+                                      <ControlPoint Id="CF6KkV3IqZCLmGnwsorwsr" Bounds="511,1160" />
+                                      <Node Bounds="509,1111,93,19" Id="UVYojHthqgzLIYaFV8g2TM">
+                                        <p:NodeReference LastCategoryFullName="Primitive.Tuple (2 Items)" LastDependency="VL.CoreLib.vl">
+                                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                          <CategoryReference Kind="ClassType" Name="Tuple (2 Items)" />
+                                          <Choice Kind="OperationCallFlag" Name="Tuple (Create)" />
+                                        </p:NodeReference>
+                                        <Pin Id="TWxU3YQdFSGLeNOuBGW2n9" Name="Item 1" Kind="InputPin" />
+                                        <Pin Id="FGS12yTZmjMQN3BL46iQlx" Name="Item 2" Kind="InputPin" />
+                                        <Pin Id="VcSsHzLbWoLPWLhYOSItNn" Name="Output" Kind="StateOutputPin" />
+                                      </Node>
+                                      <Node Bounds="509,1075,70,26" Id="I1RJpzerD7ELkCmzK8QZ0n">
+                                        <p:NodeReference LastCategoryFullName="Primitive.Tuple (2 Items)" LastDependency="VL.CoreLib.vl">
+                                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                          <CategoryReference Kind="ClassType" Name="Tuple (2 Items)" NeedsToBeDirectParent="true" />
+                                          <Choice Kind="OperationCallFlag" Name="Item1" />
+                                        </p:NodeReference>
+                                        <Pin Id="MFRNSzqGqW9QWI1Y6zP2pj" Name="Input" Kind="StateInputPin" />
+                                        <Pin Id="T1yZRXamV0GLo86Kge0vXq" Name="Item 1" Kind="OutputPin" />
+                                      </Node>
+                                      <Node Bounds="469,1037,45,26" Id="Vg7qeU04luXLFuJ38iTReB">
+                                        <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
+                                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                          <CategoryReference Kind="ClassType" Name="Channel" />
+                                          <Choice Kind="OperationCallFlag" Name="Value" />
+                                        </p:NodeReference>
+                                        <Pin Id="Q8CcgBNlRvTNbLqwtNysO9" Name="Input" Kind="StateInputPin" />
+                                        <Pin Id="RKvAPp26pnJNfHHdv222El" Name="Output" Kind="StateOutputPin" />
+                                        <Pin Id="SrKagKPPOYEOLk5JPuwJxz" Name="Value" Kind="OutputPin" />
+                                      </Node>
+                                    </Patch>
+                                  </Node>
+                                  <Node Bounds="867,899,53,19" Id="HkNSg3QwZeDNseWKW7QNqP">
+                                    <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
+                                      <Choice Kind="ProcessAppFlag" Name="Channel" />
+                                    </p:NodeReference>
+                                    <Pin Id="T0nsW1oUnMKMFXFB5zYIxk" Name="Value" Kind="InputPin" />
+                                    <Pin Id="BGoFCzqjKtXM4Clr5yEOsx" Name="Output" Kind="OutputPin" />
+                                    <Pin Id="DNFNaEIIdEiLB2kP0xMZd4" Name="Value" Kind="OutputPin" />
+                                  </Node>
+                                  <Node Bounds="374,330,280,153" Id="INI8YsJoRVZOAUEdzCs5er">
+                                    <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
+                                      <CategoryReference Kind="ClassType" Name="Channel" />
+                                      <Choice Kind="ProcessAppFlag" Name="Merge (Selector)" />
+                                    </p:NodeReference>
+                                    <Pin Id="Qq8cIeSXipiOVHudvajA3g" Name="Channel A" Kind="InputPin" />
+                                    <Pin Id="GqhER6Hh2YzQMQ9NYaOhyX" Name="Channel B" Kind="InputPin" />
+                                    <Pin Id="K3DB4rvJGOHNk7omUtQ0AK" Name="Initialization" Kind="InputPin" DefaultValue="UseA" />
+                                    <Pin Id="Rg5IHyHVbXAPF2IrnCmKEK" Name="Push Eagerly To" Kind="InputPin" />
+                                    <Patch Id="VFfsuWKflVwPo4N506MLRP" Name="To B" ManuallySortedPins="true">
+                                      <ControlPoint Id="B7R0sfHxMxsNCsvBalkbzj" Bounds="388,360" />
+                                      <ControlPoint Id="IGFOGW7hCDfL04cf7JNG6Q" Bounds="388,476" />
+                                      <Pin Id="P4E8eI9gMHRNGxu48z8Btd" Name="Input" Kind="InputPin">
+                                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                                          <Choice Kind="TypeFlag" Name="Tuple (2 Items)" />
+                                          <p:TypeArguments>
+                                            <TypeReference>
+                                              <Choice Kind="TypeFlag" Name="Boolean" />
+                                            </TypeReference>
+                                            <TypeReference>
+                                              <Choice Kind="TypeFlag" Name="String" />
+                                            </TypeReference>
+                                          </p:TypeArguments>
+                                        </p:TypeAnnotation>
+                                      </Pin>
+                                      <Pin Id="Pxpu28VPIaJPL0I0H1PXbm" Name="Result" Kind="OutputPin" />
+                                      <Node Bounds="386,424,70,26" Id="BFLmifu87oKNqdTJ6xTtv0">
+                                        <p:NodeReference LastCategoryFullName="Primitive.Tuple (2 Items)" LastDependency="VL.CoreLib.vl">
+                                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                          <CategoryReference Kind="ClassType" Name="Tuple (2 Items)" NeedsToBeDirectParent="true" />
+                                          <Choice Kind="OperationCallFlag" Name="Item1" />
+                                        </p:NodeReference>
+                                        <Pin Id="GhLVnX85VO7OdKgmT4IuEr" Name="Input" Kind="StateInputPin" />
+                                        <Pin Id="JTyVQojIa3bM215kptr9qc" Name="Item 1" Kind="OutputPin" />
+                                      </Node>
+                                    </Patch>
+                                    <Patch Id="BHmQtWNBWCrOZ2Nqg1pFFb" Name="To A" ManuallySortedPins="true">
+                                      <Pin Id="AqymRuC4Vx9MvEbPJf3t2x" Name="Input" Kind="InputPin" />
+                                      <Pin Id="OvKgiVCxNCZLdB9Zxfw2oY" Name="Result" Kind="OutputPin" />
+                                      <ControlPoint Id="JO06oGpi3sLMaLUs4R7bEn" Bounds="479,360" />
+                                      <ControlPoint Id="BjlTMAMqapAO0HEo0JxkiO" Bounds="479,476" />
+                                      <Node Bounds="477,424,100,19" Id="KoaBr3CehAsMDM6nxHxdUV">
+                                        <p:NodeReference LastCategoryFullName="Primitive.Tuple (2 Items)" LastDependency="VL.CoreLib.vl">
+                                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                          <CategoryReference Kind="ClassType" Name="Tuple (2 Items)" />
+                                          <Choice Kind="OperationCallFlag" Name="Tuple (Create)" />
+                                        </p:NodeReference>
+                                        <Pin Id="F4Qn5bmP8VBQCKQpUzt6IK" Name="Item 1" Kind="InputPin" />
+                                        <Pin Id="IxdHongC0UMOFnYooHqKpz" Name="Item 2" Kind="InputPin" />
+                                        <Pin Id="TyxnTn15pkALN6TSSnZWFc" Name="Output" Kind="StateOutputPin" />
+                                      </Node>
+                                      <Node Bounds="532,353,45,26" Id="Kx0xro9fB2XMrved7fLlwG">
+                                        <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
+                                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                          <CategoryReference Kind="ClassType" Name="Channel" />
+                                          <Choice Kind="OperationCallFlag" Name="Value" />
+                                        </p:NodeReference>
+                                        <Pin Id="QvRfz4sYFxWPPU4S6s7K9k" Name="Input" Kind="StateInputPin" />
+                                        <Pin Id="KOM92J28zRALEzsn5TGiVL" Name="Output" Kind="StateOutputPin" />
+                                        <Pin Id="T5V7hoKyAWrLJ1lwT4jDog" Name="Value" Kind="OutputPin" />
+                                      </Node>
+                                      <Node Bounds="572,394,70,26" Id="Udxq8Bm4cN1Qdc5Iubhyyx">
+                                        <p:NodeReference LastCategoryFullName="Primitive.Tuple (2 Items)" LastDependency="VL.CoreLib.vl">
+                                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                          <CategoryReference Kind="ClassType" Name="Tuple (2 Items)" NeedsToBeDirectParent="true" />
+                                          <Choice Kind="OperationCallFlag" Name="Item2" />
+                                        </p:NodeReference>
+                                        <Pin Id="Isoy0GqGipgOcdOcacjeow" Name="Input" Kind="StateInputPin" />
+                                        <Pin Id="Q6lJfiK0BNkLg3HHBCGLXJ" Name="Item 2" Kind="OutputPin" />
+                                      </Node>
+                                    </Patch>
+                                  </Node>
+                                  <Node Bounds="865,275,53,19" Id="GRyO5T9VqjXLX4XNT93ht5">
+                                    <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
+                                      <Choice Kind="ProcessAppFlag" Name="Channel" />
+                                    </p:NodeReference>
+                                    <Pin Id="NutMnLcpsf7K9ssw5lGubB" Name="Value" Kind="InputPin" />
+                                    <Pin Id="DAZcH1ziIYVMzFPu15W9RM" Name="Output" Kind="OutputPin" />
+                                    <Pin Id="EVwqtjEJPNILv7nt3DK0Oj" Name="Value" Kind="OutputPin" />
+                                  </Node>
+                                  <Overlay Id="D6xib9J0JlcLrEQbARaBbh" Name="Was ist das" Bounds="315,243,410,968" />
+                                  <ControlPoint Id="LFUu4UpHzO6NYwxwyzaLSb" Bounds="1106,161" />
+                                  <Node Bounds="1181,857,55,19" Id="FKFbjisdjkzOYQRyEgHlyZ">
+                                    <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <Choice Kind="OperationCallFlag" Name="ToString" />
+                                    </p:NodeReference>
+                                    <Pin Id="C0kOrl7scBlPySL8M5r1Ex" Name="Input" Kind="InputPin" />
+                                    <Pin Id="DGdKYDGVqBQQYU1nasloup" Name="Result" Kind="OutputPin" />
+                                  </Node>
+                                  <ControlPoint Id="K3gDS7MXDS4MJxb3QfQITt" Bounds="1183,830" />
+                                  <ControlPoint Id="LDt7rANjmbyMw3Y1YPriS0" Bounds="940,1011" />
+                                  <ControlPoint Id="J2KhsI6djvbN294EBqEMfG" Bounds="916,1274" />
+                                  <ControlPoint Id="GxmBMnbVDW8LRwh2QYFyIb" Bounds="1140,1413" />
+                                  <Pad Id="JHtsspvrBscNDyvcxOokqq" Bounds="377,649,273,208" ShowValueBox="true" isIOBox="true" Value="Ok, so in our data model, there's a Tuple&lt;Bool,String&gt; to enable/disable items quickly for the UI. But our widgets are only interesting in one of the elements of the tuple. We're using the Merge region to &quot;convert&quot; on the fly from one to the other. We get a Channel&lt;Tuple&gt; from the model that we convert either to Channel&lt;String&gt; or Channel&lt;Bool&gt;, and then do the backward conversion to write stuff to the model again.">
+                                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="TypeFlag" Name="String" />
+                                    </p:TypeAnnotation>
+                                    <p:ValueBoxSettings>
+                                      <p:fontsize p:Type="Int32">9</p:fontsize>
+                                      <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+                                    </p:ValueBoxSettings>
+                                  </Pad>
                                 </Canvas>
                                 <ProcessDefinition Id="DafkhEPHTCCMqIfKwC2MGR">
                                   <Fragment Id="EUYteL2dV9VPTLOk6fvoUj" Patch="SG2sI2EzgswMnBU9QBIP1A" Enabled="true" />
                                   <Fragment Id="KqhIQPE0dptMhGvwHGsMdr" Patch="SqUKJfOKIZsOG7c3kYdpfP" Enabled="true" />
                                 </ProcessDefinition>
                                 <Link Id="K5c1UXsSy4eOnunEb4LeUn" Ids="RBZBWxVD7ubLMdIsgVYVoO,KIaZnHTx9yrLyE0LJ4c2PA" />
-                                <Link Id="TqdDygeDXZbOgj76X9qIMP" Ids="TyJ07eBJG3VM0y7f1nzlCO,CFvZhip4k7kPCa2530nxfw" />
-                                <Link Id="E9Dd1u4NesQPhGktISVH2U" Ids="JnKgrDCKCQvN8r1Xfd47SQ,UNEgUFSKLYYOyTeC8jwYpg" IsHidden="true" />
-                                <Link Id="Ua3ugn7EMedO3p4KEI0CSY" Ids="UNEgUFSKLYYOyTeC8jwYpg,PfRj81shys9O4eFyyMGjNu" />
-                                <Link Id="NrHMLJaYoZSNc34IN206wO" Ids="AiG5eDyGmyKLQjZHos8uWx,VuNjzFF37VJNdk4017AurH" />
                                 <Link Id="LcjhjunNtdMNusoOP2MAYz" Ids="AYefMxCcPzPQPj3r5frcOv,IcTyWajvUlQMp0bDXq3UOl" />
                                 <Link Id="BQm88xn2S3LNzU4zyzX02H" Ids="CJSBi3zKLtxNWAGshg2M1I,OsYq2NeLHPdQFm1P6fhBmX" />
-                                <Link Id="Mh4BsTAgU1GPh3yBXFgKzG" Ids="UNEgUFSKLYYOyTeC8jwYpg,ToulhYPrvJEPzPAdWHoY4R" />
                                 <Link Id="HXCX9yxumbDPd3ppe9vQIK" Ids="MZb8C2FatqtPHXVLo8tbnw,A17Uk7szlH0MgljzxasBog" />
                                 <Link Id="TNbT4w8wexrLhnyB7dSXxN" Ids="Gl0uUNHW9ybNeVwqyjq3SX,FMJgkcZz8kkPkjs5YxmDAk" />
                                 <Link Id="IxxtxmftYeUMuULouH2A9g" Ids="Q26ztZZqftJORCMZwLPtjR,UIzHL4jyX1vMg2nXtGDsLt" />
-                                <Link Id="FGGXddPDZglMuQjz1CZGj3" Ids="UNEgUFSKLYYOyTeC8jwYpg,HEOEN2KXHgIM52UJouNfQz" />
                                 <Link Id="Jgfz4ZNncUMMn3YuDljsrh" Ids="P716jJiGYBWQZxXg3nRqQd,UBYOF7iCKEyOZpBUrjieyh" />
-                                <Link Id="Jzm2QB1CZb0OHVPPvetDOS" Ids="UNEgUFSKLYYOyTeC8jwYpg,CshTNFmka3wLPnQQ8cP25C" />
                                 <Link Id="JaMXDnlBTNrMjlyRmTVWnG" Ids="EHxuyU0kVT1QQQgFTb7eQe,Tbie6gJdtSPN4sceZEsgN8" />
                                 <Link Id="LkAYPyA8u1YONaOv2vm4Sj" Ids="AiG5eDyGmyKLQjZHos8uWx,ARGtfNOy2jCLG23hj8aj70" />
                                 <Link Id="F6dfSFVUCE2LK4W0s6oGKT" Ids="IsCct5UIfr8PFqVd32JCKq,Ga2JV138YmLNWlXRPiJhuG" />
@@ -7048,6 +7462,45 @@
                                 <Link Id="UfBv5FgSdVmMcSV87SaD1U" Ids="RZElBkxCxNcQZD5JxMO0hd,HdbO43m9fyeP14cJ1kKOzb" />
                                 <Link Id="TxHUJwHdbAZQSpBCOt9p6j" Ids="EdlhaoIaeRBOMOOWrpETwa,JyJxTRhRsUZLeAWSlwzEgg" />
                                 <Link Id="ClAiXt3y6aPQJOmhx55YLh" Ids="Fm5HM85ikmJOTGTVVqZzAM,IQWtY329yvINddFgcCWI8F" />
+                                <Link Id="Bwx3SeukXxQQI43YDNlfAj" Ids="QV3LNKVrbiqPV4s0qZLaKM,BeVClM1qqs8PdfTz5thfOz" IsHidden="true" />
+                                <Link Id="MpQ892VDwPvOxtNo8uYTsE" Ids="CScsPPnRi1oPJApYm7fHDD,EvuYI6Yv9KfNeGG6YCclN5" IsHidden="true" />
+                                <Link Id="KJ5xFDCJKQANQNyzBkeR8b" Ids="NSXp7ug2v0gOvDlnwJbv0u,C1hrdeKZ4jVMzxogUYeHxJ" IsHidden="true" />
+                                <Link Id="MrndnkiAe9wPUnlYBFXilc" Ids="CF6KkV3IqZCLmGnwsorwsr,BqosmHszk1gMhT7Qb36pcW" IsHidden="true" />
+                                <Link Id="AyjDBg50hMmLtlu3us1eYo" Ids="TyJ07eBJG3VM0y7f1nzlCO,R4AE2WgBUd0Omat455ttye" />
+                                <Link Id="U3B4c62qiMGPnnhFhqbpEF" Ids="BeVClM1qqs8PdfTz5thfOz,HMkwcFLO8oLOdmj0pSKhMk" />
+                                <Link Id="HxscxqDc3hWNtV2e96L1bL" Ids="Aa5wcpZQCBWMPTf3oIrkxP,CScsPPnRi1oPJApYm7fHDD" />
+                                <Link Id="VC5VE42IHvxQZhZCVawUD8" Ids="BGoFCzqjKtXM4Clr5yEOsx,UhpcprSUbWtNC9g6BTGBOz" />
+                                <Link Id="HjrFyGECxIeLZ1WfARUabb" Ids="BGoFCzqjKtXM4Clr5yEOsx,CFvZhip4k7kPCa2530nxfw" />
+                                <Link Id="Rt3vkLRlyONLzQfI5WWZtv" Ids="C1hrdeKZ4jVMzxogUYeHxJ,FGS12yTZmjMQN3BL46iQlx" />
+                                <Link Id="ONnMVh4ExUyOAmCyfCSV3a" Ids="VcSsHzLbWoLPWLhYOSItNn,CF6KkV3IqZCLmGnwsorwsr" />
+                                <Link Id="U1t558OPDncL1lmIQ121N1" Ids="P4E8eI9gMHRNGxu48z8Btd,B7R0sfHxMxsNCsvBalkbzj" IsHidden="true" />
+                                <Link Id="IXlHXiEz6wQLXJ97Iu2fJh" Ids="IGFOGW7hCDfL04cf7JNG6Q,Pxpu28VPIaJPL0I0H1PXbm" IsHidden="true" />
+                                <Link Id="M7nSFwVqMkYOkdX2kITSDj" Ids="AqymRuC4Vx9MvEbPJf3t2x,JO06oGpi3sLMaLUs4R7bEn" IsHidden="true" />
+                                <Link Id="ONf5gwgTRp0LT5ZueYbiMx" Ids="BjlTMAMqapAO0HEo0JxkiO,OvKgiVCxNCZLdB9Zxfw2oY" IsHidden="true" />
+                                <Link Id="ElcWXLl5rwYNdarjnm8I1c" Ids="B7R0sfHxMxsNCsvBalkbzj,GhLVnX85VO7OdKgmT4IuEr" />
+                                <Link Id="QgV9vcY8afCMCW9AogBkfQ" Ids="DAZcH1ziIYVMzFPu15W9RM,GqhER6Hh2YzQMQ9NYaOhyX" />
+                                <Link Id="KrDyYoXvJE3L5Rf0Slsj3t" Ids="TyxnTn15pkALN6TSSnZWFc,BjlTMAMqapAO0HEo0JxkiO" />
+                                <Link Id="TGXvtW0OGFmNQX7Svl5dqw" Ids="TyJ07eBJG3VM0y7f1nzlCO,Qq8cIeSXipiOVHudvajA3g" />
+                                <Link Id="S9YB7zwVLDxLUIaMYhYB7a" Ids="JTyVQojIa3bM215kptr9qc,IGFOGW7hCDfL04cf7JNG6Q" />
+                                <Link Id="TRwJf2qvdJDNXCwcKbmqtH" Ids="DAZcH1ziIYVMzFPu15W9RM,EbqbUfu0mLiLsjcZe7cwZD" />
+                                <Link Id="ADypx1JK4hNQZ5Mj84B1a4" Ids="JO06oGpi3sLMaLUs4R7bEn,F4Qn5bmP8VBQCKQpUzt6IK" />
+                                <Link Id="MCQs636os8WO7nwO6G5xRn" Ids="T1yZRXamV0GLo86Kge0vXq,TWxU3YQdFSGLeNOuBGW2n9" />
+                                <Link Id="M8v2WKxA6tvLqbLknNoWgw" Ids="SrKagKPPOYEOLk5JPuwJxz,MFRNSzqGqW9QWI1Y6zP2pj" />
+                                <Link Id="VfSQPa5eTP7PYhiIAwHYXC" Ids="TyJ07eBJG3VM0y7f1nzlCO,Q8CcgBNlRvTNbLqwtNysO9" />
+                                <Link Id="AY0pkEDSLvaOnyLycjujl8" Ids="T5V7hoKyAWrLJ1lwT4jDog,Isoy0GqGipgOcdOcacjeow" />
+                                <Link Id="T5DHTT1P4n5QauVYhW7T3E" Ids="Q6lJfiK0BNkLg3HHBCGLXJ,IxdHongC0UMOFnYooHqKpz" />
+                                <Link Id="D0iAEhV2LKtL5Hp2MRkII3" Ids="TyJ07eBJG3VM0y7f1nzlCO,QvRfz4sYFxWPPU4S6s7K9k" />
+                                <Link Id="TvvrXY4xPw4N67lCu93nat" Ids="JnKgrDCKCQvN8r1Xfd47SQ,LFUu4UpHzO6NYwxwyzaLSb" IsHidden="true" />
+                                <Link Id="KZ0y89BtQIIQE1L5qVwi3N" Ids="LFUu4UpHzO6NYwxwyzaLSb,PfRj81shys9O4eFyyMGjNu" />
+                                <Link Id="C76mN0zUpusNxM03MIWz3p" Ids="JnKgrDCKCQvN8r1Xfd47SQ,K3gDS7MXDS4MJxb3QfQITt" IsHidden="true" />
+                                <Link Id="ULlHPwFvF2LPzYIZJteCBX" Ids="K3gDS7MXDS4MJxb3QfQITt,C0kOrl7scBlPySL8M5r1Ex" />
+                                <Link Id="GskQ7x1zLcBLgPMtgV80p9" Ids="DGdKYDGVqBQQYU1nasloup,VuNjzFF37VJNdk4017AurH" />
+                                <Link Id="B5uZPP9yVNxNcRP00SGRLC" Ids="JnKgrDCKCQvN8r1Xfd47SQ,LDt7rANjmbyMw3Y1YPriS0" IsHidden="true" />
+                                <Link Id="QwL9Cd66FxmLNT2gUH2DbK" Ids="LDt7rANjmbyMw3Y1YPriS0,HEOEN2KXHgIM52UJouNfQz" />
+                                <Link Id="Deurw1jSPzqLyOzEmbchzI" Ids="JnKgrDCKCQvN8r1Xfd47SQ,J2KhsI6djvbN294EBqEMfG" IsHidden="true" />
+                                <Link Id="O1FMnSwYmYcPHRytXhNR9a" Ids="J2KhsI6djvbN294EBqEMfG,CshTNFmka3wLPnQQ8cP25C" />
+                                <Link Id="OrE7qdXPx6jNuSHoZNKvm5" Ids="JnKgrDCKCQvN8r1Xfd47SQ,GxmBMnbVDW8LRwh2QYFyIb" IsHidden="true" />
+                                <Link Id="K2wi3xo6nmmPoFWfH1FEOs" Ids="GxmBMnbVDW8LRwh2QYFyIb,ToulhYPrvJEPzPAdWHoY4R" />
                               </Patch>
                             </Node>
                             <ControlPoint Id="OGUyZrKHdrpM5N2R2KwFn9" Bounds="462,1290" />
@@ -7255,8 +7708,8 @@
                         </p:NodeReference>
                         <Patch Id="SzJKq44PUF5QRBA941Pbit">
                           <Canvas Id="ORa7hgBFf6YQAV8vpzvSU7" CanvasType="Group">
-                            <ControlPoint Id="FvpLIf5t88IP1leqjN3i2T" Bounds="202,164" />
-                            <Node Bounds="200,185,106,26" Id="EksjCWxUEzpLJTNKi83vU4">
+                            <ControlPoint Id="FvpLIf5t88IP1leqjN3i2T" Bounds="198,161" />
+                            <Node Bounds="196,182,106,26" Id="EksjCWxUEzpLJTNKi83vU4">
                               <p:NodeReference LastCategoryFullName="Main.App.App" LastDependency="GammaLauncher.vl">
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 <Choice Kind="OperationCallFlag" Name="GetRuntimeChannel" />
@@ -7265,7 +7718,7 @@
                               <Pin Id="PVBnZk7KEbLOTIzIDKVRB3" Name="State Output" Kind="StateOutputPin" />
                               <Pin Id="FsOY8BcYFWDOoT71ok9fY9" Name="Output" Kind="OutputPin" />
                             </Node>
-                            <Node Bounds="301,225,41,19" Id="EPgL59h6Sr6P7swi5dT53D">
+                            <Node Bounds="297,222,45,26" Id="EPgL59h6Sr6P7swi5dT53D">
                               <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -7326,7 +7779,7 @@
                               </p:NodeReference>
                               <Pin Id="A6475wZmuSMLRIePgzovJU" Name="Break" Kind="OutputPin" />
                               <ControlPoint Id="GBp8C5ltUXgLx7gx6tOuTe" Bounds="557,906" Alignment="Top" />
-                              <ControlPoint Id="ECMnRwsIVsTM7loPx032bh" Bounds="597,1965" Alignment="Bottom" />
+                              <ControlPoint Id="ECMnRwsIVsTM7loPx032bh" Bounds="597,1966" Alignment="Bottom" />
                               <ControlPoint Id="Im5lQaa0W8vM4Ugj7jHbKP" Bounds="597,906" Alignment="Top" />
                               <Patch Id="HLBXULzCwaAM6CQTvvjy4r" ManuallySortedPins="true">
                                 <Patch Id="KsWyLsHhHKfOttDof9oFZE" Name="Create" ManuallySortedPins="true" />
@@ -7338,7 +7791,7 @@
                                     <CategoryReference Kind="Category" Name="Widgets" />
                                     <Choice Kind="ProcessAppFlag" Name="CollapsingHeader" />
                                   </p:NodeReference>
-                                  <ControlPoint Id="JqoYGjWLG53NcR7MJv2ilF" Bounds="597,1945" Alignment="Bottom" />
+                                  <ControlPoint Id="JqoYGjWLG53NcR7MJv2ilF" Bounds="597,1946" Alignment="Bottom" />
                                   <Patch Id="GGDKPzpg8N8LkKO6pyS92t" ManuallySortedPins="true">
                                     <Patch Id="U3KnBdOuhdsLxR5foTtlGR" Name="Create" ManuallySortedPins="true" />
                                     <Patch Id="EO0v0kFtLySOJ7h5eVwNoG" Name="Update" ManuallySortedPins="true" />
@@ -7350,7 +7803,7 @@
                                       </p:NodeReference>
                                       <Pin Id="BWQJf10KDPMOPI0pxqN9sg" Name="Break" Kind="OutputPin" />
                                       <ControlPoint Id="MWYneSbGcbHMVgbhS6tBbh" Bounds="617,1018" Alignment="Top" />
-                                      <ControlPoint Id="DjuLIkaGuljNEWdFZlHROb" Bounds="597,1925" Alignment="Bottom" />
+                                      <ControlPoint Id="DjuLIkaGuljNEWdFZlHROb" Bounds="597,1926" Alignment="Bottom" />
                                       <ControlPoint Id="ITZOoSpDebOMyjLIQ8SWpJ" Bounds="597,1018" Alignment="Top" />
                                       <Patch Id="JIPayITk8DOPdWKmA8Csvs" ManuallySortedPins="true">
                                         <Patch Id="HdZrQq0WPqNPDroeWWM3c6" Name="Create" ManuallySortedPins="true" />
@@ -7602,7 +8055,7 @@
                                 </Node>
                               </Patch>
                             </Node>
-                            <Node Bounds="1033,95,65,19" Id="M52THAfWRzoLNHcwxlsVa7">
+                            <Node Bounds="1033,95,85,19" Id="M52THAfWRzoLNHcwxlsVa7">
                               <p:NodeReference LastCategoryFullName="Main.Editor.UI.Editor.Tabs" LastDependency="GammaLauncher.vl">
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 <CategoryReference Kind="Category" Name="Tabs" NeedsToBeDirectParent="true" />
@@ -7666,7 +8119,7 @@
                               <Pin Id="I3AuT0l2cUlOFJDey3s7ej" Name="Output" Kind="StateOutputPin" />
                               <Pin Id="MknGxLLMIpGOhTCOXorJIW" Name="Log Channel" Kind="OutputPin" />
                             </Node>
-                            <Node Bounds="580,2707,41,19" Id="B4VxqCwHN3zLG1qVnsimfz">
+                            <Node Bounds="580,2707,45,26" Id="B4VxqCwHN3zLG1qVnsimfz">
                               <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 <CategoryReference Kind="ClassType" Name="Channel" />
@@ -7707,7 +8160,7 @@
                               <Pin Id="Q7UH7HOB1NULROtXAuE1EB" Name="Anchor" Kind="InputPin" />
                               <Pin Id="AS1D1dyId49NLylodtMlm1" Name="Output" Kind="StateOutputPin" />
                             </Node>
-                            <Node Bounds="614,482,41,19" Id="M3pz3x8Yxq3MBd2xn55rSP">
+                            <Node Bounds="614,482,45,26" Id="M3pz3x8Yxq3MBd2xn55rSP">
                               <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 <CategoryReference Kind="ClassType" Name="Channel" />
@@ -7816,7 +8269,7 @@
                               <Pin Id="NucLZt9OBwdPjkjg4W8sPT" Name="Output" Kind="StateOutputPin" />
                               <Pin Id="QS1UfzmKSrfNww13QWcPsC" Name="Newer Launcher Builds Online Flag" Kind="OutputPin" />
                             </Node>
-                            <Node Bounds="620,2041,41,19" Id="Rrgn5mulTqcMqleOUo4l8A">
+                            <Node Bounds="620,2041,45,26" Id="Rrgn5mulTqcMqleOUo4l8A">
                               <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 <CategoryReference Kind="ClassType" Name="Channel" />
@@ -7826,7 +8279,7 @@
                               <Pin Id="QTsTNU1kTKZMHkROlICTez" Name="Output" Kind="StateOutputPin" />
                               <Pin Id="L0qXKjeHiBzMsWwoWLCU1h" Name="Value" Kind="OutputPin" />
                             </Node>
-                            <Node Bounds="439,2233,398,411" Id="Hubm3CplsTbLySGzjm029d">
+                            <Node Bounds="439,2233,398,412" Id="Hubm3CplsTbLySGzjm029d">
                               <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                 <CategoryReference Kind="Category" Name="Primitive" />
@@ -7834,8 +8287,8 @@
                               </p:NodeReference>
                               <Pin Id="JQLfI7XMTXyOJWK8IyYBMU" Name="Condition" Kind="InputPin" DefaultValue="True" />
                               <ControlPoint Id="V3JTtQRlwLuQSbfR0jgAPr" Bounds="599,2639" Alignment="Bottom" />
-                              <ControlPoint Id="B9F6Vg5N8csMN9AlCx6iL1" Bounds="596,2240" Alignment="Top" />
-                              <ControlPoint Id="Mbnu8dU8ZlpOIkw7082hfX" Bounds="453,2240" Name="Update Tab Runtime" Alignment="Top" />
+                              <ControlPoint Id="B9F6Vg5N8csMN9AlCx6iL1" Bounds="596,2239" Alignment="Top" />
+                              <ControlPoint Id="Mbnu8dU8ZlpOIkw7082hfX" Bounds="453,2239" Name="Update Tab Runtime" Alignment="Top" />
                               <ControlPoint Id="UODC3t0XcRKQXFdlUNjkTv" Bounds="453,2639" Name="Update Tab Runtime" Alignment="Bottom" />
                               <Patch Id="EyJB82M5OFpOSK26vQktJP" ManuallySortedPins="true">
                                 <Patch Id="FQEAsAytH7jNQe7U7vMv1a" Name="Create" ManuallySortedPins="true" />
@@ -7882,7 +8335,7 @@
                                   <Pin Id="AEZryJr5GrDN6dLyqCkuNt" Name="Download Page URL" Kind="OutputPin" />
                                   <Pin Id="G505dRnbzqQLSmbGivhtCu" Name="Asset URL" Kind="OutputPin" />
                                 </Node>
-                                <Node Bounds="603,2368,41,19" Id="F3ur0BCGkiwPO7nLDW0nM7">
+                                <Node Bounds="603,2368,45,26" Id="F3ur0BCGkiwPO7nLDW0nM7">
                                   <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                     <CategoryReference Kind="ClassType" Name="Channel" />
@@ -9825,7 +10278,7 @@
                   </Patch>
                 </Node>
                 <ControlPoint Id="KO5sIEWmxogMJS0VAeMOzK" Bounds="505,443" />
-                <Node Bounds="586,375" Id="JEGsNAXnUfEQErpY3gL0oB">
+                <Node Bounds="586,375,45,26" Id="JEGsNAXnUfEQErpY3gL0oB">
                   <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="ClassType" Name="Channel" />
@@ -12537,7 +12990,7 @@
                 <Pin Id="UTwrSQdjGzZMZKvLk2XvYv" Name="Output" Kind="StateOutputPin" />
                 <Pin Id="QTfLpk92aWkMbG1YWqXQ4j" Name="Result" Kind="OutputPin" />
               </Node>
-              <Node Bounds="284,642,105,84" Id="KdGATjf8pI9L5xZLyM2Uhg">
+              <Node Bounds="284,642,105,85" Id="KdGATjf8pI9L5xZLyM2Uhg">
                 <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <CategoryReference Kind="Category" Name="Primitive" />
@@ -12559,7 +13012,7 @@
                     <Pin Id="G7VPVLde6ZZLxF1ucHI4wX" Name="Output" Kind="StateOutputPin" />
                   </Node>
                 </Patch>
-                <ControlPoint Id="DBt8tf0ByYfNUbBbUnYgym" Bounds="298,649" Alignment="Top" />
+                <ControlPoint Id="DBt8tf0ByYfNUbBbUnYgym" Bounds="298,648" Alignment="Top" />
                 <ControlPoint Id="V1GcLNMDuHaOyvsl0cAhgu" Bounds="298,721" Alignment="Bottom" />
               </Node>
               <Node Bounds="429,610,37,19" Id="CrAtWBSshdXQWUtgZO9iiD">
@@ -12571,7 +13024,7 @@
                 <Pin Id="D3gcQql2brKLDdkSDmCtVC" Name="Input" Kind="StateInputPin" />
                 <Pin Id="PhU2fIyj4ntO7LD59OlGR8" Name="Output" Kind="StateOutputPin" />
               </Node>
-              <Node Bounds="429,644,105,76" Id="Fgp2Az16hXWOy7z8fjx0Hh">
+              <Node Bounds="429,644,105,77" Id="Fgp2Az16hXWOy7z8fjx0Hh">
                 <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <CategoryReference Kind="Category" Name="Primitive" />
@@ -12593,7 +13046,7 @@
                     <Pin Id="Tp4usqniebhQO5UWXDckNS" Name="Output" Kind="StateOutputPin" />
                   </Node>
                 </Patch>
-                <ControlPoint Id="C6Zml7MuPcbNKsEvoBSW58" Bounds="443,651" Alignment="Top" />
+                <ControlPoint Id="C6Zml7MuPcbNKsEvoBSW58" Bounds="443,650" Alignment="Top" />
                 <ControlPoint Id="NkYWb7Ss4yyLbjVbQGtoaw" Bounds="443,715" Alignment="Bottom" />
               </Node>
               <Link Id="UPUZbS7DcNSMcgrXkPdLbq" Ids="NsS3xr4IPzRMvkajQ5vAsO,Po9Bf2jE0DsLgf0xGCM1eK" />
@@ -12651,7 +13104,7 @@
     ************************ LogBuildDiscovery ************************
 
 -->
-          <Node Name="LogBuildDiscovery" Bounds="262,831,279,220" Id="NmomlvlXBqmNJNoJXnfxwB">
+          <Node Name="LogBuildDiscovery" Bounds="262,831,279,227" Id="NmomlvlXBqmNJNoJXnfxwB">
             <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
               <CategoryReference Kind="Category" Name="Primitive" NeedsToBeDirectParent="true" />
               <Choice Kind="OperationDefinition" Name="Operation" />
@@ -12679,7 +13132,7 @@
                 <Pin Id="KcCMAbxAmYvQddgXAqpLIV" Name="Input 4" Kind="InputPin" />
                 <Pin Id="DkJGcddPyXxNb5M4tImRAP" Name="Output" Kind="StateOutputPin" />
               </Node>
-              <Node Bounds="343,877,44,19" Id="SdU92Wwc9tMOsZIZblmFV7">
+              <Node Bounds="343,877,44,26" Id="SdU92Wwc9tMOsZIZblmFV7">
                 <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -12696,7 +13149,7 @@
                 <Pin Id="KUkQk49vRCzNpSrCXThJdG" Name="Input" Kind="InputPin" />
                 <Pin Id="BdKu6msL4RgPpZ2hnj3lk8" Name="Result" Kind="OutputPin" />
               </Node>
-              <Node Bounds="274,1012,55,19" Id="DodkBWRbSysL7TPpjdEPYu">
+              <Node Bounds="274,1012,55,26" Id="DodkBWRbSysL7TPpjdEPYu">
                 <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -12738,7 +13191,7 @@
     ************************ LogBuildConfigDiscovery ************************
 
 -->
-          <Node Name="LogBuildConfigDiscovery" Bounds="269,159,303,201" Id="IyxHZ8N7WPcMh610MTDGUz">
+          <Node Name="LogBuildConfigDiscovery" Bounds="269,159,303,208" Id="IyxHZ8N7WPcMh610MTDGUz">
             <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
               <CategoryReference Kind="Category" Name="Primitive" NeedsToBeDirectParent="true" />
               <Choice Kind="OperationDefinition" Name="Operation" />
@@ -12757,7 +13210,7 @@
                 <Pin Id="JA4lNNiI8FeObR3HKjFcKA" Name="Input 4" Kind="InputPin" />
                 <Pin Id="Q8CfSmAa5MMP0F3Ys7ZMbO" Name="Output" Kind="StateOutputPin" />
               </Node>
-              <Node Bounds="351,208,44,19" Id="MrsBzmTbY6AL4zoLxrQeMN">
+              <Node Bounds="351,208,44,26" Id="MrsBzmTbY6AL4zoLxrQeMN">
                 <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -12784,7 +13237,7 @@
                 <Pin Id="Nvu3UirMfZsPiTKdJCFq3m" Name="Values" Kind="InputPin" />
                 <Pin Id="Bi8zsQ2wMkDOsiKwv6P1qq" Name="Output" Kind="StateOutputPin" />
               </Node>
-              <Node Bounds="281,321,55,19" Id="CQ8ABt3sZuQOQLLDqL9SHS">
+              <Node Bounds="281,321,55,26" Id="CQ8ABt3sZuQOQLLDqL9SHS">
                 <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -12826,7 +13279,7 @@
     ************************ IsNewerGammaBuildOnline ************************
 
 -->
-          <Node Name="IsNewerGammaBuildOnline" Bounds="843,298,588,508" Id="Sbbo7EubEpALaod1eZy49J">
+          <Node Name="IsNewerGammaBuildOnline" Bounds="843,298,588,515" Id="Sbbo7EubEpALaod1eZy49J">
             <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
               <CategoryReference Kind="Category" Name="Primitive" NeedsToBeDirectParent="true" />
               <Choice Kind="OperationDefinition" Name="Operation" />
@@ -12910,7 +13363,7 @@
                     <ControlPoint Id="F7Mzs5lfpxHMX2F02PWfre" Bounds="1309,666" Alignment="Bottom" />
                   </Node>
                 </Patch>
-                <ControlPoint Id="Qpb4n8yctMuLHQmKSyOXjY" Bounds="1259,357" Alignment="Top" />
+                <ControlPoint Id="Qpb4n8yctMuLHQmKSyOXjY" Bounds="1259,356" Alignment="Top" />
                 <ControlPoint Id="TRLbC9xFYr4N0ucTatOJ5v" Bounds="1247,686" Alignment="Bottom" />
               </Node>
               <Link Id="Rm719KqWbm5N5MC7dMcgIH" Ids="Qpb4n8yctMuLHQmKSyOXjY,QLCvtfJztXnPMQ9heL1Jrz" />
@@ -12928,7 +13381,7 @@
               <Link Id="LrtooAEcyM1PGBCbLQBbv1" Ids="GiyFomfzj8eOp35wlPeTIq,Qpb4n8yctMuLHQmKSyOXjY" />
               <ControlPoint Id="GiyFomfzj8eOp35wlPeTIq" Bounds="1259,317" />
               <Link Id="ImefjuJoo5ELrZNbV0wQWf" Ids="GQgHoy3qU4FNAPjx0uOOlG,GiyFomfzj8eOp35wlPeTIq" IsHidden="true" />
-              <Node Bounds="1195,767,55,19" Id="SCNQIJ0251lP0LOD3IiM71">
+              <Node Bounds="1195,767,55,26" Id="SCNQIJ0251lP0LOD3IiM71">
                 <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -12961,7 +13414,7 @@
                   </p:TypeArguments>
                 </p:TypeAnnotation>
               </Pin>
-              <Node Bounds="1245,711,30,19" Id="EEPJt2OwEP8L2yWkhStDEC">
+              <Node Bounds="1245,711,50,26" Id="EEPJt2OwEP8L2yWkhStDEC">
                 <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="MutableInterfaceType" Name="Sequence" NeedsToBeDirectParent="true" />
@@ -13004,13 +13457,13 @@
     ************************ LogVersionCheck ************************
 
 -->
-          <Node Name="LogVersionCheck" Bounds="266,1109,130,112" Id="BckxRGjEUDmQC7X4CqXSpC">
+          <Node Name="LogVersionCheck" Bounds="266,1109,130,119" Id="BckxRGjEUDmQC7X4CqXSpC">
             <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
               <CategoryReference Kind="Category" Name="Primitive" NeedsToBeDirectParent="true" />
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="IrhqfJM5h2WPKZACDOPHJB">
-              <Node Bounds="278,1182,55,19" Id="CYBnSiPoCcOPgAIddCyrnu">
+              <Node Bounds="278,1182,55,26" Id="CYBnSiPoCcOPgAIddCyrnu">
                 <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -13037,13 +13490,13 @@
     ************************ LogVersionCheckResult ************************
 
 -->
-          <Node Name="LogVersionCheckResult" Bounds="442,1118,267,187" Id="R41E74thnNAQZMKQv39Txl">
+          <Node Name="LogVersionCheckResult" Bounds="442,1118,267,194" Id="R41E74thnNAQZMKQv39Txl">
             <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
               <CategoryReference Kind="Category" Name="Primitive" NeedsToBeDirectParent="true" />
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="EufPy8nx3tiPIzigZqUFay">
-              <Node Bounds="454,1266,55,19" Id="FdN4xZGvv3tNVnIYLur8n3">
+              <Node Bounds="454,1266,55,26" Id="FdN4xZGvv3tNVnIYLur8n3">
                 <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -13077,20 +13530,20 @@
                 <Pin Id="FSHj0N7jIbmOMkjgQvgH7n" Name="Output" Kind="OutputPin" />
               </Node>
               <Link Id="Bc3UivoVELZPCXMreT0Jia" Ids="FSHj0N7jIbmOMkjgQvgH7n,AA72eZKs0cNNseB0f9VO4k" />
-              <Pad Id="GNdtwCd4p7RPYiMERjN2yK" Comment="" Bounds="546,1212,132,0" ShowValueBox="true" isIOBox="true" Value="Newer builds available!">
+              <Pad Id="GNdtwCd4p7RPYiMERjN2yK" Comment="" Bounds="546,1212,132,15" ShowValueBox="true" isIOBox="true" Value="Newer builds available!">
                 <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="ImmutableTypeFlag" Name="String" />
                   <CategoryReference Kind="Category" Name="Primitive" />
                 </p:TypeAnnotation>
               </Pad>
               <Link Id="TqvGvNQzWm2LE9g85yI8iM" Ids="GNdtwCd4p7RPYiMERjN2yK,JiQE7GBKugIPsA23Sn4iUp" />
-              <Pad Id="KSPil7FmFmGMf48Irckqiw" Comment="" Bounds="526,1188,125,7" ShowValueBox="true" isIOBox="true" Value="No newer builds available.">
+              <Pad Id="KSPil7FmFmGMf48Irckqiw" Comment="" Bounds="526,1188,125,15" ShowValueBox="true" isIOBox="true" Value="No newer builds available.">
                 <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pad>
               <Link Id="NqqP0kMbZ5qMJBluDWzmRm" Ids="KSPil7FmFmGMf48Irckqiw,It26lfkZCOKMc4BUs8uNr6" />
-              <Node Bounds="468,1192,41,19" Id="BVKf3ZsJdqNOtUxLNJGZFb">
+              <Node Bounds="468,1192,45,26" Id="BVKf3ZsJdqNOtUxLNJGZFb">
                 <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Channel" />
@@ -13112,13 +13565,13 @@
     ************************ LogGammaLauncherLookup ************************
 
 -->
-          <Node Name="LogGammaLauncherLookup" Bounds="882,1140,130,118" Id="J94ZnWRP82tORPXwJb3xoi">
+          <Node Name="LogGammaLauncherLookup" Bounds="882,1140,130,125" Id="J94ZnWRP82tORPXwJb3xoi">
             <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
               <CategoryReference Kind="Category" Name="Primitive" NeedsToBeDirectParent="true" />
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="TeAoCNwkZlnMcSG9jiXNKe">
-              <Node Bounds="894,1219,55,19" Id="H7ljLOTrxZgNWDXGzcbHkl">
+              <Node Bounds="894,1219,55,26" Id="H7ljLOTrxZgNWDXGzcbHkl">
                 <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -13154,13 +13607,13 @@
     ************************ LogGammaLauncherVersionCheck ************************
 
 -->
-          <Node Name="LogGammaLauncherVersionCheck" Bounds="1088,1254,192,238" Id="O7z6UoO0Ik0QMHbVIZTNPa">
+          <Node Name="LogGammaLauncherVersionCheck" Bounds="1088,1254,192,245" Id="O7z6UoO0Ik0QMHbVIZTNPa">
             <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
               <CategoryReference Kind="Category" Name="Primitive" NeedsToBeDirectParent="true" />
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="QBO9gRB2PZ2NcWaQUXe3Od">
-              <Node Bounds="1100,1453,55,19" Id="RUOZ6SdFFgRLmt4nvK1MXJ">
+              <Node Bounds="1100,1453,55,26" Id="RUOZ6SdFFgRLmt4nvK1MXJ">
                 <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -13619,7 +14072,7 @@
     ************************ IsMoreRecentThanLatestLocal ************************
 
 -->
-          <Node Name="IsMoreRecentThanLatestLocal" Bounds="1264,902,478,235" Id="ES4vzudyJFpLddo5BWrTJl">
+          <Node Name="IsMoreRecentThanLatestLocal" Bounds="1264,902,478,254" Id="ES4vzudyJFpLddo5BWrTJl">
             <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>

--- a/GammaLauncher.vl
+++ b/GammaLauncher.vl
@@ -113,12 +113,12 @@
           </p:NodeReference>
           <Patch Id="L5Alz0TNkZjMTlAyzY4NWH">
             <Canvas Id="HqlWFjfKeNrOJxrXj7CTiK" CanvasType="Group">
-              <Pad Id="OWUILsNLXyXMyTbaXyNGse" SlotId="Q0QF5tSy8juPWF5tZxf75v" Bounds="330,309" />
+              <Pad Id="OWUILsNLXyXMyTbaXyNGse" SlotId="Q0QF5tSy8juPWF5tZxf75v" Bounds="172,309" />
               <Pad Id="Plm11su9ejfM6nQDfxz4UM" SlotId="GVeGWyNNAO4MbGt37YZf0x" Bounds="522,309" />
-              <ControlPoint Id="KcjhzyNdhcTNBolcSghaK1" Bounds="330,253" />
+              <ControlPoint Id="KcjhzyNdhcTNBolcSghaK1" Bounds="172,253" />
               <ControlPoint Id="UijWD1P4KgPQLwU4B2SRJ7" Bounds="522,253" />
-              <Pad Id="AkZh3mOfI4wLLYkE0RMRyT" SlotId="Sn2OaRH1HQfO3CdczN811U" Bounds="170,181" />
-              <Node Bounds="168,133,46,26" Id="UhJiCcvG6O2Oyx4ssLT9E4">
+              <Pad Id="AkZh3mOfI4wLLYkE0RMRyT" SlotId="Sn2OaRH1HQfO3CdczN811U" Bounds="170,109" />
+              <Node Bounds="168,61,46,26" Id="UhJiCcvG6O2Oyx4ssLT9E4">
                 <p:NodeReference LastCategoryFullName="System.GUID" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Create" />
@@ -126,15 +126,15 @@
                 </p:NodeReference>
                 <Pin Id="DHpxKDCeAzkMHNXkoIYbAH" Name="Result" Kind="StateOutputPin" />
               </Node>
-              <Pad Id="MNs9RTk7iD8NILIV7lLeh6" SlotId="S6mjHZNVsaJMwK5bj48p9J" Bounds="1094,309" />
-              <ControlPoint Id="H45vnuFVTYEPEQs86xuSIL" Bounds="1094,253" />
-              <Pad Id="L3Qr9LOQQJTM5YdvutFoWI" SlotId="EYZMSglGErnMZGzDXQvNWj" Bounds="700,309" />
-              <ControlPoint Id="O3j5hFuHko8Nc8f2OTdNfV" Bounds="700,253" />
-              <ControlPoint Id="RsNpzQk4oxDLdoRr6pmsXP" Bounds="1094,344" />
-              <ControlPoint Id="HzDoNoV9DjhPGMuIxbgFwy" Bounds="330,356" />
+              <Pad Id="MNs9RTk7iD8NILIV7lLeh6" SlotId="S6mjHZNVsaJMwK5bj48p9J" Bounds="431,126" />
+              <ControlPoint Id="H45vnuFVTYEPEQs86xuSIL" Bounds="431,70" />
+              <Pad Id="L3Qr9LOQQJTM5YdvutFoWI" SlotId="EYZMSglGErnMZGzDXQvNWj" Bounds="1515,297" />
+              <ControlPoint Id="O3j5hFuHko8Nc8f2OTdNfV" Bounds="1515,241" />
+              <ControlPoint Id="RsNpzQk4oxDLdoRr6pmsXP" Bounds="431,161" />
+              <ControlPoint Id="HzDoNoV9DjhPGMuIxbgFwy" Bounds="172,356" />
               <ControlPoint Id="MFQOMRdxDMpMu7tisVQcPv" Bounds="522,352" />
               <Pad Id="PYkBkqJ2qB7LK2djFWRxZI" SlotId="GVeGWyNNAO4MbGt37YZf0x" Bounds="525,431" />
-              <Node Bounds="523,452,35,19" Id="QKxQSsbmK4JMCI4zQhZpAN">
+              <Node Bounds="523,452,41,26" Id="QKxQSsbmK4JMCI4zQhZpAN">
                 <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -144,12 +144,12 @@
                 <Pin Id="VPeF2BxJA8UPkBVTEVI7T2" Name="Item" Kind="InputPin" />
                 <Pin Id="MO5ippD1d6YPF6h399kKNK" Name="Output" Kind="StateOutputPin" />
               </Node>
-              <ControlPoint Id="TBMl51KDBOyPh67uQks9xX" Bounds="555,433" />
+              <ControlPoint Id="TBMl51KDBOyPh67uQks9xX" Bounds="561,434" />
               <Pad Id="EoeNtPs1fwzMFHbGxo5uRJ" SlotId="GVeGWyNNAO4MbGt37YZf0x" Bounds="525,495" />
               <Pad Id="LXEnPscU7arMsUyyL6HGf2" SlotId="GVeGWyNNAO4MbGt37YZf0x" Bounds="537,572" />
               <Pad Id="JeQwVruuCgyQT5Sc1DRVGF" SlotId="GVeGWyNNAO4MbGt37YZf0x" Bounds="537,636" />
               <ControlPoint Id="KmLE4kCpa3uQPnMbZknxUZ" Bounds="614,573" />
-              <Node Bounds="535,596,82,19" Id="Iq6efIgJfFbPl793IKrzHd">
+              <Node Bounds="535,596,82,26" Id="Iq6efIgJfFbPl793IKrzHd">
                 <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Spread" />
@@ -159,12 +159,12 @@
                 <Pin Id="ROPUZ81gtGJMKK76Aajtl2" Name="Index" Kind="InputPin" />
                 <Pin Id="MeLhn7UZwVWN1Udhcr8N4n" Name="Output" Kind="StateOutputPin" />
               </Node>
-              <ControlPoint Id="OueEDgAUE6ING8kNRPvDxt" Bounds="700,347" />
-              <Pad Id="HAsLTaoSrLCLh1uGyHCIAv" SlotId="TDNm6sN5QMXM9rMYJ3igvi" Bounds="905,307" />
-              <ControlPoint Id="BWX3u8A2F7TPDHniQWIiZj" Bounds="905,252" />
-              <ControlPoint Id="LQz1AXSS0mMMgaxXQzdZ2z" Bounds="905,353" />
-              <Pad Id="SmpCnSNQ4TFOf6TInUEwEf" SlotId="G11KrVKiywxMeTKlcYObeJ" Bounds="881,431" />
-              <Node Bounds="879,452,35,19" Id="R98PaFwZxD4PPcSEauVM41">
+              <ControlPoint Id="OueEDgAUE6ING8kNRPvDxt" Bounds="1515,335" />
+              <Pad Id="HAsLTaoSrLCLh1uGyHCIAv" SlotId="TDNm6sN5QMXM9rMYJ3igvi" Bounds="1278,303" />
+              <ControlPoint Id="BWX3u8A2F7TPDHniQWIiZj" Bounds="1278,248" />
+              <ControlPoint Id="LQz1AXSS0mMMgaxXQzdZ2z" Bounds="1278,349" />
+              <Pad Id="SmpCnSNQ4TFOf6TInUEwEf" SlotId="G11KrVKiywxMeTKlcYObeJ" Bounds="926,413" />
+              <Node Bounds="924,434,41,26" Id="R98PaFwZxD4PPcSEauVM41">
                 <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -174,12 +174,12 @@
                 <Pin Id="SwhARsZxGzOOYV5UqkPsIi" Name="Item" Kind="InputPin" />
                 <Pin Id="MPe2aLTXK39ME2FNf5PhoA" Name="Output" Kind="StateOutputPin" />
               </Node>
-              <ControlPoint Id="AVMTWz9yThaM1M034xxrhL" Bounds="911,433" />
-              <Pad Id="OtVBrkKh4IjOo0GPE2d7Dq" SlotId="G11KrVKiywxMeTKlcYObeJ" Bounds="881,495" />
-              <Pad Id="EpVz4xI8KRGOYou143XnTI" SlotId="G11KrVKiywxMeTKlcYObeJ" Bounds="893,572" />
-              <Pad Id="CoZtBQIlyN8MJ536t9lP1d" SlotId="G11KrVKiywxMeTKlcYObeJ" Bounds="893,636" />
-              <ControlPoint Id="CcE3y5D9R1JNeoTL11fGQP" Bounds="970,573" />
-              <Node Bounds="891,596,82,19" Id="LqWoNcw9aY3QcZpWo4xrVx">
+              <ControlPoint Id="AVMTWz9yThaM1M034xxrhL" Bounds="962,414" />
+              <Pad Id="OtVBrkKh4IjOo0GPE2d7Dq" SlotId="G11KrVKiywxMeTKlcYObeJ" Bounds="926,477" />
+              <Pad Id="EpVz4xI8KRGOYou143XnTI" SlotId="G11KrVKiywxMeTKlcYObeJ" Bounds="938,554" />
+              <Pad Id="CoZtBQIlyN8MJ536t9lP1d" SlotId="G11KrVKiywxMeTKlcYObeJ" Bounds="938,618" />
+              <ControlPoint Id="CcE3y5D9R1JNeoTL11fGQP" Bounds="1015,555" />
+              <Node Bounds="936,578,82,26" Id="LqWoNcw9aY3QcZpWo4xrVx">
                 <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Spread" />
@@ -189,9 +189,9 @@
                 <Pin Id="BCVuDNSAqihLscjahHhaJV" Name="Index" Kind="InputPin" />
                 <Pin Id="JJcJm04OGTELdGLG55iW2I" Name="Output" Kind="StateOutputPin" />
               </Node>
-              <Pad Id="VjsXHCQLECQNHOiiJTvnfu" SlotId="G11KrVKiywxMeTKlcYObeJ" Bounds="1114,472" />
-              <ControlPoint Id="DDXcQ2vAcXSNd7mBxTZ51O" Bounds="1114,416" />
-              <ControlPoint Id="Mxk9hePjq0pP8iFVPSK9x0" Bounds="1114,515" />
+              <Pad Id="VjsXHCQLECQNHOiiJTvnfu" SlotId="G11KrVKiywxMeTKlcYObeJ" Bounds="921,307" />
+              <ControlPoint Id="DDXcQ2vAcXSNd7mBxTZ51O" Bounds="921,251" />
+              <ControlPoint Id="Mxk9hePjq0pP8iFVPSK9x0" Bounds="921,350" />
             </Canvas>
             <ProcessDefinition Id="G4xHqW3NVjyNxtTCXbGGoC" IsHidden="true">
               <Fragment Id="BJkWqwEYSUnMrj29lfd2wh" Patch="MJW81wKDFnBLugU5wC3c3k" Enabled="true" />
@@ -216,7 +216,15 @@
                 <Choice Kind="TypeFlag" Name="Spread" />
                 <p:TypeArguments>
                   <TypeReference>
-                    <Choice Kind="TypeFlag" Name="String" />
+                    <Choice Kind="TypeFlag" Name="Tuple (2 Items)" />
+                    <p:TypeArguments>
+                      <TypeReference>
+                        <Choice Kind="TypeFlag" Name="Boolean" />
+                      </TypeReference>
+                      <TypeReference>
+                        <Choice Kind="TypeFlag" Name="String" />
+                      </TypeReference>
+                    </p:TypeArguments>
                   </TypeReference>
                 </p:TypeArguments>
               </p:TypeAnnotation>
@@ -269,18 +277,59 @@
             </Slot>
             <Link Id="T3SSErHAOpMOrPqPgbAz1w" Ids="BWX3u8A2F7TPDHniQWIiZj,HAsLTaoSrLCLh1uGyHCIAv" />
             <Link Id="ShfpFSKbr29MM0wW2GEoVR" Ids="U8nq5YPIId2Oa6qLmny0UL,BWX3u8A2F7TPDHniQWIiZj" IsHidden="true" />
+            <Link Id="R6eyjv1xsYhOYm1UjnZNUq" Ids="HAsLTaoSrLCLh1uGyHCIAv,LQz1AXSS0mMMgaxXQzdZ2z" />
+            <Link Id="Ks6IqLtLG4KQCnilHp7G54" Ids="LQz1AXSS0mMMgaxXQzdZ2z,CzdJzktxue9O619p6gZmTH" IsHidden="true" />
+            <Link Id="IQpt3vGnfRgPv41K16LwJd" Ids="SmpCnSNQ4TFOf6TInUEwEf,IWBoZt6ZP8QObtTbsefLNB" />
+            <Link Id="P8OxL5R9DD5LJkl0jbyXSf" Ids="AVMTWz9yThaM1M034xxrhL,SwhARsZxGzOOYV5UqkPsIi" />
+            <Link Id="O2JwG2QGEXcNWE5i5CvLnK" Ids="MPe2aLTXK39ME2FNf5PhoA,OtVBrkKh4IjOo0GPE2d7Dq" />
+            <Link Id="GNzUQQBh0ORNgBkVcwe36I" Ids="EpVz4xI8KRGOYou143XnTI,UBjHuAr0It1QAk4mumOpxV" />
+            <Link Id="She94PNwAeaQdkqfbwgbJa" Ids="CcE3y5D9R1JNeoTL11fGQP,BCVuDNSAqihLscjahHhaJV" />
+            <Link Id="DUR1PeaegbVLHuthZyAEmO" Ids="JJcJm04OGTELdGLG55iW2I,CoZtBQIlyN8MJ536t9lP1d" />
+            <Slot Id="G11KrVKiywxMeTKlcYObeJ" Name="Editable Packages">
+              <p:TypeAnnotation p:Type="TypeReference">
+                <Choice Kind="TypeFlag" Name="Spread" />
+                <p:TypeArguments>
+                  <TypeReference>
+                    <Choice Kind="TypeFlag" Name="Tuple (2 Items)" />
+                    <p:TypeArguments>
+                      <TypeReference>
+                        <Choice Kind="TypeFlag" Name="Boolean" />
+                      </TypeReference>
+                      <TypeReference>
+                        <Choice Kind="TypeFlag" Name="String" />
+                      </TypeReference>
+                    </p:TypeArguments>
+                  </TypeReference>
+                </p:TypeArguments>
+              </p:TypeAnnotation>
+            </Slot>
+            <Link Id="PlWlf7yMSeVQbLUcDcaZIy" Ids="VpJsfJvpIcVNxXgCj79j8b,AVMTWz9yThaM1M034xxrhL" IsHidden="true" />
+            <Link Id="EjnAhdSdORSLuspCa4gN6f" Ids="FYwyQBFKdpHOMD0zBqNKTN,CcE3y5D9R1JNeoTL11fGQP" IsHidden="true" />
+            <Link Id="CRtfyRkDmCmLmXkCrD4HGR" Ids="DDXcQ2vAcXSNd7mBxTZ51O,VjsXHCQLECQNHOiiJTvnfu" />
+            <Link Id="JjWKmT9zHoiOnmqwb0Jd8p" Ids="VjsXHCQLECQNHOiiJTvnfu,Mxk9hePjq0pP8iFVPSK9x0" />
+            <Link Id="NqdVPreB4PGQQS10HeGSey" Ids="NaLDeW3Sxu6PfQfpyfaEhr,DDXcQ2vAcXSNd7mBxTZ51O" IsHidden="true" />
+            <Link Id="HYAZ34eduuzPKOw0C8GCVX" Ids="Mxk9hePjq0pP8iFVPSK9x0,FxgrN6PK5mUQaX4iHAUudI" IsHidden="true" />
             <Patch Id="MJW81wKDFnBLugU5wC3c3k" Name="Create" ParticipatingElements="UhJiCcvG6O2Oyx4ssLT9E4,EJeLZEPm7NvNMfUvxXZguz,F6PV7SW0pYaMW4gVUoLqwS">
               <Pin Id="OMwc1xD5ZN7MMS4NBSHurz" Name="VVVV Installations Folder" Kind="InputPin" Bounds="96,337" DefaultValue="C:\Program Files\vvvv">
                 <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
+              <Pin Id="EniMXuhDBVyNkyQpwQ7Og7" Name="Window Bounds" Kind="InputPin" />
               <Pin Id="F8VkLHDE4WqPke7F3CWkrL" Name="Package Repositories Folder" Kind="InputPin" Bounds="417,328">
                 <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
-                      <Choice Kind="TypeFlag" Name="String" />
+                      <Choice Kind="TypeFlag" Name="Tuple (2 Items)" />
+                      <p:TypeArguments>
+                        <TypeReference>
+                          <Choice Kind="TypeFlag" Name="Boolean" />
+                        </TypeReference>
+                        <TypeReference>
+                          <Choice Kind="TypeFlag" Name="String" />
+                        </TypeReference>
+                      </p:TypeArguments>
                     </TypeReference>
                   </p:TypeArguments>
                 </p:TypeAnnotation>
@@ -288,10 +337,9 @@
                   <Item>D:\Documents\dev\vvvv\libraries</Item>
                 </p:DefaultValue>
               </Pin>
-              <Pin Id="KVOVxZ55KXjQIyV7sTP8i5" Name="Nugets Override Folder" Kind="InputPin" />
-              <Pin Id="U8nq5YPIId2Oa6qLmny0UL" Name="Extra Args" Kind="InputPin" />
-              <Pin Id="EniMXuhDBVyNkyQpwQ7Og7" Name="Window Bounds" Kind="InputPin" />
               <Pin Id="NaLDeW3Sxu6PfQfpyfaEhr" Name="Editable Packages" Kind="InputPin" />
+              <Pin Id="U8nq5YPIId2Oa6qLmny0UL" Name="Extra Args" Kind="InputPin" />
+              <Pin Id="KVOVxZ55KXjQIyV7sTP8i5" Name="Nugets Override Folder" Kind="InputPin" />
             </Patch>
             <Patch Id="BAgRgjwYUOwL9IDiXRtYVw" Name="GetWindowBounds" ParticipatingElements="Hvb23lWxHdyNvcTp6ttOq1">
               <Pin Id="JlQ9mQ43PiDNcIVQ74jJdh" Name="Window Bounds" Kind="OutputPin" />
@@ -311,39 +359,15 @@
             <Patch Id="Nd24UdHf7a5MVqlS7IGfza" Name="GetNugetOverrideFolder" ParticipatingElements="DYHcmEuRLkHNg84tEsnAzG">
               <Pin Id="VoVmfPitlljMYx9inb6N1t" Name="Nugets Override Folder" Kind="OutputPin" />
             </Patch>
-            <Link Id="R6eyjv1xsYhOYm1UjnZNUq" Ids="HAsLTaoSrLCLh1uGyHCIAv,LQz1AXSS0mMMgaxXQzdZ2z" />
-            <Link Id="Ks6IqLtLG4KQCnilHp7G54" Ids="LQz1AXSS0mMMgaxXQzdZ2z,CzdJzktxue9O619p6gZmTH" IsHidden="true" />
             <Patch Id="NOL05Ga6OPfNww2XHtylke" Name="GetExtraArgs" ParticipatingElements="R6eyjv1xsYhOYm1UjnZNUq">
               <Pin Id="CzdJzktxue9O619p6gZmTH" Name="Extra Args" Kind="OutputPin" />
             </Patch>
-            <Link Id="IQpt3vGnfRgPv41K16LwJd" Ids="SmpCnSNQ4TFOf6TInUEwEf,IWBoZt6ZP8QObtTbsefLNB" />
-            <Link Id="P8OxL5R9DD5LJkl0jbyXSf" Ids="AVMTWz9yThaM1M034xxrhL,SwhARsZxGzOOYV5UqkPsIi" />
-            <Link Id="O2JwG2QGEXcNWE5i5CvLnK" Ids="MPe2aLTXK39ME2FNf5PhoA,OtVBrkKh4IjOo0GPE2d7Dq" />
-            <Link Id="GNzUQQBh0ORNgBkVcwe36I" Ids="EpVz4xI8KRGOYou143XnTI,UBjHuAr0It1QAk4mumOpxV" />
-            <Link Id="She94PNwAeaQdkqfbwgbJa" Ids="CcE3y5D9R1JNeoTL11fGQP,BCVuDNSAqihLscjahHhaJV" />
-            <Link Id="DUR1PeaegbVLHuthZyAEmO" Ids="JJcJm04OGTELdGLG55iW2I,CoZtBQIlyN8MJ536t9lP1d" />
-            <Slot Id="G11KrVKiywxMeTKlcYObeJ" Name="Editable Packages">
-              <p:TypeAnnotation p:Type="TypeReference">
-                <Choice Kind="TypeFlag" Name="Spread" />
-                <p:TypeArguments>
-                  <TypeReference>
-                    <Choice Kind="TypeFlag" Name="String" />
-                  </TypeReference>
-                </p:TypeArguments>
-              </p:TypeAnnotation>
-            </Slot>
             <Patch Id="JFJ15VANlEGQY73cwsUWEx" Name="AddEditablePackage">
               <Pin Id="VpJsfJvpIcVNxXgCj79j8b" Name="Item" Kind="InputPin" />
             </Patch>
-            <Link Id="PlWlf7yMSeVQbLUcDcaZIy" Ids="VpJsfJvpIcVNxXgCj79j8b,AVMTWz9yThaM1M034xxrhL" IsHidden="true" />
             <Patch Id="AczlG45FuhiOxtb8sZU7B4" Name="RemoveEditablePackage">
               <Pin Id="FYwyQBFKdpHOMD0zBqNKTN" Name="Index" Kind="InputPin" />
             </Patch>
-            <Link Id="EjnAhdSdORSLuspCa4gN6f" Ids="FYwyQBFKdpHOMD0zBqNKTN,CcE3y5D9R1JNeoTL11fGQP" IsHidden="true" />
-            <Link Id="CRtfyRkDmCmLmXkCrD4HGR" Ids="DDXcQ2vAcXSNd7mBxTZ51O,VjsXHCQLECQNHOiiJTvnfu" />
-            <Link Id="JjWKmT9zHoiOnmqwb0Jd8p" Ids="VjsXHCQLECQNHOiiJTvnfu,Mxk9hePjq0pP8iFVPSK9x0" />
-            <Link Id="NqdVPreB4PGQQS10HeGSey" Ids="NaLDeW3Sxu6PfQfpyfaEhr,DDXcQ2vAcXSNd7mBxTZ51O" IsHidden="true" />
-            <Link Id="HYAZ34eduuzPKOw0C8GCVX" Ids="Mxk9hePjq0pP8iFVPSK9x0,FxgrN6PK5mUQaX4iHAUudI" IsHidden="true" />
             <Patch Id="Fg8k1URfN6yQAg3nLTOPQ5" Name="GetEditablePackages">
               <Pin Id="FxgrN6PK5mUQaX4iHAUudI" Name="Editable Packages" Kind="OutputPin" />
             </Patch>
@@ -780,7 +804,7 @@
                 <Pin Id="D3a2P2XAMCoOHNSiOky6Q3" Name="Path" Kind="InputPin" DefaultValue="Settings Model" />
                 <Pin Id="RiNl5UiFmKFOEhLKBWO17d" Name="Output" Kind="OutputPin" />
               </Node>
-              <Node Bounds="277,731,41,19" Id="A5cRraBq1XjNHJGxtKn0IN">
+              <Node Bounds="277,731,45,26" Id="A5cRraBq1XjNHJGxtKn0IN">
                 <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -875,7 +899,7 @@
               <Overlay Id="Ka9EJQtE6iuLav0iXGSYfz" Name="Kill vvvv" Bounds="516,413,238,160">
                 <p:ColorIndex p:Type="Int32">11</p:ColorIndex>
               </Overlay>
-              <Node Bounds="793,721,41,19" Id="RfIjPh87mLDPR101kb3WlO">
+              <Node Bounds="793,721,45,26" Id="RfIjPh87mLDPR101kb3WlO">
                 <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -979,7 +1003,7 @@
                   </Node>
                 </Patch>
               </Node>
-              <Node Bounds="817,798,75,130" Id="VtGyt88yU6DLneUawUyF07">
+              <Node Bounds="817,798,75,136" Id="VtGyt88yU6DLneUawUyF07">
                 <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
@@ -987,12 +1011,12 @@
                 </p:NodeReference>
                 <Pin Id="UVXrkBaz3UnPtSsnZXG7fv" Name="Break" Kind="OutputPin" />
                 <ControlPoint Id="BflrzoV52bbNyaG58xCUEi" Bounds="831,804" Alignment="Top" />
-                <ControlPoint Id="Scc1ZMbXQsoNffjFvToVrr" Bounds="831,922" Alignment="Bottom" />
+                <ControlPoint Id="Scc1ZMbXQsoNffjFvToVrr" Bounds="831,928" Alignment="Bottom" />
                 <Patch Id="I0a72v0d69nNqhCrKMcob0" ManuallySortedPins="true">
                   <Patch Id="Ulvz3qo388ANFcKJQqJgei" Name="Create" ManuallySortedPins="true" />
                   <Patch Id="Gk941cSYIxsNmp4bnurOzm" Name="Update" ManuallySortedPins="true" />
                   <Patch Id="MjtFAI3VmBjOsyjXDH1O3h" Name="Dispose" ManuallySortedPins="true" />
-                  <Node Bounds="829,888,43,19" Id="G65jZxa2ZV6NuX3f6j09nV">
+                  <Node Bounds="829,888,43,26" Id="G65jZxa2ZV6NuX3f6j09nV">
                     <p:NodeReference LastCategoryFullName="IO.Path" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="Exists" />
@@ -1011,7 +1035,7 @@
                     <Pin Id="A936IqsIFYfPHRIQKQTqll" Name="Input" Kind="InputPin" />
                     <Pin Id="KRTSUBh222gNslLh4EbLzA" Name="Result" Kind="OutputPin" />
                   </Node>
-                  <Node Bounds="829,825,51,19" Id="IkIGj6HxciyN84ONSxEy3Z">
+                  <Node Bounds="829,825,51,26" Id="IkIGj6HxciyN84ONSxEy3Z">
                     <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="Replace" />
@@ -1024,7 +1048,7 @@
                   </Node>
                 </Patch>
               </Node>
-              <Node Bounds="966,951,37,19" Id="CR2bDvFZYcxOo7vChSOoMD">
+              <Node Bounds="966,951,50,26" Id="CR2bDvFZYcxOo7vChSOoMD">
                 <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="AND (Spectral)" />
@@ -1069,7 +1093,7 @@
                 <Pin Id="IVfknzwjW0QPIOWB0Za90d" Name="Input" Kind="StateInputPin" />
                 <Pin Id="LQXvfFn81FINud6YoQGTj3" Name="Selected Vvvv Version" Kind="OutputPin" />
               </Node>
-              <Node Bounds="807,1293,41,19" Id="I0DLMLRLL2pLtnn5tPwSfx">
+              <Node Bounds="807,1293,45,26" Id="I0DLMLRLL2pLtnn5tPwSfx">
                 <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -1083,7 +1107,7 @@
               <Overlay Id="JkNaiqe0FoDNVvsMTAndc6" Name="Show installed nugets" Bounds="642,1210,589,612">
                 <p:ColorIndex p:Type="Int32">11</p:ColorIndex>
               </Overlay>
-              <Node Bounds="1490,1007,41,19" Id="BRnbF5mruUKMJRTj70Ty9O">
+              <Node Bounds="1490,1007,45,26" Id="BRnbF5mruUKMJRTj70Ty9O">
                 <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -1269,7 +1293,7 @@
                   <CategoryReference Kind="Category" Name="Primitive" />
                 </p:TypeAnnotation>
               </Pad>
-              <Node Bounds="450,812,46,19" Id="BQnqh3N5F9IPXKQvQwOoKw">
+              <Node Bounds="450,812,66,26" Id="BQnqh3N5F9IPXKQvQwOoKw">
                 <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="SpreadBuilder" />
@@ -1370,7 +1394,7 @@
               <Overlay Id="OL5HBKjWDqJO3rkUrSuJqj" Name="Start new instance with patch and current args" Bounds="1225,413,457,434">
                 <p:ColorIndex p:Type="Int32">11</p:ColorIndex>
               </Overlay>
-              <Node Bounds="1422,653,56,19" Id="L2Upo4zsJorMKCojBLXgGe">
+              <Node Bounds="1422,653,56,26" Id="L2Upo4zsJorMKCojBLXgGe">
                 <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Contains" />
@@ -1431,7 +1455,7 @@
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pad>
-              <Node Bounds="1488,1581,55,19" Id="M8fuXDfBFMIMo9nMQigzOk">
+              <Node Bounds="1488,1581,55,26" Id="M8fuXDfBFMIMo9nMQigzOk">
                 <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Channel" />
@@ -1662,7 +1686,7 @@
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pad>
-              <Node Bounds="1485,1821,55,19" Id="KDlLilTikyjO0dtna1ylKY">
+              <Node Bounds="1485,1821,55,26" Id="KDlLilTikyjO0dtna1ylKY">
                 <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Channel" />
@@ -6680,13 +6704,13 @@
                                 <Link Id="Ur94FfDxxvhMfm0G20uL51" Ids="UPUBLlvNWobQAmPQpgXOjB,A2EB6J42lUxLZVL3K7pUMa" />
                                 <Link Id="JbxCgQoh9keL3T6Q4r8hgv" Ids="Ga8Md74dZm5MGNVuNmFl3V,GX84aJBf5tHOnrDWp03D46" />
                                 <Link Id="HFDJSVTrKDvOvxmclCsvkk" Ids="OwzUtp9BnHYPETHeQfRVBP,OMu2qt2ux0gPEVEjEPV2Fj" />
-                                <Link Id="Gj531Wi9MUOLYVk2gOT5Gj" Ids="L4SkuufLtFJOwO5mvvGFkG,A2lptISiR2gOy4alVk4E7Z" />
                                 <Link Id="BdyMdaWdxAOLxITZ83bzKW" Ids="NJVd60Gfe5WPD07t4m7DpN,QFgVxNQOo1nOL4GLKE9K5j" />
                                 <Link Id="CU5Tm13YgHELtXiJ8xnXEU" Ids="PolUKEGAtqMMxEguKiOdAc,Por9hgUnYNANIOWvelVlcU" />
                                 <Link Id="GoiF4MPPhqaMzloPkq6Izo" Ids="Por9hgUnYNANIOWvelVlcU,KK2lbZonGcAN38jyKjij6J" />
                                 <Link Id="INErfXNb3lcLGTC0TjhVNm" Ids="SYDFhV7EwLqNZftUQ3KAkd,UD7MTEsn0TWOY82GWcQuCt" />
                                 <Link Id="Bt6eF0NSrKyPOHf1qcstDZ" Ids="LfByQmTkoeXOkfrUPr9tnx,D8Lhlt0VTyhPefT5lzAGV2" IsHidden="true" />
                                 <Link Id="Ol9zx5RbAB0L3CUFZKzp9G" Ids="D8Lhlt0VTyhPefT5lzAGV2,I8ApKKIfWK0P6bcstfdajz" />
+                                <Link Id="RBihG74Z5AKNgKEQ2mE7zd" Ids="L4SkuufLtFJOwO5mvvGFkG,A2lptISiR2gOy4alVk4E7Z" />
                               </Patch>
                             </Node>
                             <!--
@@ -6967,11 +6991,6 @@
                                     <Pin Id="FfTiRsAbnTtLQm62Qf3HP7" Name="Running" Kind="OutputPin" />
                                   </Node>
                                 </Canvas>
-                                <!--
-
-    ************************  ************************
-
--->
                                 <ProcessDefinition Id="DafkhEPHTCCMqIfKwC2MGR">
                                   <Fragment Id="EUYteL2dV9VPTLOk6fvoUj" Patch="SG2sI2EzgswMnBU9QBIP1A" Enabled="true" />
                                   <Fragment Id="KqhIQPE0dptMhGvwHGsMdr" Patch="SqUKJfOKIZsOG7c3kYdpfP" Enabled="true" />
@@ -9937,11 +9956,11 @@
                         <Choice Kind="OperationCallFlag" Name="Create" />
                       </p:NodeReference>
                       <Pin Id="J01EAoIEdzhOLinDbKk0yG" Name="VVVV Installations Folder" Kind="InputPin" />
-                      <Pin Id="Q7DuzN5KnNgPJtMaZtN7UH" Name="Package Repositories Folder" Kind="InputPin" />
-                      <Pin Id="B8Kn0mE6c4WQJuunCJ43Xs" Name="Nugets Override Folder" Kind="InputPin" />
-                      <Pin Id="UVNLHyC4j3MO4OijfoHGO1" Name="Extra Args" Kind="InputPin" />
                       <Pin Id="CEgOl7NIhy7NFvWlmY8iaQ" Name="Window Bounds" Kind="InputPin" />
+                      <Pin Id="Q7DuzN5KnNgPJtMaZtN7UH" Name="Package Repositories Folder" Kind="InputPin" />
                       <Pin Id="P9rsLtz5BXwLWFzKZYxGaR" Name="Editable Packages" Kind="InputPin" />
+                      <Pin Id="UVNLHyC4j3MO4OijfoHGO1" Name="Extra Args" Kind="InputPin" />
+                      <Pin Id="B8Kn0mE6c4WQJuunCJ43Xs" Name="Nugets Override Folder" Kind="InputPin" />
                       <Pin Id="VEJNCLkN7DjNVh8vjVPcOe" Name="Output" Kind="StateOutputPin" />
                     </Node>
                     <Node Bounds="418,533,61,19" Id="NqY974wCcbkQFrwAVec8m5">
@@ -13793,8 +13812,8 @@
             </p:NodeReference>
             <Patch Id="F8FOUG9PfyYLjYoR39TbLf">
               <Canvas Id="IaZqPHo725eNe1eNlT24Pv" CanvasType="Group">
-                <ControlPoint Id="KkIqu2wPNgILFHoDDBiJq3" Bounds="584,322" />
-                <Node Bounds="663,666,45,19" Id="SuipNxcVURaLUHZcsaf1I1">
+                <ControlPoint Id="KkIqu2wPNgILFHoDDBiJq3" Bounds="578,323" />
+                <Node Bounds="663,666,45,26" Id="SuipNxcVURaLUHZcsaf1I1">
                   <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -13824,7 +13843,7 @@
                   <Pin Id="Ly9K53MvMvSMBxb2Q7CKfv" Name="Input 4" Kind="InputPin" />
                   <Pin Id="UcCN8M8e2jqLWYzar3LFJR" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="795,666,45,19" Id="ANPRCkmQFsxNN4imK32opl">
+                <Node Bounds="795,666,45,26" Id="ANPRCkmQFsxNN4imK32opl">
                   <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -13848,7 +13867,7 @@
                   <Pin Id="K4RDk29Mr7nQAHv8FqlnfF" Name="Input 4" Kind="InputPin" />
                   <Pin Id="TwzUgKeKl3OPsxP4HnY6RO" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="930,666,45,19" Id="TO1nVp7Fen3QXJLtb3lSOZ">
+                <Node Bounds="930,666,45,26" Id="TO1nVp7Fen3QXJLtb3lSOZ">
                   <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -13859,7 +13878,7 @@
                   <Pin Id="Mhwd3wG4EeULqQDZ6uwrbP" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="DXefah4JJZFLVaodjyT9Zc" Name="Apply" Kind="InputPin" />
                 </Node>
-                <Node Bounds="1065,666,45,19" Id="EJDTSChJuY1LMA364DtCnl">
+                <Node Bounds="1065,666,45,26" Id="EJDTSChJuY1LMA364DtCnl">
                   <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -13876,7 +13895,7 @@
                     <CategoryReference Kind="Category" Name="Primitive" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Node Bounds="1183,666,45,19" Id="HEo5RCzgq5cL1FA9HMWnI5">
+                <Node Bounds="1183,666,45,26" Id="HEo5RCzgq5cL1FA9HMWnI5">
                   <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -13893,7 +13912,7 @@
                     <CategoryReference Kind="Category" Name="Primitive" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Node Bounds="1322,666,45,19" Id="HxNl7bfzyBOOsY1nNhJOqp">
+                <Node Bounds="1322,666,45,26" Id="HxNl7bfzyBOOsY1nNhJOqp">
                   <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -13904,13 +13923,13 @@
                   <Pin Id="F2fcCeAYecOOcmMoMoLCm2" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="L80KR5IT7FkOL45CGvt5uO" Name="Apply" Kind="InputPin" />
                 </Node>
-                <Pad Id="AT2iE6IV882OFzbg3I1Yyu" Comment="" Bounds="1344,626,142,-30" ShowValueBox="true" isIOBox="true" Value="--disable-package-compiler">
+                <Pad Id="AT2iE6IV882OFzbg3I1Yyu" Comment="" Bounds="1344,626,142,15" ShowValueBox="true" isIOBox="true" Value="--disable-package-compiler">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="ImmutableTypeFlag" Name="String" />
                     <CategoryReference Kind="Category" Name="Primitive" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Node Bounds="1489,666,45,19" Id="QRmHdl3HlaRMl5lEloZWh2">
+                <Node Bounds="1489,666,45,26" Id="QRmHdl3HlaRMl5lEloZWh2">
                   <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -13921,7 +13940,7 @@
                   <Pin Id="TSA3SXuRBscLnQvOp1JJxI" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="CABZSCXIn0qNpXtAGhhF8s" Name="Apply" Kind="InputPin" />
                 </Node>
-                <Node Bounds="1784,665,45,19" Id="P1Gc6x8PMaqNLrBCkSmHDB">
+                <Node Bounds="1784,665,45,26" Id="P1Gc6x8PMaqNLrBCkSmHDB">
                   <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -13938,7 +13957,7 @@
                     <CategoryReference Kind="Category" Name="Primitive" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Node Bounds="1909,665,45,19" Id="JSmpoXs1VuWLgzIjN40yxS">
+                <Node Bounds="1909,665,45,26" Id="JSmpoXs1VuWLgzIjN40yxS">
                   <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -14052,8 +14071,8 @@
                   <Pin Id="IAHnOHnXlcRPGMvoxKcOTH" Name="Input" Kind="StateInputPin" />
                   <Pin Id="US41eH5ohyxNOjRUKPAAkp" Name="Debug" Kind="OutputPin" />
                 </Node>
-                <ControlPoint Id="TUFharbLNMxPY6z8M33cdE" Bounds="516,718" />
-                <Node Bounds="582,351,41,19" Id="EdMoUj2LmZBMOquqNzo16H">
+                <ControlPoint Id="TUFharbLNMxPY6z8M33cdE" Bounds="460,808" />
+                <Node Bounds="576,352,45,26" Id="EdMoUj2LmZBMOquqNzo16H">
                   <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -14064,8 +14083,8 @@
                   <Pin Id="DEHzRw0W2loPMSHD3HkS0R" Name="Value" Kind="OutputPin" />
                 </Node>
                 <ControlPoint Id="Lu0h8nMv6rPPJHiBRjr63g" Bounds="480,527" />
-                <ControlPoint Id="TA4Ob0e0RrePE1XxShVdKS" Bounds="791,321" />
-                <Node Bounds="789,341,41,19" Id="FFYxxx1RLHHOokBQeJgrYc">
+                <ControlPoint Id="TA4Ob0e0RrePE1XxShVdKS" Bounds="786,319" />
+                <Node Bounds="784,339,45,26" Id="FFYxxx1RLHHOokBQeJgrYc">
                   <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -14110,7 +14129,7 @@
                   <Pin Id="HkkhQvcUVRRLKehDGgfk6q" Name="Input" Kind="StateInputPin" />
                   <Pin Id="T4y8rzvaDf3QTRDw5yBIZ4" Name="Extra Args" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="2052,664,45,19" Id="Hh6KA0Ynj9xQLyneqw7mA7">
+                <Node Bounds="2052,664,45,26" Id="Hh6KA0Ynj9xQLyneqw7mA7">
                   <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -14148,7 +14167,7 @@
                   <Pin Id="S1C9ipbMtOCPPrZHmuGHaF" Name="Launch Tab Model Channel" Kind="InputPin" />
                   <Pin Id="To1YslLqN28NdVkBEu9e1y" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="514,676,85,19" Id="C3fI1hBasE8LpXM4Grbovz">
+                <Node Bounds="458,766,85,19" Id="C3fI1hBasE8LpXM4Grbovz">
                   <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
@@ -14161,7 +14180,7 @@
                   <Pin Id="Jr0JYY1NUfILXLGOnH6dkz" Name="Input 4" Kind="InputPin" />
                   <Pin Id="EDHhsn2GdtgNO7q3vQOm95" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="1508,570,85,19" Id="UDVMgXlulLDMSwjL2WTcut">
+                <Node Bounds="1508,600,85,19" Id="UDVMgXlulLDMSwjL2WTcut">
                   <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
@@ -14174,7 +14193,7 @@
                   <Pin Id="E5ezwuXRIrTMCxjM0m6K0C" Name="Input 4" Kind="InputPin" />
                   <Pin Id="A5hi3ti63g8O3WPKl7SfCN" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="1557,452,153,26" Id="LKxnBpcXrcsNobPtsqVmm9">
+                <Node Bounds="1557,431,153,26" Id="LKxnBpcXrcsNobPtsqVmm9">
                   <p:NodeReference LastCategoryFullName="Main.Model.SettingsTabModel" LastDependency="GammaLauncher.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="RecordType" Name="SettingsTabModel" />
@@ -14183,7 +14202,7 @@
                   <Pin Id="DQDlTA2N3ycPDXuEudw93S" Name="Input" Kind="StateInputPin" />
                   <Pin Id="J3ZEk4IYnxJLftpAqbSPbh" Name="Editable Packages" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1528,536,34,19" Id="Sj8UebXNkKpOFukEW8NoBE">
+                <Node Bounds="1528,566,34,19" Id="Sj8UebXNkKpOFukEW8NoBE">
                   <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Join" />
@@ -14194,7 +14213,7 @@
                   <Pin Id="HKTDJuUqpwVNjgcGg8Qw7K" Name="Output" Kind="StateOutputPin" />
                 </Node>
                 <ControlPoint Id="BvGvWdppsIFPUjMZ4kmapB" Bounds="1560,378" />
-                <Node Bounds="1611,536,34,19" Id="MW7I0r7kzeHQBei1LvJPQP">
+                <Node Bounds="1611,566,34,19" Id="MW7I0r7kzeHQBei1LvJPQP">
                   <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="MutableInterfaceType" Name="Sequence" NeedsToBeDirectParent="true" />
@@ -14203,7 +14222,7 @@
                   <Pin Id="ABlfTaTMTI5NoaDg5PJVCb" Name="Input" Kind="StateInputPin" />
                   <Pin Id="D3HfeshM1FMPV6YNKAqe4t" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1611,570,57,19" Id="VcfgeM6sJDvQIkJ5gXLLAr">
+                <Node Bounds="1611,600,57,19" Id="VcfgeM6sJDvQIkJ5gXLLAr">
                   <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="ANDNOT" />
@@ -14212,18 +14231,17 @@
                   <Pin Id="RLwIQzr3z5OPwPV97ovy1o" Name="Input 2" Kind="InputPin" />
                   <Pin Id="VvsqS35EtnVMoaBlaeq7VD" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Pad Id="OZDs3H4fCgRNBrMfhTiKYO" Comment="" Bounds="1118,947,339,77" ShowValueBox="true" isIOBox="true" />
                 <!--
 
     ************************ RemoveEmptyLines ************************
 
 -->
-                <Node Name="RemoveEmptyLines" Bounds="528,898,186,207" Id="PJYiVdN2PNtMCUVGYyzU7I">
+                <Node Name="RemoveEmptyLines" Bounds="528,1019,186,207" Id="PJYiVdN2PNtMCUVGYyzU7I">
                   <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                     <Choice Kind="OperationDefinition" Name="Operation" />
                   </p:NodeReference>
                   <Patch Id="M0T2mpsIwfrP9CKPkDRC0W">
-                    <Node Bounds="572,946,130,112" Id="TWUT8ujYm78Qbt92oyvKp4">
+                    <Node Bounds="572,1067,130,112" Id="TWUT8ujYm78Qbt92oyvKp4">
                       <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
                         <CategoryReference Kind="MutableInterfaceType" Name="Sequence" NeedsToBeDirectParent="true" />
@@ -14235,10 +14253,10 @@
                         <Pin Id="UznGlPLRLGaQKp107Qqn9V" Name="Input 1" Kind="InputPin" />
                         <Pin Id="MJzfLFGZiOcPNmJxYcxuv7" Name="Input 2" Kind="InputPin" />
                         <Pin Id="KEHlg6jHW0YPRHE38sdTV0" Name="Result" Kind="OutputPin" />
-                        <ControlPoint Id="IhtjJABHWmrMN5CWKtwUDP" Bounds="586,954" />
-                        <ControlPoint Id="VPrCVxCjaXhOsMWaSLOBWP" Bounds="646,954" />
-                        <ControlPoint Id="EluGEGuABI1MYZhmHiwFUQ" Bounds="586,1051" />
-                        <Node Bounds="584,982,104,19" Id="T91hS8rqaIUNixlH1BGN3S">
+                        <ControlPoint Id="IhtjJABHWmrMN5CWKtwUDP" Bounds="586,1075" />
+                        <ControlPoint Id="VPrCVxCjaXhOsMWaSLOBWP" Bounds="646,1075" />
+                        <ControlPoint Id="EluGEGuABI1MYZhmHiwFUQ" Bounds="586,1172" />
+                        <Node Bounds="584,1103,104,19" Id="T91hS8rqaIUNixlH1BGN3S">
                           <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="IsNullOrWhiteSpace" />
@@ -14246,7 +14264,7 @@
                           <Pin Id="SrgXwYTGaN0NJITxlYFocz" Name="Input" Kind="StateInputPin" />
                           <Pin Id="U4HlcTzZXu6O9xBmQvmVXJ" Name="Result" Kind="OutputPin" />
                         </Node>
-                        <Node Bounds="584,1012,37,19" Id="SwWkJUo3cRvOKzYjrOPzlu">
+                        <Node Bounds="584,1133,37,19" Id="SwWkJUo3cRvOKzYjrOPzlu">
                           <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="NOT" />
@@ -14263,16 +14281,16 @@
                     <Link Id="M1fYvDYQRKzLFl9DY4AAuR" Ids="U4HlcTzZXu6O9xBmQvmVXJ,NwePFA5pKpmP4cYBaidQz5" />
                     <Link Id="MkR93Q4ku1XNYBgoWb4kJ0" Ids="OSGQiFFSdZjM3d6JK5aE5k,EluGEGuABI1MYZhmHiwFUQ" />
                     <Pin Id="ONvCrDtZBw9OZRnISbEY4Y" Name="Input" Kind="InputPin" />
-                    <ControlPoint Id="OcIJZsNJywbNJnfj46nbFj" Bounds="574,916" />
+                    <ControlPoint Id="OcIJZsNJywbNJnfj46nbFj" Bounds="574,1037" />
                     <Link Id="DLeyd2k3AmON8FJoBxaFhD" Ids="ONvCrDtZBw9OZRnISbEY4Y,OcIJZsNJywbNJnfj46nbFj" IsHidden="true" />
                     <Link Id="Fo74Qa73vHoP0Nwojaz020" Ids="OcIJZsNJywbNJnfj46nbFj,Msi0rTUOpzbNitivSRjYhl" />
                     <Pin Id="Vwh4mwHXljENnmZTFm472q" Name="Output" Kind="OutputPin" />
-                    <ControlPoint Id="KXK6DlnOP1XMIREfRQeT2l" Bounds="574,1088" />
+                    <ControlPoint Id="KXK6DlnOP1XMIREfRQeT2l" Bounds="574,1209" />
                     <Link Id="OJeLGe6gwXSO8a4Gkw1RWA" Ids="KXK6DlnOP1XMIREfRQeT2l,Vwh4mwHXljENnmZTFm472q" IsHidden="true" />
                     <Link Id="PGow2seoEXIMPgqqdZnnKr" Ids="ETSJ1MgOJNtMIm4Ntb0K2c,KXK6DlnOP1XMIREfRQeT2l" />
                   </Patch>
                 </Node>
-                <Node Bounds="825,489,104,19" Id="L0swFARe8pLQMRXlFcWFCc">
+                <Node Bounds="825,547,104,19" Id="L0swFARe8pLQMRXlFcWFCc">
                   <p:NodeReference LastCategoryFullName="Main.Utils.LaunchTab.BuildStartupString" LastDependency="GammaLauncher.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="RemoveEmptyLines" />
@@ -14280,7 +14298,7 @@
                   <Pin Id="M0GwPY4eZfOMnzjhjlIE1n" Name="Input" Kind="InputPin" />
                   <Pin Id="GRVJJ01uKcyN47keGPbgk9" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1557,489,104,19" Id="BYRbSE4MVy7P8YVJFPaFVp">
+                <Node Bounds="1557,529,104,19" Id="BYRbSE4MVy7P8YVJFPaFVp">
                   <p:NodeReference LastCategoryFullName="Main.Utils.LaunchTab.BuildStartupString" LastDependency="GammaLauncher.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="RemoveEmptyLines" />
@@ -14288,11 +14306,176 @@
                   <Pin Id="IHcbIJCWGSCMEHsb0pBhzO" Name="Input" Kind="InputPin" />
                   <Pin Id="E0dK4wddSdSLKtMXEAH00V" Name="Output" Kind="OutputPin" />
                 </Node>
+                <!--
+
+    ************************ RemoveDisabledEntries ************************
+
+-->
+                <Node Name="RemoveDisabledEntries" Bounds="836,1047,186,184" Id="OiWWdcnAkbAP0ePS1uH9yI">
+                  <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                    <Choice Kind="OperationDefinition" Name="Operation" />
+                  </p:NodeReference>
+                  <Patch Id="SIOfaddKyXGNvvv5ypFHMJ">
+                    <ControlPoint Id="L6zEfts1z6xQavGw8M53UF" Bounds="882,1065" />
+                    <Link Id="HLcXDmzKO4kK9lNdgW1ubY" Ids="DFg31GKGxEZLj8zKErNEPL,L6zEfts1z6xQavGw8M53UF" IsHidden="true" />
+                    <Pin Id="DFg31GKGxEZLj8zKErNEPL" Name="Input" Kind="InputPin">
+                      <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="TypeFlag" Name="Spread" />
+                        <p:TypeArguments>
+                          <TypeReference>
+                            <Choice Kind="TypeFlag" Name="Tuple (2 Items)" />
+                            <p:TypeArguments>
+                              <TypeReference>
+                                <Choice Kind="TypeFlag" Name="Boolean" />
+                              </TypeReference>
+                              <TypeReference>
+                                <Choice Kind="TypeFlag" Name="String" />
+                              </TypeReference>
+                            </p:TypeArguments>
+                          </TypeReference>
+                        </p:TypeArguments>
+                      </p:TypeAnnotation>
+                    </Pin>
+                    <Node Bounds="880,1088,130,95" Id="EJ8bgpx0nLxO9JlOBnGuIO">
+                      <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
+                        <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
+                        <Choice Kind="OperationCallFlag" Name="Where" />
+                      </p:NodeReference>
+                      <Pin Id="IycgqiNWRbTOj34TyA3bFy" Name="Input" Kind="StateInputPin" />
+                      <Pin Id="SUjxeltdNDTNpH5nHrevqN" Name="Output" Kind="StateOutputPin" />
+                      <Patch Id="BL0AeuJfcvXLX0K5dXgrwv" Name="Predicate" ManuallySortedPins="true">
+                        <Pin Id="EQdUXs7eLEhNOqWME3anSc" Name="Input 1" Kind="InputPin" />
+                        <Pin Id="BEOmhdcWRmnO7PDYhbiGJQ" Name="Input 2" Kind="InputPin" />
+                        <Pin Id="QxveqBm2kPNOxou73BD2TT" Name="Result" Kind="OutputPin" />
+                        <ControlPoint Id="Kd1xQWgKvt3MY3Jepg0J8c" Bounds="894,1096" />
+                        <ControlPoint Id="DI1udeTQPPzNLALdbCz9L9" Bounds="954,1096" />
+                        <ControlPoint Id="Fcuq8puq8UXLqYacOrKUnC" Bounds="894,1176" />
+                        <Node Bounds="892,1123,70,26" Id="EzgbrbhU5EfPIMb0SftVC4">
+                          <p:NodeReference LastCategoryFullName="Primitive.Tuple (2 Items)" LastDependency="VL.CoreLib.vl">
+                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                            <CategoryReference Kind="ClassType" Name="Tuple (2 Items)" />
+                            <Choice Kind="OperationCallFlag" Name="Item1" />
+                          </p:NodeReference>
+                          <Pin Id="FR94qp12pbTQSHfFPELQhD" Name="Input" Kind="StateInputPin" />
+                          <Pin Id="CESnWjObxLrMZwi9Ll2fbi" Name="Item 1" Kind="OutputPin" />
+                        </Node>
+                      </Patch>
+                    </Node>
+                    <Link Id="RZ4ttsYCcNFObixeQmnHnv" Ids="EQdUXs7eLEhNOqWME3anSc,Kd1xQWgKvt3MY3Jepg0J8c" IsHidden="true" />
+                    <Link Id="B3FF3DeY1GEOqmwP7uZcU8" Ids="BEOmhdcWRmnO7PDYhbiGJQ,DI1udeTQPPzNLALdbCz9L9" IsHidden="true" />
+                    <Link Id="BICRHlCtnV7Pq4kuka3UpT" Ids="Fcuq8puq8UXLqYacOrKUnC,QxveqBm2kPNOxou73BD2TT" IsHidden="true" />
+                    <Link Id="IYrpCCsyKRYMwyQnfSebM4" Ids="L6zEfts1z6xQavGw8M53UF,IycgqiNWRbTOj34TyA3bFy" />
+                    <Link Id="RQnDIrt4FxpMeHHszy5qw0" Ids="Kd1xQWgKvt3MY3Jepg0J8c,FR94qp12pbTQSHfFPELQhD" />
+                    <Link Id="IueCPVQ2LXTLqW8Hcjgai5" Ids="CESnWjObxLrMZwi9Ll2fbi,Fcuq8puq8UXLqYacOrKUnC" />
+                    <ControlPoint Id="Rc4u4fD2fI2PjkgPG5xTir" Bounds="882,1214" />
+                    <Link Id="Vt5EDO1h3yDMMuecMwUDzw" Ids="SUjxeltdNDTNpH5nHrevqN,Rc4u4fD2fI2PjkgPG5xTir" />
+                    <Pin Id="K44sq5pv1EGLnzmgpdiaxm" Name="Output" Kind="OutputPin" Bounds="903,1204" />
+                    <Link Id="StdOcvkP4rUOyFqHR12klq" Ids="Rc4u4fD2fI2PjkgPG5xTir,K44sq5pv1EGLnzmgpdiaxm" IsHidden="true" />
+                  </Patch>
+                </Node>
+                <Node Bounds="825,487,122,19" Id="GzWRNghOJTvPCJyNOXjzQm">
+                  <p:NodeReference LastCategoryFullName="Main.Utils.LaunchTab.BuildStartupString" LastDependency="GammaLauncher.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="RemoveDisabledEntries" />
+                  </p:NodeReference>
+                  <Pin Id="Iqf0tBBfnrLLn9S2WDfhZR" Name="Input" Kind="InputPin" />
+                  <Pin Id="CiFwZJW5ntMMR3uAWwm1Gu" Name="Output" Kind="OutputPin" />
+                </Node>
+                <!--
+
+    ************************ RetrieveTupleSecondItem ************************
+
+-->
+                <Node Name="RetrieveTupleSecondItem" Bounds="1060,1090,158,174" Id="OC5HgUREOVHLstVItNIR47">
+                  <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                    <Choice Kind="OperationDefinition" Name="Operation" />
+                  </p:NodeReference>
+                  <Patch Id="JGTS5TpNCycNOp6zeN3HD2">
+                    <Node Bounds="1112,1128,94,86" Id="Ty2pLxR9VGzM5zSouSJkkr">
+                      <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                        <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                        <CategoryReference Kind="Category" Name="Primitive" />
+                        <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
+                      </p:NodeReference>
+                      <Pin Id="Df5OXNaDI30QYm4bnO2QAJ" Name="Break" Kind="OutputPin" />
+                      <Patch Id="GZmjjwyKJU4PGnzE5BjBOv" ManuallySortedPins="true">
+                        <Patch Id="BieIzL4G0X6N2nGbsu4E0J" Name="Create" ManuallySortedPins="true" />
+                        <Patch Id="Ro7xhiAxcklLYQLXs422M0" Name="Update" ManuallySortedPins="true" />
+                        <Patch Id="P78WxBV735DOknckAx0vxl" Name="Dispose" ManuallySortedPins="true" />
+                        <Node Bounds="1124,1158,70,26" Id="P1JYuAUVOk7LG2abHn4YoJ">
+                          <p:NodeReference LastCategoryFullName="Primitive.Tuple (2 Items)" LastDependency="VL.CoreLib.vl">
+                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                            <CategoryReference Kind="ClassType" Name="Tuple (2 Items)" />
+                            <Choice Kind="OperationCallFlag" Name="Item2" />
+                          </p:NodeReference>
+                          <Pin Id="CQeGrFCcK0oOLjhlrryUKt" Name="Input" Kind="StateInputPin" />
+                          <Pin Id="L0HUAvKLlmZLXdJ5uy5QNL" Name="Item 2" Kind="OutputPin" />
+                        </Node>
+                      </Patch>
+                      <ControlPoint Id="Q9aMRrn6XOFPBFP0LWxAAb" Bounds="1126,1134" Alignment="Top" />
+                      <ControlPoint Id="IUhfwqKm9n4PuTgYWlp3EZ" Bounds="1126,1208" Alignment="Bottom" />
+                    </Node>
+                    <ControlPoint Id="SoIHHwhnvrEMjI9EhWHUij" Bounds="1126,1108" />
+                    <Pin Id="K3m629w5rCBN0Cl2JlQpqq" Name="Input" Kind="InputPin">
+                      <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="TypeFlag" Name="Spread" />
+                        <p:TypeArguments>
+                          <TypeReference>
+                            <Choice Kind="TypeFlag" Name="Tuple (2 Items)" />
+                            <p:TypeArguments>
+                              <TypeReference>
+                                <Choice Kind="TypeFlag" Name="Boolean" />
+                              </TypeReference>
+                              <TypeReference>
+                                <Choice Kind="TypeFlag" Name="String" />
+                              </TypeReference>
+                            </p:TypeArguments>
+                          </TypeReference>
+                        </p:TypeArguments>
+                      </p:TypeAnnotation>
+                    </Pin>
+                    <Link Id="UNYHGzxwi39N4uUUTUeWrT" Ids="K3m629w5rCBN0Cl2JlQpqq,SoIHHwhnvrEMjI9EhWHUij" IsHidden="true" />
+                    <Link Id="Bal44w9IuEEMVCpq9C705U" Ids="SoIHHwhnvrEMjI9EhWHUij,Q9aMRrn6XOFPBFP0LWxAAb" />
+                    <Link Id="UCnVq9ZLbFSO2M4gMBoorU" Ids="Q9aMRrn6XOFPBFP0LWxAAb,CQeGrFCcK0oOLjhlrryUKt" />
+                    <Link Id="GWwconqe4CaP6NrFMxBa4e" Ids="L0HUAvKLlmZLXdJ5uy5QNL,IUhfwqKm9n4PuTgYWlp3EZ" />
+                    <ControlPoint Id="CHuLgqkV3vyOLpuo1aLkua" Bounds="1126,1247" />
+                    <Link Id="VP7MZQoB2sONsUGeirlEBx" Ids="IUhfwqKm9n4PuTgYWlp3EZ,CHuLgqkV3vyOLpuo1aLkua" />
+                    <Pin Id="NcGdpUA37PsNJQlh9LCAXH" Name="Output" Kind="OutputPin" Bounds="1126,1247" />
+                    <Link Id="FqelEOJdnNcM7qzFxVK0oO" Ids="CHuLgqkV3vyOLpuo1aLkua,NcGdpUA37PsNJQlh9LCAXH" IsHidden="true" />
+                  </Patch>
+                </Node>
+                <Node Bounds="825,517,131,19" Id="Mc6OXjOammLLtq15I9qEEh">
+                  <p:NodeReference LastCategoryFullName="Main.Utils.LaunchTab.BuildStartupString" LastDependency="GammaLauncher.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="RetrieveTupleSecondItem" />
+                  </p:NodeReference>
+                  <Pin Id="D0V3YOTECizOyEqCfh3rXL" Name="Input" Kind="InputPin" />
+                  <Pin Id="QAxJ5kzwVpYOfn7RgE6UdG" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="1557,468,122,19" Id="QTx7H7XSrP7PZzZqr2gdh1">
+                  <p:NodeReference LastCategoryFullName="Main.Utils.LaunchTab.BuildStartupString" LastDependency="GammaLauncher.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="RemoveDisabledEntries" />
+                  </p:NodeReference>
+                  <Pin Id="MpL4gLQSZoeMSqlCGIZZvA" Name="Input" Kind="InputPin" />
+                  <Pin Id="T14dyU1XT9WPV2jgayntfo" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="1557,498,131,19" Id="KxaOxIDWUh8QTIG8CE4fgc">
+                  <p:NodeReference LastCategoryFullName="Main.Utils.LaunchTab.BuildStartupString" LastDependency="GammaLauncher.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="RetrieveTupleSecondItem" />
+                  </p:NodeReference>
+                  <Pin Id="Hj0qp9KhdO4L3TUKL80VQz" Name="Input" Kind="InputPin" />
+                  <Pin Id="CWCqq6FkPGuOqX8Cg9lTvf" Name="Output" Kind="OutputPin" />
+                </Node>
               </Canvas>
               <ProcessDefinition Id="VRQ3RHXrnHHL7bJrMSkdJH">
                 <Fragment Id="VIrm0Vmg1G7OX8dinBFHtw" Patch="Pm7URYVCDbxQGUl0snxavE" Enabled="true" />
                 <Fragment Id="VoUXGvHdUBKMuBwYhQ5ejv" Patch="IQYPLTporanLtktmpv9m2i" Enabled="true" />
                 <Fragment Id="EKLkGPpG3F3Mcfxuefgx4K" Patch="PJYiVdN2PNtMCUVGYyzU7I" />
+                <Fragment Id="M0DET4kcY9HQKQ0MEztFfv" Patch="OiWWdcnAkbAP0ePS1uH9yI" />
+                <Fragment Id="ImdzTwY93jgNAOo28KXoOn" Patch="OC5HgUREOVHLstVItNIR47" />
               </ProcessDefinition>
               <Link Id="SruLhPKod4LQEofWOQU9ZP" Ids="OJCW3D64GxRNxiqiFAXttJ,KkIqu2wPNgILFHoDDBiJq3" IsHidden="true" />
               <Link Id="PsaGba0eQh8Ppy1GtBbz6B" Ids="DCNobQxacHlNsZWD4m8mz4,VPA0CG1okYdQDiNTkr5YtR" />
@@ -14339,7 +14522,6 @@
               <Link Id="V8Oof6GmViGPXd4td5PYxg" Ids="F5qOqclMvfaQRNszceuSH5,TA4Ob0e0RrePE1XxShVdKS" IsHidden="true" />
               <Link Id="Tlgq7ZUm5fqLiz8omnUyu9" Ids="TA4Ob0e0RrePE1XxShVdKS,Sst841dI23yOYA3c0PokjD" />
               <Link Id="P0bSBeZH7fHPg6XXKGY89g" Ids="LFckw98MKecL3bbe9vBnqw,ShM3YHzBz0YLxOrI6B2Yhi" />
-              <Link Id="NsQvS3z3kMwQaNLjjted3T" Ids="CgErItAfT6EPWbBfyYmO48,M0GwPY4eZfOMnzjhjlIE1n" />
               <Link Id="Q7hh1FZYK6kMWFIOd2Q65M" Ids="PrPYfgHrYdOOTIsu3Y37wj,OeSOT6lrtIyNyAJGAwwa9D" />
               <Link Id="NMIgiwh7Kq4O2GAPsPAgmG" Ids="LFckw98MKecL3bbe9vBnqw,GJklNUYjv9aOGxSXep8cSw" />
               <Link Id="MsYWNVyugB7Lj5ERz1pBwm" Ids="DvtyvQUOXeUNLlXcbPBAMa,LBFleHffVYKNBJKeqfQxGN" />
@@ -14401,11 +14583,15 @@
               <Link Id="HnTG4chyiwfMBt2aZtFXGn" Ids="CKYAas77ipAPvYp8uglYSC,RLwIQzr3z5OPwPV97ovy1o" />
               <Link Id="IZZnGMqfLUWPXkbIBdgBIP" Ids="VvsqS35EtnVMoaBlaeq7VD,CABZSCXIn0qNpXtAGhhF8s" />
               <Link Id="KjqJjAxGQ1NLK7mtJ2ge5o" Ids="A5hi3ti63g8O3WPKl7SfCN,NmKLuuov7IhQb5kIzOp75d" />
-              <Link Id="TLBZWVwd8DlOfYhmGY5StZ" Ids="E0EhgQbWxMWMvDGJ4o95O9,OZDs3H4fCgRNBrMfhTiKYO" />
               <Link Id="E12cNk4JtKwLxAl6is8O9X" Ids="GRVJJ01uKcyN47keGPbgk9,RXK0S0r75GcMtIcidkHMWz" />
-              <Link Id="POrn2N5ecL0QbtS4NpbNtI" Ids="J3ZEk4IYnxJLftpAqbSPbh,IHcbIJCWGSCMEHsb0pBhzO" />
               <Link Id="VvEZ9zv1HnMMnHeJhRi3GQ" Ids="E0dK4wddSdSLKtMXEAH00V,AzKW8m57IuENiigxtx9w7C" />
               <Link Id="FAmoJW7gEQnMLWsbQ2eU0L" Ids="E0dK4wddSdSLKtMXEAH00V,ABlfTaTMTI5NoaDg5PJVCb" />
+              <Link Id="O2rLgI99GXvOApYijGJSEE" Ids="CgErItAfT6EPWbBfyYmO48,Iqf0tBBfnrLLn9S2WDfhZR" />
+              <Link Id="GEDY3ogC1wjMBusZKWZhAU" Ids="CiFwZJW5ntMMR3uAWwm1Gu,D0V3YOTECizOyEqCfh3rXL" />
+              <Link Id="OS9nLKEmIdNOwRyWcwc8lK" Ids="QAxJ5kzwVpYOfn7RgE6UdG,M0GwPY4eZfOMnzjhjlIE1n" />
+              <Link Id="PvEniCVIEFsN1fgcvsxMNi" Ids="T14dyU1XT9WPV2jgayntfo,Hj0qp9KhdO4L3TUKL80VQz" />
+              <Link Id="JNkZ8yqlqxGOQcQc2IrPaE" Ids="J3ZEk4IYnxJLftpAqbSPbh,MpL4gLQSZoeMSqlCGIZZvA" />
+              <Link Id="R0digCG5jWJLZplYf3Ynkf" Ids="CWCqq6FkPGuOqX8Cg9lTvf,IHcbIJCWGSCMEHsb0pBhzO" />
             </Patch>
           </Node>
           <!--

--- a/GammaLauncher.vl
+++ b/GammaLauncher.vl
@@ -8484,7 +8484,7 @@
                             <Pin Id="VPlRdiGyOsWP9kI7VU9EnF" Name="Value" Kind="OutputPin" />
                           </Node>
                           <Patch Id="DUFlQY1ezCjN93BlLDZnGi" Name="Create" ManuallySortedPins="true" />
-                          <Patch Id="IT3RHVJShZYNSANZi3GGye" Name="Update" ParticipatingElements="RXJRQjrCg1vODIRtTlJmBo,EkcYHjPhnqzNCJZX755DtP,VXLvdkxrkbuNzLqwRmtjbN,LSkkEjdAwdPPccoGb9qLz8,AlnHURZhPpxPuH1OFKYFWf,MfrGTF9vtRBNVrLas5ga27,KJVViVjz7zOPAhWDOIj8Yh" ManuallySortedPins="true" />
+                          <Patch Id="IT3RHVJShZYNSANZi3GGye" Name="Update" ParticipatingElements="RXJRQjrCg1vODIRtTlJmBo,EkcYHjPhnqzNCJZX755DtP,VXLvdkxrkbuNzLqwRmtjbN,LSkkEjdAwdPPccoGb9qLz8,AlnHURZhPpxPuH1OFKYFWf,MfrGTF9vtRBNVrLas5ga27,KJVViVjz7zOPAhWDOIj8Yh,SvPnXTtcTp4LfLnoNd1l01" ManuallySortedPins="true" />
                           <Node Bounds="929,1632,61,19" Id="QT6tVkKctjYPX45McJQDY2">
                             <p:NodeReference LastCategoryFullName="2D.Rectangle" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -8732,6 +8732,7 @@
                     <Link Id="S7OS3YF6UwfNT0Nnuxh4wr" Ids="Mvj1oaUIo3RL70hlEnV44z,KKhazo9cfx2N7k5UQdChwA" />
                     <Link Id="O3svbiZ7HSaLDgXbx4tlQc" Ids="UoRbK3DKnwNOvNQdupbGJJ,E98JJ5gHw6XOZTzMt7rc70" />
                     <Link Id="KJVViVjz7zOPAhWDOIj8Yh" Ids="B7lq1skic9hNdPiTRGSh07,R9fuN86EU0eQIUvzyxgQ6F" />
+                    <Link Id="SvPnXTtcTp4LfLnoNd1l01" Ids="N3DqgsU1WkiNPMAPlHsK51,U1RWQbVSQK1OcDaZJyhLau" />
                   </Patch>
                 </Node>
                 <Node Bounds="459,454,105,19" Id="D0CpyGCX0snPKt1QQ1WfUk">
@@ -8893,8 +8894,8 @@
                     </Patch>
                   </Patch>
                 </Node>
-                <ControlPoint Id="GQKcuzWv7FgMt6H5AbwIL8" Bounds="152,881" />
-                <Node Bounds="150,907,106,26" Id="BOLRGfAO9jmLFcxW48CVJU">
+                <ControlPoint Id="GQKcuzWv7FgMt6H5AbwIL8" Bounds="148,927" />
+                <Node Bounds="146,953,106,26" Id="BOLRGfAO9jmLFcxW48CVJU">
                   <p:NodeReference LastCategoryFullName="Main.App.App" LastDependency="GammaLauncher.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="GetRuntimeChannel" />
@@ -8903,7 +8904,7 @@
                   <Pin Id="QqOsBXwwBOGOMzsRDm8C9J" Name="State Output" Kind="StateOutputPin" />
                   <Pin Id="QKyTU2Ysh5aNKSJmoKL18G" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="251,955,45,26" Id="TlpTE4nxDgbNVBjmXIXbss">
+                <Node Bounds="247,1001,45,26" Id="TlpTE4nxDgbNVBjmXIXbss">
                   <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="ClassType" Name="Channel" />

--- a/GammaLauncher.vl
+++ b/GammaLauncher.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="PJSrtxvah1rPaRdkPeoySD" LanguageVersion="2022.5.0-0676-g91d259b3a1" Version="0.128">
-  <NugetDependency Id="S7VWZeBsvN1PjJuK8xKPoa" Location="VL.CoreLib" Version="2022.5.0-0676-g91d259b3a1" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="PJSrtxvah1rPaRdkPeoySD" LanguageVersion="2023.5.0" Version="0.128">
+  <NugetDependency Id="S7VWZeBsvN1PjJuK8xKPoa" Location="VL.CoreLib" Version="2023.5.0" />
   <Patch Id="VwtUUR3K9mbPm4q6fszgF3">
     <Canvas Id="Cn8FrGu71DtOiQColm6Utc" DefaultCategory="Main" CanvasType="FullCategory">
       <Canvas Id="A8kMw5cSAh9N9pwyyLzDKt" Name="Model" Position="92,129">
@@ -1935,7 +1935,7 @@
                       <Choice Kind="TypeFlag" Name="String" />
                     </p:TypeAnnotation>
                   </Pad>
-                  <Node Bounds="394,926,55,19" Id="QkuSGQA3LqqOfVWyQSF8Cx">
+                  <Node Bounds="394,926,55,26" Id="QkuSGQA3LqqOfVWyQSF8Cx">
                     <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -1960,7 +1960,7 @@
                   </Node>
                 </Patch>
               </Node>
-              <Node Bounds="270,350,46,19" Id="Ft8UvbndoC9NOlQIlZlFLW">
+              <Node Bounds="270,350,46,26" Id="Ft8UvbndoC9NOlQIlZlFLW">
                 <p:NodeReference LastCategoryFullName="Reactive.Subjects.Subject" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Subject" />
@@ -1978,7 +1978,7 @@
                   </p:TypeArguments>
                 </p:TypeAnnotation>
               </Pad>
-              <Node Bounds="319,465,51,19" Id="Ee12vfqzBWHMIaDsAJNpPj">
+              <Node Bounds="319,465,51,26" Id="Ee12vfqzBWHMIaDsAJNpPj">
                 <p:NodeReference LastCategoryFullName="Reactive.Subjects.Subject" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Subject" NeedsToBeDirectParent="true" />
@@ -2029,7 +2029,7 @@
                       <Choice Kind="TypeFlag" Name="String" />
                     </p:TypeAnnotation>
                   </Pad>
-                  <Node Bounds="345,1509,63,19" Id="HZtRCcfig3cNtj04WS8RaV">
+                  <Node Bounds="345,1509,63,26" Id="HZtRCcfig3cNtj04WS8RaV">
                     <p:NodeReference LastCategoryFullName="System.XML" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="ParseJSON" />
@@ -2047,8 +2047,8 @@
                     </p:NodeReference>
                     <Pin Id="F1AQlChq70ELlRBOIHNuSs" Name="Break" Kind="OutputPin" />
                     <ControlPoint Id="Q2LXbDM6OFGLVDy9sWpjCG" Bounds="347,1588" Alignment="Top" />
-                    <ControlPoint Id="FiRBLqblfBIM99VDwjwt9M" Bounds="347,1713" Alignment="Bottom" />
-                    <ControlPoint Id="TVqexQ8gDuQLYpMaWHrwzM" Bounds="519,1713" Alignment="Bottom" />
+                    <ControlPoint Id="FiRBLqblfBIM99VDwjwt9M" Bounds="347,1714" Alignment="Bottom" />
+                    <ControlPoint Id="TVqexQ8gDuQLYpMaWHrwzM" Bounds="519,1714" Alignment="Bottom" />
                     <Patch Id="QxVhFvL68fSO0LCKa04vfG" ManuallySortedPins="true">
                       <Patch Id="Kp3zx77RhJRK97EaWYuImB" Name="Create" ManuallySortedPins="true" />
                       <Patch Id="E1Ev5FVKtGFNRfLxBSTl5w" Name="Update" ManuallySortedPins="true" />
@@ -2139,7 +2139,7 @@
                         <Pin Id="OqNlLK3O2zdNaVfkwIUmh9" Name="Output" Kind="StateOutputPin" />
                         <Pin Id="FkYz5sEUvsFPQHzvnU3xwg" Name="Content" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="574,2300,63,19" Id="NQN8vggbG64OnZOwHkg3RU">
+                      <Node Bounds="574,2300,63,26" Id="NQN8vggbG64OnZOwHkg3RU">
                         <p:NodeReference LastCategoryFullName="System.XML" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="ParseJSON" />
@@ -2248,7 +2248,7 @@
               </Pad>
               <Pad Id="DenjCJFYl64OnRzRI6fnnO" SlotId="RK6vJ0m4NRdQYLzKtTybOY" Bounds="79,1020" />
               <Pad Id="EgQuiDs52BeObfdPAPWrcD" SlotId="RK6vJ0m4NRdQYLzKtTybOY" Bounds="477,428" />
-              <Node Bounds="475,465,55,19" Id="UZna9LNyLMRPGAKLQXpEP9">
+              <Node Bounds="475,465,55,26" Id="UZna9LNyLMRPGAKLQXpEP9">
                 <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Channel" />
@@ -2275,7 +2275,7 @@
                   </Patch>
                   <ControlPoint Id="CJQFMh9lrGlQURBIbHwHVW" Bounds="365,4106" />
                   <ControlPoint Id="U4OkxNYZ8YtQWyWvnpA12T" Bounds="365,4186" />
-                  <Node Bounds="411,4140,55,19" Id="LWVuycAUcKEPDykC7lrJXI">
+                  <Node Bounds="411,4140,55,26" Id="LWVuycAUcKEPDykC7lrJXI">
                     <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="ClassType" Name="Channel" />
@@ -2386,7 +2386,7 @@
                     <Pin Id="PF6Zf4VS8FeP0Qq6rHNwuB" Name="Input 1" Kind="InputPin" />
                     <Pin Id="H5GxMsn1wPaNPNKsEgngJd" Name="Output" Kind="OutputPin" />
                   </Patch>
-                  <Node Bounds="1555,764,55,19" Id="EI2V0Xncom9LehqBd6fEqn">
+                  <Node Bounds="1555,764,55,26" Id="EI2V0Xncom9LehqBd6fEqn">
                     <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="ClassType" Name="Channel" />
@@ -2411,7 +2411,7 @@
                   </Node>
                 </Patch>
               </Node>
-              <Node Bounds="1469,354,46,19" Id="MVEAFbDZILzOd780Jr8lKj">
+              <Node Bounds="1469,354,46,26" Id="MVEAFbDZILzOd780Jr8lKj">
                 <p:NodeReference LastCategoryFullName="Reactive.Subjects.Subject" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Subject" />
@@ -2469,7 +2469,7 @@
                     <Pin Id="ViHGJWFZqS0NxGIeMehFVW" Name="Output" Kind="OutputPin" />
                     <Pin Id="NDgBCLGGhMTPK2vrRInWjk" Name="Input 3" Kind="InputPin" />
                   </Node>
-                  <Node Bounds="1544,941,63,19" Id="CvXgbUJzj70PX9UGmbZtDf">
+                  <Node Bounds="1544,941,63,26" Id="CvXgbUJzj70PX9UGmbZtDf">
                     <p:NodeReference LastCategoryFullName="System.XML" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="ParseJSON" />
@@ -2506,7 +2506,7 @@
                   </p:TypeArguments>
                 </p:TypeAnnotation>
               </Pad>
-              <Node Bounds="1518,462,51,19" Id="RZUV2b1Hv9HQTdGvh42axZ">
+              <Node Bounds="1518,462,51,26" Id="RZUV2b1Hv9HQTdGvh42axZ">
                 <p:NodeReference LastCategoryFullName="Reactive.Subjects.Subject" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Subject" NeedsToBeDirectParent="true" />
@@ -2627,7 +2627,7 @@
                   </Node>
                 </Patch>
               </Node>
-              <Node Bounds="507,1229,264,110" Id="NvEZSiehHbFPJ98LC94gZR">
+              <Node Bounds="507,1229,264,117" Id="NvEZSiehHbFPJ98LC94gZR">
                 <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
@@ -2644,7 +2644,7 @@
                   </Patch>
                   <ControlPoint Id="QplCsdozh3lNZyIn5U1nGc" Bounds="511,1237" />
                   <ControlPoint Id="T2EZxbglH9xMVZa5GZy7Wo" Bounds="511,1317" />
-                  <Node Bounds="524,1274,55,19" Id="Qa0TbmUgIFsPLVnrmFjEJH">
+                  <Node Bounds="524,1274,55,26" Id="Qa0TbmUgIFsPLVnrmFjEJH">
                     <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -2659,7 +2659,7 @@
                       <Choice Kind="TypeFlag" Name="String" />
                     </p:TypeAnnotation>
                   </Pad>
-                  <Node Bounds="625,1300,55,19" Id="I1WJqJjkiYAPmdpINakCb2">
+                  <Node Bounds="625,1300,55,26" Id="I1WJqJjkiYAPmdpINakCb2">
                     <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -2688,7 +2688,7 @@
                   </Patch>
                   <ControlPoint Id="AqE7p1o3Ll6NcECA11CKP2" Bounds="274,648" />
                   <ControlPoint Id="SRW4xwfI0GOLrpHMvxupHT" Bounds="274,728" />
-                  <Node Bounds="301,686,55,19" Id="NGgSFFXMSutOJrErKukdpp">
+                  <Node Bounds="301,686,55,26" Id="NGgSFFXMSutOJrErKukdpp">
                     <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -2705,7 +2705,7 @@
                   </Pad>
                 </Patch>
               </Node>
-              <Node Bounds="1323,1246,101,26" Id="Hcmr4FCk5CONNXouoJ8GGR">
+              <Node Bounds="1323,1246,101,19" Id="Hcmr4FCk5CONNXouoJ8GGR">
                 <p:NodeReference LastCategoryFullName="Downloader.DownloadConfiguration" LastDependency="Downloader.dll">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="AssemblyCategory" Name="DownloadConfiguration" />
@@ -2713,7 +2713,7 @@
                 </p:NodeReference>
                 <Pin Id="SbPQJVAgLjBLpNLKw0AJGD" Name="Output" Kind="StateOutputPin" />
               </Node>
-              <Node Bounds="1323,1295,77,26" Id="TzAHwOmFOtsPFDo8LxgHlv">
+              <Node Bounds="1323,1295,77,19" Id="TzAHwOmFOtsPFDo8LxgHlv">
                 <p:NodeReference LastCategoryFullName="Downloader.DownloadService" LastDependency="Downloader.dll" OverloadStrategy="AllPinsThatAreNotCommon">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="AssemblyCategory" Name="DownloadService" />
@@ -2723,7 +2723,7 @@
                 <Pin Id="MSf7ZdjDCAENiH5jf5PVHW" Name="Options" Kind="InputPin" />
                 <Pin Id="LRDby3h3FkGQAI4TdKUo3P" Name="Output" Kind="StateOutputPin" />
               </Node>
-              <Node Bounds="1591,1547,141,26" Id="RpPEwkY2bvkNHUf1rSMC9w">
+              <Node Bounds="1591,1547,141,19" Id="RpPEwkY2bvkNHUf1rSMC9w">
                 <p:NodeReference LastCategoryFullName="Downloader.DownloadService" LastDependency="Downloader.dll">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="AssemblyCategory" Name="DownloadService" />
@@ -2732,7 +2732,7 @@
                 <Pin Id="TpYQzIA2doOPDMRu1bYFhR" Name="Input" Kind="StateInputPin" />
                 <Pin Id="IeWlAiqAbQjMq5P6elujU8" Name="Result" Kind="OutputPin" />
               </Node>
-              <Node Bounds="1323,1547,94,26" Id="QiCJxLOK87cLpDqjgEczX3">
+              <Node Bounds="1323,1547,94,19" Id="QiCJxLOK87cLpDqjgEczX3">
                 <p:NodeReference LastCategoryFullName="Downloader.DownloadService" LastDependency="Downloader.dll">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="AssemblyCategory" Name="DownloadService" />
@@ -2741,7 +2741,7 @@
                 <Pin Id="MLvWm5FMlzMLv2u6hwp2Wy" Name="Input" Kind="StateInputPin" />
                 <Pin Id="RKy3d8ji5xnMvKhjIc52SA" Name="Result" Kind="OutputPin" />
               </Node>
-              <Node Bounds="1894,1546,127,26" Id="C6qXUYELD1BLUOs9AW2tAu">
+              <Node Bounds="1894,1546,127,19" Id="C6qXUYELD1BLUOs9AW2tAu">
                 <p:NodeReference LastCategoryFullName="Downloader.DownloadService" LastDependency="Downloader.dll">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="AssemblyCategory" Name="DownloadService" />
@@ -2762,7 +2762,7 @@
                 <Patch Id="N9u1yONh5qrPXZIpj9pUHu" ManuallySortedPins="true">
                   <ControlPoint Id="UcJMR7OiMFsL4s234rOuG7" Bounds="1337,1623" />
                   <ControlPoint Id="HmND8KU9Qi2QbVj5ppiTnr" Bounds="1331,1906" />
-                  <Node Bounds="1335,1643,62,19" Id="It0CmORhBGLMEvsXVq0XI6">
+                  <Node Bounds="1335,1643,62,26" Id="It0CmORhBGLMEvsXVq0XI6">
                     <p:NodeReference LastCategoryFullName="Reactive.EventPattern" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="EventArgs" />
@@ -2770,7 +2770,7 @@
                     <Pin Id="GkOIZsA9SyHM0lrCzPGYjh" Name="Input" Kind="StateInputPin" />
                     <Pin Id="Hz6ixbXJKMrLFYzDToMeJf" Name="Event Args" Kind="OutputPin" />
                   </Node>
-                  <Node Bounds="1373,1859,55,19" Id="R6q9otqISkMMhwEqlaFQge">
+                  <Node Bounds="1373,1859,55,26" Id="R6q9otqISkMMhwEqlaFQge">
                     <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="ClassType" Name="Channel" />
@@ -2808,7 +2808,7 @@
                 <Patch Id="JoVS642uA1DQCqaujwfnCN" ManuallySortedPins="true">
                   <ControlPoint Id="KEJRo7klyqWQGIGACNvJi3" Bounds="1605,1615" />
                   <ControlPoint Id="FFjUJE4ss0iMqVfaYbK0sp" Bounds="1599,1906" />
-                  <Node Bounds="1603,1635,62,19" Id="RgxYouF9xooMdz4yZVJ84a">
+                  <Node Bounds="1603,1635,62,26" Id="RgxYouF9xooMdz4yZVJ84a">
                     <p:NodeReference LastCategoryFullName="Reactive.EventPattern" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="EventArgs" />
@@ -2825,7 +2825,7 @@
                       </p:TypeAnnotation>
                     </Pin>
                   </Patch>
-                  <Node Bounds="1603,1683,150,26" Id="B0CKUlopaNcNjcdfEZtZzw">
+                  <Node Bounds="1603,1683,150,19" Id="B0CKUlopaNcNjcdfEZtZzw">
                     <p:NodeReference LastCategoryFullName="Downloader.DownloadProgressChangedEventArgs" LastDependency="Downloader.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="DownloadProgressChangedEventArgs" />
@@ -2848,7 +2848,7 @@
                     <Pin Id="OFAjcxIu154QAAEevlt1Sz" Name="Input 4" Kind="InputPin" />
                     <Pin Id="PRBpy0KdrvGMFCp7hpre2P" Name="Output" Kind="StateOutputPin" />
                   </Node>
-                  <Node Bounds="1678,1859,55,19" Id="CO7YPJ83mIQQQLFk2XpmKL">
+                  <Node Bounds="1678,1859,55,26" Id="CO7YPJ83mIQQQLFk2XpmKL">
                     <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="ClassType" Name="Channel" />
@@ -2869,7 +2869,7 @@
                   </Node>
                 </Patch>
               </Node>
-              <Node Bounds="1894,1603,145,306" Id="DAVWS699BltNIbQMSfXzIs">
+              <Node Bounds="1894,1603,253,306" Id="DAVWS699BltNIbQMSfXzIs">
                 <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
@@ -2890,7 +2890,7 @@
                       </p:TypeAnnotation>
                     </Pin>
                   </Patch>
-                  <Node Bounds="1921,1797,55,19" Id="RpKjaBBc0iqLdziGZG8fRF">
+                  <Node Bounds="1921,1797,55,26" Id="RpKjaBBc0iqLdziGZG8fRF">
                     <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="ClassType" Name="Channel" />
@@ -2900,7 +2900,7 @@
                     <Pin Id="Uar8BaiV4k5M3h8p0913Tv" Name="Value" Kind="InputPin" />
                     <Pin Id="P0FP8EbKWjQOtpxbC4sdWM" Name="Output" Kind="StateOutputPin" />
                   </Node>
-                  <Pad Id="R57kdnGqH4lQHRXxcbQKOL" Comment="" Bounds="1973,1778,143,0" ShowValueBox="true" isIOBox="true" Value="Done! Running installer...">
+                  <Pad Id="R57kdnGqH4lQHRXxcbQKOL" Comment="" Bounds="1973,1778,143,15" ShowValueBox="true" isIOBox="true" Value="Done! Running installer...">
                     <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="String" />
                     </p:TypeAnnotation>
@@ -2953,7 +2953,7 @@
                     <Pin Id="JJSGnhuj2Y9Om01jQrXDb8" Name="Working Directory" Kind="InputPin" />
                     <Pin Id="JM5YCEnLqfDPnM2XpmuqOR" Name="Output" Kind="OutputPin" />
                   </Node>
-                  <Node Bounds="1906,1976,41,19" Id="ScBOnnRszgyNYYMq3mZ0Ug">
+                  <Node Bounds="1906,1976,45,26" Id="ScBOnnRszgyNYYMq3mZ0Ug">
                     <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="ClassType" Name="Channel" />
@@ -2987,7 +2987,7 @@
                 <Patch Id="AoKokANyBY0MLkoS1bBlNK" ManuallySortedPins="true">
                   <ControlPoint Id="RJNnAJSoqijNEPARO9H8Si" Bounds="1522,1172" />
                   <ControlPoint Id="QPJmj8ncB3kQGkC7KTr0si" Bounds="1487,1423" />
-                  <Node Bounds="1481,1368,125,26" Id="VvE4ub1XAnaLAuJFUguBhV">
+                  <Node Bounds="1481,1368,125,19" Id="VvE4ub1XAnaLAuJFUguBhV">
                     <p:NodeReference LastCategoryFullName="Downloader.DownloadService" LastDependency="Downloader.dll" OverloadStrategy="AllPinsThatAreNotCommon">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="DownloadService" />
@@ -3077,7 +3077,7 @@
                       </p:TypeAnnotation>
                     </Pin>
                   </Patch>
-                  <Node Bounds="1644,1372,55,19" Id="LslSpWSu7p5OWF0vgv7pb4">
+                  <Node Bounds="1644,1372,55,26" Id="LslSpWSu7p5OWF0vgv7pb4">
                     <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -3137,7 +3137,7 @@
                   </Patch>
                   <ControlPoint Id="ImieZr2ux0aNDRA3cahCPv" Bounds="1779,2151" />
                   <ControlPoint Id="M9WEexXkFOlPgpC0dFtsOA" Bounds="1857,2234" />
-                  <Node Bounds="1803,2187" Id="LBwrBswSDjVOszDVArrbBN">
+                  <Node Bounds="1803,2187,43,26" Id="LBwrBswSDjVOszDVArrbBN">
                     <p:NodeReference LastCategoryFullName="GammaLauncher.Utils.Process" LastDependency="GammaLauncher.Proxies.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="Category" Name="Process" NeedsToBeDirectParent="true">
@@ -3151,7 +3151,7 @@
                   </Node>
                 </Patch>
               </Node>
-              <Node Bounds="1775,2276,214,97" Id="I3lCgu4h9TANcyAwZmbMKu">
+              <Node Bounds="1775,2276,214,100" Id="I3lCgu4h9TANcyAwZmbMKu">
                 <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
                   <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
@@ -3179,7 +3179,7 @@
                       <Choice Kind="TypeFlag" Name="Integer32" />
                     </p:TypeAnnotation>
                   </Pad>
-                  <Node Bounds="1842,2330,55,19" Id="JIIhmHFzk9WL6G2O0YtvOM">
+                  <Node Bounds="1842,2330,55,26" Id="JIIhmHFzk9WL6G2O0YtvOM">
                     <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="ClassType" Name="Channel" />
@@ -3229,7 +3229,7 @@
                     <Pin Id="E9xI0ViOy3kO45a7aU1x3t" Name="Input" Kind="StateInputPin" />
                     <Pin Id="QFlUb7qzJLVMS5kneIS3nq" Name="Output" Kind="StateOutputPin" />
                   </Node>
-                  <Node Bounds="1929,2511,55,19" Id="Fgby1luvdgTL081GlZOiGM">
+                  <Node Bounds="1929,2511,55,26" Id="Fgby1luvdgTL081GlZOiGM">
                     <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="ClassType" Name="Channel" />
@@ -3289,7 +3289,7 @@
                   </Patch>
                   <ControlPoint Id="PPVD3EhspmAMcGN87jB7t8" Bounds="2214,2471" />
                   <ControlPoint Id="HnH9TZcwHkRPNZDiriaIHi" Bounds="2214,2551" />
-                  <Node Bounds="2257,2507,55,19" Id="Gxoe7FXzJVYLiXHnvolSVB">
+                  <Node Bounds="2257,2507,55,26" Id="Gxoe7FXzJVYLiXHnvolSVB">
                     <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="ClassType" Name="Channel" />
@@ -3463,7 +3463,7 @@
                     <Pin Id="SBCFoGwt22BLEV1tQsH99n" Name="Local Version" Kind="InputPin" />
                     <Pin Id="Szx60B1SCbOQHf0yBagqwR" Name="Latest Remote" Kind="InputPin" />
                   </Node>
-                  <Node Bounds="635,3491,55,19" Id="UOsXZFFa8C6NuovtSTQGtG">
+                  <Node Bounds="635,3491,55,26" Id="UOsXZFFa8C6NuovtSTQGtG">
                     <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -3531,7 +3531,7 @@
                   </Patch>
                   <ControlPoint Id="OQ60xNglADdPHjSI87YR3E" Bounds="636,3878" />
                   <ControlPoint Id="NhPnLDgqsY5OBZIolpERy0" Bounds="636,3958" />
-                  <Node Bounds="662,3913,55,19" Id="Pq3QDANIu6xNiI3KSOcpH1">
+                  <Node Bounds="662,3913,55,26" Id="Pq3QDANIu6xNiI3KSOcpH1">
                     <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="ClassType" Name="Channel" />
@@ -3546,7 +3546,7 @@
                       <Choice Kind="TypeFlag" Name="String" />
                     </p:TypeAnnotation>
                   </Pad>
-                  <Node Bounds="739,3913,55,19" Id="E6jujV90GUJMVO0WXpp1ac">
+                  <Node Bounds="739,3913,55,26" Id="E6jujV90GUJMVO0WXpp1ac">
                     <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="ClassType" Name="Channel" />
@@ -3558,7 +3558,7 @@
                   </Node>
                 </Patch>
               </Node>
-              <Node Bounds="361,3863,172,95" Id="S4N6mRKfiC3LENxLKK3Nv3">
+              <Node Bounds="361,3863,172,96" Id="S4N6mRKfiC3LENxLKK3Nv3">
                 <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
@@ -3575,7 +3575,7 @@
                   </Patch>
                   <ControlPoint Id="BJMacnZ4lHUMAUleR0fZVu" Bounds="365,3871" />
                   <ControlPoint Id="J3qctSeaWcRMuDxgyGx7cf" Bounds="365,3951" />
-                  <Node Bounds="391,3913,55,19" Id="RlOScUF44R9Pb1ILxjpA4v">
+                  <Node Bounds="391,3913,55,26" Id="RlOScUF44R9Pb1ILxjpA4v">
                     <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="ClassType" Name="Channel" />
@@ -3590,7 +3590,7 @@
                       <Choice Kind="TypeFlag" Name="String" />
                     </p:TypeAnnotation>
                   </Pad>
-                  <Node Bounds="466,3913,55,19" Id="VGtHSJqy5e3LbtvvzXVLhd">
+                  <Node Bounds="466,3913,55,26" Id="VGtHSJqy5e3LbtvvzXVLhd">
                     <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="ClassType" Name="Channel" />
@@ -3635,7 +3635,7 @@
               </Node>
               <Pad Id="RFhuuWXTBwRP3jc5EhTV1T" Bounds="751,3400" />
               <ControlPoint Id="VGASovb1YbxN6CbCaj5DjP" Bounds="751,3437" />
-              <Node Bounds="361,4041,45,19" Id="OBW8lMQxyJcOgebL30BXZt">
+              <Node Bounds="361,4041,56,26" Id="OBW8lMQxyJcOgebL30BXZt">
                 <p:NodeReference LastCategoryFullName="Reactive.Observable" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="MutableInterfaceType" Name="Observable" />
@@ -4050,6 +4050,7 @@
                   <Pin Id="KtLGlrwyQoCLBxukcFDIP4" Name="Docking Enabled" Kind="InputPin" DefaultValue="False" />
                   <Pin Id="UsPdsGv37q2PilCo54HWMp" Name="Fonts" Kind="InputPin" />
                   <Pin Id="B3KlJfTr8bdLbAVNFssCBH" Name="Add Fullscreen Window" Kind="InputPin" />
+                  <Pin Id="RnBicouoopWOF82NkQwVQs" Name="Fullscreen Window Style" Kind="InputPin" />
                   <Pin Id="RBZzaEs1GrpLoWbFnnvGrL" Name="Use Skia Space" Kind="InputPin" DefaultValue="False" />
                   <Pin Id="SLNax2kslNsO5FFa0pWvKG" Name="Output" Kind="OutputPin" />
                   <Patch Id="S5Hb94D5xeUPdTL1np6TIQ" ManuallySortedPins="true">
@@ -4083,7 +4084,7 @@
                       </p:NodeReference>
                       <Pin Id="TWxDvjDm3jTMvPFTmU4O43" Name="Context" Kind="InputPin" />
                       <Pin Id="KNDfN68OE7kNCtHhG9jAkw" Name="Application" Kind="InputPin" />
-                      <Pin Id="Te39Jm17W3nP737I1dFFtZ" Name="Is Open" Kind="InputPin" />
+                      <Pin Id="LuMJe9jJvmOMwPwuNQVaLH" Name="Visible" Kind="InputPin" />
                     </Node>
                   </Patch>
                 </Node>
@@ -4116,7 +4117,7 @@
                   </p:NodeReference>
                   <Patch Id="BCqVo4kujWUOiaZyTjjXcW">
                     <Canvas Id="HM1WE4bDKrlOkaNgUKI7Sl" CanvasType="Group">
-                      <Node Bounds="280,189,694,1164" Id="JcKIGwdReETPUkk9inkEDo">
+                      <Node Bounds="280,189,698,1164" Id="JcKIGwdReETPUkk9inkEDo">
                         <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                           <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="TabBar" />
@@ -4129,25 +4130,15 @@
                         <Patch Id="NiTDlEO08P6Lut8BOZJEIE" ManuallySortedPins="true">
                           <Patch Id="NEUyeqgjcG4LbMg8XFJsEA" Name="Create" ManuallySortedPins="true" />
                           <Patch Id="PWszmwX8f6oNriyKdqACaS" Name="Update" ParticipatingElements="IYnyn7sRVu1NDXcs6LUqfM" ManuallySortedPins="true" />
-                          <Node Bounds="357,209,169,80" Id="RE2qlYWLG1NOb2iYxtvqj7">
+                          <Node Bounds="357,209,169,87" Id="RE2qlYWLG1NOb2iYxtvqj7">
                             <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                               <Choice Kind="ProcessAppFlag" Name="TabItem" />
                             </p:NodeReference>
-                            <Pin Id="EZ5Tt5uYvHdNgojMlls9yK" Name="Context" Kind="InputPin" />
-                            <Pin Id="Ex4LAwkAxsaPGWhvx9IAxn" Name="Label" Kind="InputPin" DefaultValue="Launch" />
-                            <Pin Id="J1wIr812jstNECVMVKAHyk" Name="Has Close Button" Kind="InputPin" DefaultValue="False" />
-                            <Pin Id="TePur7ne8OYNqWMsGq8jMw" Name="Is Visible" Kind="InputPin" />
-                            <Pin Id="U16NcabFTh1O15r0ZzO3qG" Name="Is Active" Kind="InputPin" />
-                            <Pin Id="BU0JhJMiGglNT8E8MRADP5" Name="Style" Kind="InputPin" />
-                            <Pin Id="F4bcCEjOmMAM84H7NIYWHc" Name="Flags" Kind="InputPin" />
-                            <Pin Id="VCpeTThSRhjORTcGZdrUrV" Name="Context" Kind="OutputPin" />
-                            <Pin Id="CAOeHMwMSyAMoSRpaaC9YW" Name="Is Visible" Kind="OutputPin" />
-                            <Pin Id="SkoBCyZtdDsP5kjZPT1dd3" Name="Is Active" Kind="OutputPin" />
                             <Patch Id="BtNOCa8A5FpLrm2PsdloST" ManuallySortedPins="true">
                               <Patch Id="A8KIgDjuWvqLTiMVmop6SD" Name="Create" ManuallySortedPins="true" />
                               <Patch Id="S9Jmnia2JoBOKoCIupUiYd" Name="Update" ManuallySortedPins="true" />
-                              <Node Bounds="411,248" Id="Hux2TJ2AGhwMhIaIc986sA">
+                              <Node Bounds="411,248,25,19" Id="Hux2TJ2AGhwMhIaIc986sA">
                                 <p:NodeReference LastCategoryFullName="Main.Editor.UI.Editor.Tabs" LastDependency="GammaLauncher.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="ProcessAppFlag" Name="Launch" />
@@ -4156,22 +4147,22 @@
                                 <Pin Id="DgKsAV1SmW3MQUmzrQTwHO" Name="Kill All Instances Popup Channel" Kind="InputPin" />
                               </Node>
                             </Patch>
+                            <Pin Id="EZ5Tt5uYvHdNgojMlls9yK" Name="Context" Kind="InputPin" />
+                            <Pin Id="Ex4LAwkAxsaPGWhvx9IAxn" Name="Label" Kind="InputPin" DefaultValue="Launch" />
+                            <Pin Id="PH6hnTlDYkWLIDl04pG9Ht" Name="Visible" Kind="InputPin" />
+                            <Pin Id="TGsNY1R5ovXNF7y3fnH6sO" Name="Active" Kind="InputPin" />
+                            <Pin Id="U0f6u0DVDsIMu6SNibFnKQ" Name="Closing" Kind="InputPin" />
+                            <Pin Id="BU0JhJMiGglNT8E8MRADP5" Name="Style" Kind="InputPin" />
+                            <Pin Id="F4bcCEjOmMAM84H7NIYWHc" Name="Flags" Kind="InputPin" />
+                            <Pin Id="VCpeTThSRhjORTcGZdrUrV" Name="Context" Kind="OutputPin" />
+                            <Pin Id="IYFMPJ9bo6AQWNgBN8RAgH" Name="Close Clicked" Kind="OutputPin" />
+                            <Pin Id="Otlj4YaAgG4PnihLEeI033" Name="Content Is Visible" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="357,1120,124,80" Id="M1e9liPqDliLMTT7VsZb3M">
                             <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                               <Choice Kind="ProcessAppFlag" Name="TabItem" />
                             </p:NodeReference>
-                            <Pin Id="DYV55sJw3EhPpTp3vJCnZY" Name="Context" Kind="InputPin" />
-                            <Pin Id="VUDZ3VC9KV5QcEf2zKpl7g" Name="Label" Kind="InputPin" DefaultValue="Updates" />
-                            <Pin Id="LQMi1KzOrcZM6U3eL6i4S6" Name="Has Close Button" Kind="InputPin" DefaultValue="False" />
-                            <Pin Id="KcCUH4hxNLiOTuWkVkq00u" Name="Is Visible" Kind="InputPin" />
-                            <Pin Id="FWoJrCq6ImjMrgadQqa4tU" Name="Is Active" Kind="InputPin" DefaultValue="False" />
-                            <Pin Id="UDceWN0QyYNPKoJJQWhTKA" Name="Style" Kind="InputPin" />
-                            <Pin Id="CYjcQGeTKz3MloRRTYBi6B" Name="Flags" Kind="InputPin" DefaultValue="None" />
-                            <Pin Id="FxhBgl8R4NvOAocOevVVV6" Name="Context" Kind="OutputPin" />
-                            <Pin Id="M55wyGp5zIBPlDehGgvMF6" Name="Is Visible" Kind="OutputPin" />
-                            <Pin Id="HRjGp0yryUdNL87KdarqAX" Name="Is Active" Kind="OutputPin" />
                             <Patch Id="IKMYDzMRLCPL1ymZgbxhiL" ManuallySortedPins="true">
                               <Patch Id="I4oaozLeAcnPZh07qYgvdu" Name="Create" ManuallySortedPins="true" />
                               <Patch Id="BWd2p0CWXThMvPOOOrrH39" Name="Update" ManuallySortedPins="true" />
@@ -4183,22 +4174,22 @@
                                 <Pin Id="U7Ij6ZExXWHLGlKoUsDQRt" Name="Application" Kind="InputPin" />
                               </Node>
                             </Patch>
+                            <Pin Id="DYV55sJw3EhPpTp3vJCnZY" Name="Context" Kind="InputPin" />
+                            <Pin Id="VUDZ3VC9KV5QcEf2zKpl7g" Name="Label" Kind="InputPin" DefaultValue="Updates" />
+                            <Pin Id="MskQH3bAxUhOz4FQab1udz" Name="Visible" Kind="InputPin" />
+                            <Pin Id="SFr3V84bDeSOqgZmsX6lw0" Name="Active" Kind="InputPin" />
+                            <Pin Id="RBd6XqzTIlUNyoLPfUQQxs" Name="Closing" Kind="InputPin" />
+                            <Pin Id="UDceWN0QyYNPKoJJQWhTKA" Name="Style" Kind="InputPin" />
+                            <Pin Id="CYjcQGeTKz3MloRRTYBi6B" Name="Flags" Kind="InputPin" DefaultValue="None" />
+                            <Pin Id="FxhBgl8R4NvOAocOevVVV6" Name="Context" Kind="OutputPin" />
+                            <Pin Id="PYDteaCAO2WLlBFYZcVcZ8" Name="Close Clicked" Kind="OutputPin" />
+                            <Pin Id="IH3hHZFBRbSOHZWHFVwqIz" Name="Content Is Visible" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="357,1253,134,80" Id="ThENHAcaNo1NNO49o0TsuS">
                             <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                               <Choice Kind="ProcessAppFlag" Name="TabItem" />
                             </p:NodeReference>
-                            <Pin Id="DRjgA4gcPkvNgJkOUWgu9d" Name="Context" Kind="InputPin" />
-                            <Pin Id="KQJu9gxNlTzNxfxvfVIv9a" Name="Label" Kind="InputPin" DefaultValue="Settings" />
-                            <Pin Id="Q1jljMcGvA6P17bjVtq0ps" Name="Has Close Button" Kind="InputPin" DefaultValue="False" />
-                            <Pin Id="LYQ1AvjCahaOfCRNLX7I2r" Name="Is Visible" Kind="InputPin" />
-                            <Pin Id="J4AbyCODaBZLZBEB7rbtd1" Name="Is Active" Kind="InputPin" />
-                            <Pin Id="EMxj8UjtDixLcJdWGhmpp0" Name="Style" Kind="InputPin" />
-                            <Pin Id="LRPhYPkCSl0NmJKq1t80OR" Name="Flags" Kind="InputPin" />
-                            <Pin Id="AGtyBXhvFZzQLOTt1av4cS" Name="Context" Kind="OutputPin" />
-                            <Pin Id="RYpR3uGaa09OxYXGlh2TSJ" Name="Is Visible" Kind="OutputPin" />
-                            <Pin Id="Anb5isF8RY9OwJ5LCGhS5J" Name="Is Active" Kind="OutputPin" />
                             <Patch Id="MWXBqaznbdcNnSm4cxNhLb" ManuallySortedPins="true">
                               <Patch Id="OKEdOo4ABTvOP5lh0yC8B7" Name="Create" ManuallySortedPins="true" />
                               <Patch Id="CkCbIeXVE8lOehxVTIsxom" Name="Update" ManuallySortedPins="true" />
@@ -4211,6 +4202,16 @@
                                 <Pin Id="UgVXCv53KuJNaXFbhCZYYO" Name="Application" Kind="InputPin" />
                               </Node>
                             </Patch>
+                            <Pin Id="DRjgA4gcPkvNgJkOUWgu9d" Name="Context" Kind="InputPin" />
+                            <Pin Id="KQJu9gxNlTzNxfxvfVIv9a" Name="Label" Kind="InputPin" DefaultValue="Settings" />
+                            <Pin Id="NlF6REXjdwYNQjx5rqkkt6" Name="Visible" Kind="InputPin" />
+                            <Pin Id="UeMFtFEoKxnLyebp2gd9EQ" Name="Active" Kind="InputPin" />
+                            <Pin Id="KMzGhDFP0DLM5rQAUm0CSp" Name="Closing" Kind="InputPin" />
+                            <Pin Id="EMxj8UjtDixLcJdWGhmpp0" Name="Style" Kind="InputPin" />
+                            <Pin Id="LRPhYPkCSl0NmJKq1t80OR" Name="Flags" Kind="InputPin" />
+                            <Pin Id="AGtyBXhvFZzQLOTt1av4cS" Name="Context" Kind="OutputPin" />
+                            <Pin Id="H788iMCISEiNpTtnTrFzTb" Name="Close Clicked" Kind="OutputPin" />
+                            <Pin Id="U1rlU78bVUPNSKNM3qEL4X" Name="Content Is Visible" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="303,334,360,148" Id="FplNeZEcIs4LhSmdhQNEeQ">
                             <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
@@ -4219,8 +4220,8 @@
                               <Choice Kind="ApplicationStatefulRegion" Name="If" />
                             </p:NodeReference>
                             <Pin Id="GLeiQNJU91rMxgCS5bq3Eq" Name="Condition" Kind="InputPin" />
-                            <ControlPoint Id="KLNrt4NBTm7P7sSQKhpV3B" Bounds="359,341" Alignment="Top" />
-                            <ControlPoint Id="QHLcEeIxBAHODoV6H2sqOt" Bounds="359,455" Alignment="Bottom" />
+                            <ControlPoint Id="KLNrt4NBTm7P7sSQKhpV3B" Bounds="359,340" Alignment="Top" />
+                            <ControlPoint Id="QHLcEeIxBAHODoV6H2sqOt" Bounds="359,476" Alignment="Bottom" />
                             <Patch Id="OSkeSQ7kPctLJVuyvGZEDF" ManuallySortedPins="true">
                               <Patch Id="HSfuKS41S5gPfHf3AIIQyd" Name="Create" ManuallySortedPins="true" />
                               <Patch Id="HxCH7EiPOK5M4pi0vEaZMl" Name="Then" ManuallySortedPins="true" />
@@ -4235,14 +4236,14 @@
                                 </Patch>
                                 <Pin Id="Cw9p0qRvIeFLAXf1ITUbo5" Name="Context" Kind="InputPin" />
                                 <Pin Id="Ro67gvqdZSqMDJOXPyVFSu" Name="Label" Kind="InputPin" DefaultValue="Projects" />
-                                <Pin Id="Cn1d0Dw3NG6OLH9dII7Ej5" Name="Has Close Button" Kind="InputPin" DefaultValue="False" />
-                                <Pin Id="TrRFNCL2yYrQHgLkyefhUI" Name="Is Visible" Kind="InputPin" />
-                                <Pin Id="JF6ETspAjUUMleU6jFiYJL" Name="Is Active" Kind="InputPin" />
+                                <Pin Id="BCkRkuEffkTNziQM6D9nFj" Name="Visible" Kind="InputPin" />
+                                <Pin Id="EMupfkKxm9RMc96lBuxxAe" Name="Active" Kind="InputPin" />
+                                <Pin Id="LpHvdvwfxwDOaq2I8khKEy" Name="Closing" Kind="InputPin" />
                                 <Pin Id="MfbGXWMF1otNhbwYIwn25S" Name="Style" Kind="InputPin" />
                                 <Pin Id="ER1CQbQTs8PPNWFHY92Oes" Name="Flags" Kind="InputPin" />
                                 <Pin Id="LdbTAVUxMOZNUzbcK7c1nC" Name="Context" Kind="OutputPin" />
-                                <Pin Id="TzswRhuZg8DP7LpAkbdXVj" Name="Is Visible" Kind="OutputPin" />
-                                <Pin Id="JWKcFbHu7zpPEbBhvs2GBW" Name="Is Active" Kind="OutputPin" />
+                                <Pin Id="LgjBgmHm5zONw0465BRb7n" Name="Close Clicked" Kind="OutputPin" />
+                                <Pin Id="JzrvKtL0cimOqTwtjMxNtQ" Name="Content Is Visible" Kind="OutputPin" />
                               </Node>
                               <Pad Id="QwLeB5XHCoxOU3XTJE172r" Bounds="544,400,100,19" ShowValueBox="true" isIOBox="true" Value="maybe one day">
                                 <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
@@ -4255,14 +4256,14 @@
                               </Pad>
                             </Patch>
                           </Node>
-                          <Node Bounds="303,503,350,152" Id="HSFdFBEgTAYLEBZGpouzvA">
+                          <Node Bounds="303,503,350,153" Id="HSFdFBEgTAYLEBZGpouzvA">
                             <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                               <CategoryReference Kind="Category" Name="Primitive" />
                               <Choice Kind="ApplicationStatefulRegion" Name="If" />
                             </p:NodeReference>
                             <Pin Id="VJ1D5NvcJD2Ozy0pdMfhah" Name="Condition" Kind="InputPin" />
-                            <ControlPoint Id="TvKfCQBP0xEMnHKrGVLIOh" Bounds="359,534" Alignment="Top" />
+                            <ControlPoint Id="TvKfCQBP0xEMnHKrGVLIOh" Bounds="359,509" Alignment="Top" />
                             <ControlPoint Id="VbiD9nVtPuhOuteDMiNQXh" Bounds="359,650" Alignment="Bottom" />
                             <Patch Id="Imp3Udbx2FuMhZpoLJ6cZV" ManuallySortedPins="true">
                               <Patch Id="VuRIZM7qoa5QZ8ueMhuHvl" Name="Create" ManuallySortedPins="true" />
@@ -4278,14 +4279,14 @@
                                 </Patch>
                                 <Pin Id="SrP82S4bzriPc0X3wobef5" Name="Context" Kind="InputPin" />
                                 <Pin Id="RkrBsvjC9vwMgGt6OsdC48" Name="Label" Kind="InputPin" DefaultValue="Versions" />
-                                <Pin Id="R6rdy2bH0sROivieWgiHiR" Name="Has Close Button" Kind="InputPin" DefaultValue="False" />
-                                <Pin Id="ODCtT5XCFbtPiYO2pgUoMj" Name="Is Visible" Kind="InputPin" />
-                                <Pin Id="UL7NyfLmH78PJv1uzo3aB7" Name="Is Active" Kind="InputPin" DefaultValue="False" />
+                                <Pin Id="OPgAQgbVNlXPsuqztOqC2V" Name="Visible" Kind="InputPin" />
+                                <Pin Id="I10KGYzV6y5LhTiYpHM5P6" Name="Active" Kind="InputPin" />
+                                <Pin Id="LxzeTJXESplL4h0IVELAET" Name="Closing" Kind="InputPin" />
                                 <Pin Id="GRX1OFcsnMFM1yEsZr38hC" Name="Style" Kind="InputPin" />
                                 <Pin Id="ARFTYEoZwX3MmpWgJS1nDU" Name="Flags" Kind="InputPin" />
                                 <Pin Id="SmxhA2FUKfoNeV4dtviTYB" Name="Context" Kind="OutputPin" />
-                                <Pin Id="RZkuxA2GXjJQBqa2eocTIT" Name="Is Visible" Kind="OutputPin" />
-                                <Pin Id="Q6oMScuJiuJMCsdwiEW4Cg" Name="Is Active" Kind="OutputPin" />
+                                <Pin Id="I4mrNwAnxg8NNlenzMS5ZT" Name="Close Clicked" Kind="OutputPin" />
+                                <Pin Id="SDbtNoziLydOHnVx7ccIsf" Name="Content Is Visible" Kind="OutputPin" />
                               </Node>
                               <Pad Id="Kb2RU37EvidO0JvtVy9PqB" Bounds="524,586,110,19" ShowValueBox="true" isIOBox="true" Value="probably useless">
                                 <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
@@ -4321,7 +4322,7 @@
                             <Pin Id="QY1REy1Bq2FM0pqsjJLX0g" Name="State Output" Kind="StateOutputPin" />
                             <Pin Id="PKluMVlzoOoPsDnNXgT3XW" Name="Output" Kind="OutputPin" />
                           </Node>
-                          <Node Bounds="403,733,41,19" Id="RVbpmLJtklALyV4wTSWZQR">
+                          <Node Bounds="403,733,45,26" Id="RVbpmLJtklALyV4wTSWZQR">
                             <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -4341,7 +4342,7 @@
                             <Pin Id="UweCNgZQhB8NM59Z1MCZ0u" Name="Output" Kind="StateOutputPin" />
                             <Pin Id="SShxaN6PE8vL06Glhkb4iC" Name="Updates Tab Runtime" Kind="OutputPin" />
                           </Node>
-                          <Node Bounds="445,968,152,132" Id="ShUp27m1516OpuI9GkIX6F">
+                          <Node Bounds="445,968,152,133" Id="ShUp27m1516OpuI9GkIX6F">
                             <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                               <CategoryReference Kind="Category" Name="Primitive" />
@@ -4349,7 +4350,7 @@
                             </p:NodeReference>
                             <Pin Id="L7RBqwfP3crLGJfE2eokR6" Name="Condition" Kind="InputPin" />
                             <ControlPoint Id="OeGkbwUCh1AMxW79ptX7Ba" Bounds="459,1095" Alignment="Bottom" />
-                            <ControlPoint Id="MObENcaSdEGPXI5lRWUm5W" Bounds="459,975" Alignment="Top" />
+                            <ControlPoint Id="MObENcaSdEGPXI5lRWUm5W" Bounds="459,974" Alignment="Top" />
                             <Patch Id="GnDAg4issUBNnTAqlQEqx9" ManuallySortedPins="true">
                               <Patch Id="QlW6jtJWyWuOzV6G5eBQMB" Name="Create" ManuallySortedPins="true" />
                               <Patch Id="VkpVErN53qXMFcTgQzk1z6" Name="Then" ManuallySortedPins="true" />
@@ -4401,7 +4402,7 @@
                               </Node>
                             </Patch>
                           </Node>
-                          <Node Bounds="409,904,41,19" Id="AwtzGPREoGoQZWDZqfSL73">
+                          <Node Bounds="409,904,45,26" Id="AwtzGPREoGoQZWDZqfSL73">
                             <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -4420,7 +4421,7 @@
                             <Pin Id="MTQWwAN5fb3PbrPAfbrDU0" Name="Output" Kind="StateOutputPin" />
                             <Pin Id="S0NraZtkPScLQhbL2ylqbt" Name="Newer Launcher Builds Online Flag" Kind="OutputPin" />
                           </Node>
-                          <Node Bounds="921,861,41,19" Id="DWfDgs0xNFfN4p1A1s8i2U">
+                          <Node Bounds="921,861,45,26" Id="DWfDgs0xNFfN4p1A1s8i2U">
                             <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -5547,15 +5548,6 @@
                                       <CategoryReference Kind="Category" Name="Widgets" />
                                       <Choice Kind="ProcessAppFlag" Name="Popup (Modal)" />
                                     </p:NodeReference>
-                                    <Pin Id="V2A7q29X75yLW4z4kaDWAf" Name="Context" Kind="InputPin" />
-                                    <Pin Id="QQdnwCqrLbELNzHEjyaFLD" Name="Label" Kind="InputPin" DefaultValue="Kill vvvv" />
-                                    <Pin Id="CS2ZNHuI8HeNwMeoNPV6P6" Name="Has Close Button" Kind="InputPin" DefaultValue="True" />
-                                    <Pin Id="MId2Ek2RsmLNjYAIVFEA7B" Name="Bounds" Kind="InputPin" />
-                                    <Pin Id="VnToXBj2y7TOdSitLchTNP" Name="Is Open" Kind="InputPin" />
-                                    <Pin Id="SVVwfWgRG4lOy0BmC3WTAQ" Name="Style" Kind="InputPin" />
-                                    <Pin Id="DbZ9lq2JSerPdAGcAsBJIf" Name="Flags" Kind="InputPin" DefaultValue="NoResize" />
-                                    <Pin Id="DDU8qFQ7mbhNtJVloiQro1" Name="Context" Kind="OutputPin" />
-                                    <Pin Id="N0Yjth7PcYxLXBmquGVeJb" Name="Is Open" Kind="OutputPin" />
                                     <Patch Id="AXWGvuIgEbvPkXSVkOFJUs" ManuallySortedPins="true">
                                       <Patch Id="L4AUJ5PX2txMR5isUuH8DJ" Name="Create" ManuallySortedPins="true" />
                                       <Patch Id="KhFrZ8zGuiUP4Jrg3YDf9t" Name="Update" ParticipatingElements="Szy7slULhtOP4V0VDZaxkJ,LGOrZ88rbFDN9cktHeiCWr,PWqmnDekOclMYst41sKn39,J5TPgyqWjS3PB8LgENgj1N,LWf7SBCUV38L5QBeUAcZeD,AE015Bgsg8AP34H3XN6OU1,UoalQ4ZchrrLYorPoQ0FVY,T6TeR17mTkqP7OwwNHAZ4R" ManuallySortedPins="true" />
@@ -5602,7 +5594,7 @@
                                         <Pin Id="ClUAjbcds3RO2ya3uMyIAf" Name="Style" Kind="InputPin" />
                                         <Pin Id="ERbBzaXX6PENIBa8bXNiZ5" Name="Context" Kind="OutputPin" />
                                       </Node>
-                                      <Node Bounds="347,552,-5,26" Id="AGHq2gIalOhMljXTBi3Ecg">
+                                      <Node Bounds="347,552,85,26" Id="AGHq2gIalOhMljXTBi3Ecg">
                                         <p:NodeReference LastCategoryFullName="Main.Runtime.LaunchTabRuntime" LastDependency="GammaLauncher.vl">
                                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                           <Choice Kind="OperationCallFlag" Name="KillVvvv" />
@@ -5620,7 +5612,7 @@
                                         <Pin Id="TSigqZLpzoGOLfD8LB9nKW" Name="Output" Kind="StateOutputPin" />
                                         <Pin Id="D3uNGsxBMOpN5u8JJehOCz" Name="Launch Tab Runtime" Kind="OutputPin" />
                                       </Node>
-                                      <Node Bounds="96,433,106,19" Id="DnPV1MSS2GvMIE32zKvCnO">
+                                      <Node Bounds="96,433,106,26" Id="DnPV1MSS2GvMIE32zKvCnO">
                                         <p:NodeReference LastCategoryFullName="Main.App.App" LastDependency="GammaLauncher.vl">
                                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                           <Choice Kind="OperationCallFlag" Name="GetRuntimeChannel" />
@@ -5629,7 +5621,7 @@
                                         <Pin Id="THBnvHXyAABPutr28OxJQH" Name="State Output" Kind="StateOutputPin" />
                                         <Pin Id="QYrHgUL4dkkNj9OJNAulrQ" Name="Output" Kind="OutputPin" />
                                       </Node>
-                                      <Node Bounds="197,470,41,19" Id="Hroho8eEJSHPlDoDJIsmrs">
+                                      <Node Bounds="197,470,45,26" Id="Hroho8eEJSHPlDoDJIsmrs">
                                         <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                           <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -5681,7 +5673,7 @@
                                         <Pin Id="BrP1mktXGO2L81BjF8QWoY" Name="Input 2" Kind="InputPin" />
                                         <Pin Id="IpuApg4phNjPtEed3HS1qc" Name="Output" Kind="StateOutputPin" />
                                       </Node>
-                                      <Node Bounds="565,526" Id="MNKibZhHUGFLc7BieGl0ip">
+                                      <Node Bounds="565,526,85,19" Id="MNKibZhHUGFLc7BieGl0ip">
                                         <p:NodeReference LastCategoryFullName="ImGui.Styling" LastDependency="VL.ImGui.vl">
                                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                           <Choice Kind="ProcessNode" Name="SetButtonStyle" />
@@ -5694,8 +5686,17 @@
                                         <Pin Id="IXFCEcNfSTQLGcrd2e6ZhK" Name="Output" Kind="OutputPin" />
                                       </Node>
                                     </Patch>
+                                    <Pin Id="V2A7q29X75yLW4z4kaDWAf" Name="Context" Kind="InputPin" />
+                                    <Pin Id="QQdnwCqrLbELNzHEjyaFLD" Name="Label" Kind="InputPin" DefaultValue="Kill vvvv" />
+                                    <Pin Id="AuWjYd7mZSlMQOGSbu01hy" Name="Visible" Kind="InputPin" />
+                                    <Pin Id="RnUJEUkll8MNRXUCTR17fa" Name="Closing" Kind="InputPin" />
+                                    <Pin Id="MId2Ek2RsmLNjYAIVFEA7B" Name="Bounds" Kind="InputPin" />
+                                    <Pin Id="SVVwfWgRG4lOy0BmC3WTAQ" Name="Style" Kind="InputPin" />
+                                    <Pin Id="DbZ9lq2JSerPdAGcAsBJIf" Name="Flags" Kind="InputPin" DefaultValue="NoResize" />
+                                    <Pin Id="DDU8qFQ7mbhNtJVloiQro1" Name="Context" Kind="OutputPin" />
+                                    <Pin Id="A0XCrClV4d6PfWDE8x3VgP" Name="Close Clicked" Kind="OutputPin" />
+                                    <Pin Id="Ok1uTfE63IqN4YnxyRxMwq" Name="Content Is Visible" Kind="OutputPin" />
                                   </Node>
-                                  <ControlPoint Id="KxowMrhxlXALa5AfkbEv4C" Bounds="425,354" />
                                   <ControlPoint Id="B3xkq5L6djVP5N5287Go8d" Bounds="86,329" />
                                   <ControlPoint Id="IgmhyuSm0aCPSSy7g1mc7z" Bounds="98,353" />
                                   <Node Bounds="623,246,85,19" Id="HE8Z2q4Ef0TNiaDWNUE1Kd">
@@ -5731,6 +5732,37 @@
                                     <Pin Id="E75w4ldHhHcLkc5oa4PVm7" Name="Border Size" Kind="InputPin" />
                                     <Pin Id="NFikNUgdznuPVXkuEPulv3" Name="Output" Kind="OutputPin" />
                                   </Node>
+                                  <ControlPoint Id="MQb0SuUix8RM9yupCcgmkt" Bounds="271,231" />
+                                  <Node Bounds="361,297,53,19" Id="NUyGZrpUq46M6Rfhj0Zmld">
+                                    <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
+                                      <Choice Kind="ProcessAppFlag" Name="Channel" />
+                                    </p:NodeReference>
+                                    <Pin Id="IKkxyDd9fZ2Mlvn0uLE6G5" Name="Value" Kind="InputPin" />
+                                    <Pin Id="C2EDEdfFJavLUG4nbvBLeR" Name="Output" Kind="OutputPin" />
+                                    <Pin Id="BXvU5bLVYtVL4RkccLLdyk" Name="Value" Kind="OutputPin" />
+                                  </Node>
+                                  <Node Bounds="446,269,53,19" Id="Vz61UxwmxN0N9N4uTHW4Rv">
+                                    <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
+                                      <Choice Kind="ProcessAppFlag" Name="Channel" />
+                                    </p:NodeReference>
+                                    <Pin Id="O5AnFL85musLqlJlKqor86" Name="Value" Kind="InputPin" />
+                                    <Pin Id="EoLqZIY4jkGOhwbEAsLJL9" Name="Output" Kind="OutputPin" />
+                                    <Pin Id="IlTBu31fnRXK9jWLFb6RCD" Name="Value" Kind="OutputPin" />
+                                  </Node>
+                                  <Node Bounds="470,223,61,19" Id="UHfjKqlIrDZNBGaSsRYbqw">
+                                    <p:NodeReference LastCategoryFullName="2D.Rectangle" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <Choice Kind="OperationCallFlag" Name="Rectangle (Join)" />
+                                    </p:NodeReference>
+                                    <Pin Id="PuXnYPZyiyFP3ZNCugpUka" Name="Position" Kind="InputPin" DefaultValue="0.06, 1.35" />
+                                    <Pin Id="VW7xpMCWmY3LuDLtcirzSx" Name="Size" Kind="InputPin" DefaultValue="2.6, 1.15" />
+                                    <Pin Id="Fk4dw5lm3H3O8l02UILgHo" Name="Anchor" Kind="InputPin" />
+                                    <Pin Id="KyKAYDyk1PrQIWyPTop24K" Name="Output" Kind="StateOutputPin" />
+                                  </Node>
                                 </Canvas>
                                 <ProcessDefinition Id="EKud86Ak1icLu4xqN0lJYZ">
                                   <Fragment Id="D59BKqWFHuVLI6j0WoVRQT" Patch="GqGMz46zKeZPQAuSfkRv2l" Enabled="true" />
@@ -5740,8 +5772,6 @@
                                 <Link Id="Szy7slULhtOP4V0VDZaxkJ" Ids="ERbBzaXX6PENIBa8bXNiZ5,FaoYFV2q80VMYuRAR0pGiL" />
                                 <Link Id="LGOrZ88rbFDN9cktHeiCWr" Ids="NShvNd82djkNFT3gqo3gKa,KfXYpIaWJ1iO3vkU3uvOuH" />
                                 <Link Id="HX2uemX65Y7QEMNLuJcFEP" Ids="OpXQy8BkBaLM5ydjCnTugQ,AczjvaXGzFMQBeYdpE8ujq" />
-                                <Link Id="FFobvxEe5xPMrbXUamDfWq" Ids="KxowMrhxlXALa5AfkbEv4C,VnToXBj2y7TOdSitLchTNP" />
-                                <Link Id="DoITt3WfZfaQaEdwaeZYDM" Ids="I5gr81UeEY8QSTzIDjuypM,KxowMrhxlXALa5AfkbEv4C" IsHidden="true" />
                                 <Link Id="JyEUH2CdQonPUDL0ljKhAr" Ids="B3xkq5L6djVP5N5287Go8d,V2A7q29X75yLW4z4kaDWAf" />
                                 <Link Id="RLyreRWezluNS20JjcSzHM" Ids="HeV36lX4eDNOGWJko9V97F,B3xkq5L6djVP5N5287Go8d" IsHidden="true" />
                                 <Link Id="Q9ews37pzUbOr9clvVOLly" Ids="IgmhyuSm0aCPSSy7g1mc7z,OUJruvP4Jw0PcGo3b7PtwN" />
@@ -5750,7 +5780,7 @@
                                 <Patch Id="RLMTpQB5acTQTjOEIuwj4q" Name="Update">
                                   <Pin Id="HeV36lX4eDNOGWJko9V97F" Name="Context" Kind="InputPin" Bounds="329,324" />
                                   <Pin Id="HVIPD0bWtX8Oy0cgTPHOd7" Name="Application" Kind="InputPin" Bounds="348,184" />
-                                  <Pin Id="I5gr81UeEY8QSTzIDjuypM" Name="Is Open" Kind="InputPin" Bounds="622,265" />
+                                  <Pin Id="LM5nyx8bMJlMkSQlnhM5Vl" Name="Visible" Kind="InputPin" Bounds="271,231" />
                                 </Patch>
                                 <Link Id="Hz1lwD0jIL8O3o9khlepuX" Ids="D3uNGsxBMOpN5u8JJehOCz,BnBqMSN3dQaOg42sUf6ns6" />
                                 <Link Id="SyK9Uo39RtPLlyYRmQIZ4n" Ids="QYrHgUL4dkkNj9OJNAulrQ,FvQ5MvplzB8QCC4LWwfnRd" />
@@ -5769,6 +5799,11 @@
                                 <Link Id="BMZJlNJ6ZMZOHXFMHEXWSE" Ids="SyhRkuVZkWiMAeyjqTgMWh,VfBelnzmiFrQTux1jnNYWG" />
                                 <Link Id="NIuQNfKEXENMvYCAxPAzr8" Ids="IMU857CChgQP1H42PEJH36,DJ2ZwT1i2UxO3rWTXN5pQu" />
                                 <Link Id="QqSTtzI9zrWPbgdFkSQIFu" Ids="AjgaCbweK1UPmcLU0ONpY5,DVUC4GUWmxBPCebh1oDtib" />
+                                <Link Id="OnOkvARXvOJMtsBOBzUdKm" Ids="MQb0SuUix8RM9yupCcgmkt,AuWjYd7mZSlMQOGSbu01hy" />
+                                <Link Id="Q7HuexphPNDLdlrB52QhfO" Ids="LM5nyx8bMJlMkSQlnhM5Vl,MQb0SuUix8RM9yupCcgmkt" IsHidden="true" />
+                                <Link Id="EkdXyUMBoF3QF1hpJU7Bu5" Ids="C2EDEdfFJavLUG4nbvBLeR,RnUJEUkll8MNRXUCTR17fa" />
+                                <Link Id="VtlZsjvkynbLMpeejGswCw" Ids="EoLqZIY4jkGOhwbEAsLJL9,MId2Ek2RsmLNjYAIVFEA7B" />
+                                <Link Id="IsVHYR45EEhO87Z8hUcOvO" Ids="KyKAYDyk1PrQIWyPTop24K,O5AnFL85musLqlJlKqor86" />
                               </Patch>
                             </Node>
                           </Canvas>
@@ -5809,7 +5844,7 @@
                         <Pin Id="M10xjcmXeejNLDIpEJuLrb" Name="Rounding" Kind="InputPin" DefaultValue="0" />
                         <Pin Id="KSRRpugAQU0PLba742HtU5" Name="Output" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="580,76,65,19" Id="AZ1iO3vcOigOihedmu5HW5">
+                      <Node Bounds="580,76,85,19" Id="AZ1iO3vcOigOihedmu5HW5">
                         <p:NodeReference LastCategoryFullName="Main.Editor.UI.Editor.Tabs" LastDependency="GammaLauncher.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="Palette" />
@@ -5892,16 +5927,6 @@
                                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                 <Choice Kind="ProcessAppFlag" Name="CollapsingHeader" />
                               </p:NodeReference>
-                              <Pin Id="P46V37KCC9NMPrWfpm4J87" Name="Context" Kind="InputPin" />
-                              <Pin Id="JexMj0A0JW2P78XoqZEZ4x" Name="Label" Kind="InputPin" DefaultValue="Package repositories" />
-                              <Pin Id="TeZlJj5fg5CN88PQTNetVf" Name="Has Close Button" Kind="InputPin" DefaultValue="False" />
-                              <Pin Id="VdJ2NBPHlcVOSg5KsyoBm3" Name="Is Visible" Kind="InputPin" />
-                              <Pin Id="BI6ANcAkutCMidNdOr4zQH" Name="Is Open" Kind="InputPin" />
-                              <Pin Id="CKkM30rLCXcP3jHpzurVaf" Name="Style" Kind="InputPin" />
-                              <Pin Id="JNDB2lBrn0BPblPshKbi5A" Name="Flags" Kind="InputPin" DefaultValue="SpanAvailWidth" />
-                              <Pin Id="CGpf39Xn8CELBO3HeuyvdR" Name="Context" Kind="OutputPin" />
-                              <Pin Id="BbdTj6CUhqaMG5O3z8LUNq" Name="Is Visible" Kind="OutputPin" />
-                              <Pin Id="FTgAOVIrqGoMsItCAgvjtT" Name="Is Open" Kind="OutputPin" />
                               <ControlPoint Id="Tu8kzWZENr6QBaDArKtXWV" Bounds="692,1071" Alignment="Top" />
                               <Patch Id="BGx35HKuQMULeTs5ucP4R6" ManuallySortedPins="true">
                                 <Patch Id="NRlmwz1l94BOGvyMDrVWHm" Name="Create" ManuallySortedPins="true" />
@@ -6134,6 +6159,17 @@
                                   </Patch>
                                 </Node>
                               </Patch>
+                              <Pin Id="P46V37KCC9NMPrWfpm4J87" Name="Context" Kind="InputPin" />
+                              <Pin Id="JexMj0A0JW2P78XoqZEZ4x" Name="Label" Kind="InputPin" DefaultValue="Package repositories" />
+                              <Pin Id="QNRtpg196iBODisOEEQvhj" Name="Visible" Kind="InputPin" />
+                              <Pin Id="GBBBq9sAC6SPIDg2o7v7Ty" Name="Collapsed" Kind="InputPin" />
+                              <Pin Id="F3sPntnsUNoM8YcDISHCFR" Name="Closing" Kind="InputPin" />
+                              <Pin Id="CKkM30rLCXcP3jHpzurVaf" Name="Style" Kind="InputPin" />
+                              <Pin Id="JNDB2lBrn0BPblPshKbi5A" Name="Flags" Kind="InputPin" DefaultValue="SpanAvailWidth" />
+                              <Pin Id="CGpf39Xn8CELBO3HeuyvdR" Name="Context" Kind="OutputPin" />
+                              <Pin Id="PmIIap86AUgMcruN74fLfd" Name="Close Clicked" Kind="OutputPin" />
+                              <Pin Id="Q5BWMR8GsuDMOP8ccdUa6j" Name="Content Is Visible" Kind="OutputPin" />
+                              <Pin Id="TeZlJj5fg5CN88PQTNetVf" Name="Has Close Button" Kind="InputPin" DefaultValue="False" />
                             </Node>
                             <Node Bounds="745,461,41,19" Id="R1tz4VM5ThrMD6wuAGv6Ds">
                               <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
@@ -6358,16 +6394,6 @@
                                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                 <Choice Kind="ProcessAppFlag" Name="CollapsingHeader" />
                               </p:NodeReference>
-                              <Pin Id="UCTr7LmH3vGMAsZYCX2Ukq" Name="Context" Kind="InputPin" />
-                              <Pin Id="BL6bjrD4dGQQT81s218KFN" Name="Label" Kind="InputPin" DefaultValue="Editable Packages" />
-                              <Pin Id="CISTm9JlV2YND2yfcXZKQu" Name="Has Close Button" Kind="InputPin" DefaultValue="False" />
-                              <Pin Id="JAYGkNh9cJbPW9igdefhbS" Name="Is Visible" Kind="InputPin" />
-                              <Pin Id="LScNY6SnmjSN57Xo0skiBq" Name="Is Open" Kind="InputPin" />
-                              <Pin Id="UDdvfgvcLLcPmSayPzZknJ" Name="Style" Kind="InputPin" />
-                              <Pin Id="BeSmanyU4V2NMiOCyMlKL8" Name="Flags" Kind="InputPin" DefaultValue="SpanAvailWidth" />
-                              <Pin Id="Sgmckc5AxWbN19WAczxT95" Name="Context" Kind="OutputPin" />
-                              <Pin Id="NiMwhyjTGCjOceVvOtTicf" Name="Is Visible" Kind="OutputPin" />
-                              <Pin Id="HebjhhEbGZSOQ8c5m47fOA" Name="Is Open" Kind="OutputPin" />
                               <ControlPoint Id="BxFUAWGB2wwOhnQQMc6TMZ" Bounds="687,2003" Alignment="Top" />
                               <Patch Id="JQ5JT7eYsCbMWHQx9MWhHX" ManuallySortedPins="true">
                                 <Patch Id="A5pRTs3mEuVNeXrMW37K8d" Name="Create" ManuallySortedPins="true" />
@@ -6583,6 +6609,17 @@
                                   </Patch>
                                 </Node>
                               </Patch>
+                              <Pin Id="UCTr7LmH3vGMAsZYCX2Ukq" Name="Context" Kind="InputPin" />
+                              <Pin Id="BL6bjrD4dGQQT81s218KFN" Name="Label" Kind="InputPin" DefaultValue="Editable Packages" />
+                              <Pin Id="Oq2HTbbwrXALCOaK4536ri" Name="Visible" Kind="InputPin" />
+                              <Pin Id="EBT6xCwb165PguEgYtx9Oo" Name="Collapsed" Kind="InputPin" />
+                              <Pin Id="Qn3cq0nLpKgPGXpD9chuOf" Name="Closing" Kind="InputPin" />
+                              <Pin Id="UDdvfgvcLLcPmSayPzZknJ" Name="Style" Kind="InputPin" />
+                              <Pin Id="BeSmanyU4V2NMiOCyMlKL8" Name="Flags" Kind="InputPin" DefaultValue="SpanAvailWidth" />
+                              <Pin Id="Sgmckc5AxWbN19WAczxT95" Name="Context" Kind="OutputPin" />
+                              <Pin Id="Dpy6VULIYwdQQ5xuzfT4TT" Name="Close Clicked" Kind="OutputPin" />
+                              <Pin Id="PZqtRAZ1LOKPtNwienxJFt" Name="Content Is Visible" Kind="OutputPin" />
+                              <Pin Id="CISTm9JlV2YND2yfcXZKQu" Name="Has Close Button" Kind="InputPin" DefaultValue="False" />
                             </Node>
                             <ControlPoint Id="Iv5y2s3RxO3QJvhGOpySfl" Bounds="412,564" />
                             <Pad Id="LkrMtExgm5NPl3NiAheu5O" Bounds="411,1913" />
@@ -6929,16 +6966,6 @@
                                     <CategoryReference Kind="Category" Name="Widgets" />
                                     <Choice Kind="ProcessAppFlag" Name="CollapsingHeader" />
                                   </p:NodeReference>
-                                  <Pin Id="TOmQbL9TvQZPzbCArpJDqL" Name="Context" Kind="InputPin" />
-                                  <Pin Id="OwQWefdgWGLNo8imy01asL" Name="Label" Kind="InputPin" />
-                                  <Pin Id="VhcASXTPYOlLOdd8eLAZ8l" Name="Has Close Button" Kind="InputPin" DefaultValue="False" />
-                                  <Pin Id="SVpaSIOE96GOGmwkOqN1rF" Name="Is Visible" Kind="InputPin" />
-                                  <Pin Id="Rfe6pCS6uNWNY6jUTgRbBm" Name="Is Open" Kind="InputPin" />
-                                  <Pin Id="JiBtbrBL5TvPhkMqeATp1v" Name="Style" Kind="InputPin" />
-                                  <Pin Id="ELP23PXhNHeNjB1iNrrtN6" Name="Flags" Kind="InputPin" />
-                                  <Pin Id="Ji5Q9F3ZAg8PxedQc6GOZK" Name="Context" Kind="OutputPin" />
-                                  <Pin Id="HqDhJBXmABsQEEgxx2M2w0" Name="Is Visible" Kind="OutputPin" />
-                                  <Pin Id="ExoxlUmoBUTNGtneOHEaHi" Name="Is Open" Kind="OutputPin" />
                                   <ControlPoint Id="JqoYGjWLG53NcR7MJv2ilF" Bounds="597,1945" Alignment="Bottom" />
                                   <Patch Id="GGDKPzpg8N8LkKO6pyS92t" ManuallySortedPins="true">
                                     <Patch Id="U3KnBdOuhdsLxR5foTtlGR" Name="Create" ManuallySortedPins="true" />
@@ -7179,6 +7206,17 @@
                                       </Patch>
                                     </Node>
                                   </Patch>
+                                  <Pin Id="TOmQbL9TvQZPzbCArpJDqL" Name="Context" Kind="InputPin" />
+                                  <Pin Id="OwQWefdgWGLNo8imy01asL" Name="Label" Kind="InputPin" />
+                                  <Pin Id="ORTOJO48dPSMWlat8Jir5z" Name="Visible" Kind="InputPin" />
+                                  <Pin Id="SUXFqXJsbWwNeRdWSkSfCO" Name="Collapsed" Kind="InputPin" />
+                                  <Pin Id="JTtpxAfW7WLN9c5bwIQdjs" Name="Closing" Kind="InputPin" />
+                                  <Pin Id="JiBtbrBL5TvPhkMqeATp1v" Name="Style" Kind="InputPin" />
+                                  <Pin Id="ELP23PXhNHeNjB1iNrrtN6" Name="Flags" Kind="InputPin" />
+                                  <Pin Id="Ji5Q9F3ZAg8PxedQc6GOZK" Name="Context" Kind="OutputPin" />
+                                  <Pin Id="KLVxiFdGENSMDF7H2bZEGl" Name="Close Clicked" Kind="OutputPin" />
+                                  <Pin Id="TY3KeNJOjkAMQK8MUfZXK7" Name="Content Is Visible" Kind="OutputPin" />
+                                  <Pin Id="VhcASXTPYOlLOdd8eLAZ8l" Name="Has Close Button" Kind="InputPin" DefaultValue="False" />
                                 </Node>
                                 <Node Bounds="555,936,65,26" Id="Vry2nE5ivspMRDKDNKxFk4">
                                   <p:NodeReference LastCategoryFullName="Collections.Common.KeyValuePair" LastDependency="VL.CoreLib.vl">
@@ -7328,14 +7366,15 @@
                               </Patch>
                               <Pin Id="S4BzZpU7hsVMsHbNfHmR6d" Name="Context" Kind="InputPin" />
                               <Pin Id="PVi32pfoqhMP5tcsHuo6ze" Name="Label" Kind="InputPin" DefaultValue="vvvv" />
-                              <Pin Id="BRjMAYWxXhbOw4HXfE4KxL" Name="Has Close Button" Kind="InputPin" DefaultValue="False" />
-                              <Pin Id="LQWjgIThA4PQJXO9RiXlTX" Name="Is Visible" Kind="InputPin" />
-                              <Pin Id="IUQh7YaiwfuMNkrZjBQN3V" Name="Is Open" Kind="InputPin" />
+                              <Pin Id="RdFUwG0ChNoLWTBZBlErXp" Name="Visible" Kind="InputPin" />
+                              <Pin Id="JWD59sNW0ZHOwBWiamHNxk" Name="Collapsed" Kind="InputPin" />
+                              <Pin Id="HvZJDEEay7NN6L94eFZYR2" Name="Closing" Kind="InputPin" />
                               <Pin Id="SqGNjSKd5G2P67BPZnhqu3" Name="Style" Kind="InputPin" />
                               <Pin Id="AINjSqdjXi7LfwlpgLqmW6" Name="Flags" Kind="InputPin" DefaultValue="Leaf" />
                               <Pin Id="M8HhGyREu9aOyBi4ZfvJB7" Name="Context" Kind="OutputPin" />
-                              <Pin Id="KFs92fbBVVQLHzGIvyASbe" Name="Is Visible" Kind="OutputPin" />
-                              <Pin Id="LKEAIFPSTqQOpaB60QVOMu" Name="Is Open" Kind="OutputPin" />
+                              <Pin Id="EIeBFkQ4LXMNRnmr59VZLy" Name="Close Clicked" Kind="OutputPin" />
+                              <Pin Id="R7S2ciqQvfpPy4JEPd0Jm7" Name="Content Is Visible" Kind="OutputPin" />
+                              <Pin Id="BRjMAYWxXhbOw4HXfE4KxL" Name="Has Close Button" Kind="InputPin" DefaultValue="False" />
                             </Node>
                             <Node Bounds="637,660,84,19" Id="UwBmvDC06jFMcVGP6x21nI">
                               <p:NodeReference LastCategoryFullName="ImGui.Styling" LastDependency="VL.ImGui.vl">
@@ -7441,14 +7480,15 @@
                                   </Patch>
                                   <Pin Id="TKrBjzVnQhLMPA2JudY9Ny" Name="Context" Kind="InputPin" />
                                   <Pin Id="CeJeYBbpJ1GPCzfDDTzn5c" Name="Label" Kind="InputPin" DefaultValue="GammaLauncher" />
-                                  <Pin Id="Q5AaVZJuk3mMYZCXfVmBG4" Name="Has Close Button" Kind="InputPin" DefaultValue="False" />
-                                  <Pin Id="Fd92qCHqO4kMMEtN2CTI2Z" Name="Is Visible" Kind="InputPin" />
-                                  <Pin Id="Jc4YfTVKJ47OqCnS1SRF27" Name="Is Open" Kind="InputPin" />
+                                  <Pin Id="Sitdx0Gb0bpNhECdZnuejJ" Name="Visible" Kind="InputPin" />
+                                  <Pin Id="QsUjNSljG3kNtaX1AlVyDN" Name="Collapsed" Kind="InputPin" />
+                                  <Pin Id="GhPRn5dkBGEMny0R1R9lDw" Name="Closing" Kind="InputPin" />
                                   <Pin Id="GZEdmxL2EFhOzFkyeEmiml" Name="Style" Kind="InputPin" />
                                   <Pin Id="EKUMloECiBKN6xMA4hAqQJ" Name="Flags" Kind="InputPin" DefaultValue="Leaf" />
                                   <Pin Id="KAeukF2wdOzMBEWtoLJZOD" Name="Context" Kind="OutputPin" />
-                                  <Pin Id="DvX6tol1iHhNfFbAxtkANP" Name="Is Visible" Kind="OutputPin" />
-                                  <Pin Id="HosdDRgCdTxNARFUJ365Pn" Name="Is Open" Kind="OutputPin" />
+                                  <Pin Id="FJVZLb04sFJLDUfaaBvpFV" Name="Close Clicked" Kind="OutputPin" />
+                                  <Pin Id="BTgNrjhj9vTN4JtlSdaIoi" Name="Content Is Visible" Kind="OutputPin" />
+                                  <Pin Id="Q5AaVZJuk3mMYZCXfVmBG4" Name="Has Close Button" Kind="InputPin" DefaultValue="False" />
                                 </Node>
                                 <Node Bounds="451,2328,157,26" Id="JmWnLQ7FlUUQNEuZG2OL4f">
                                   <p:NodeReference LastCategoryFullName="Main.Runtime.UpdatesTabRuntime" LastDependency="GammaLauncher.vl">
@@ -7829,7 +7869,7 @@
                   </p:NodeReference>
                   <Patch Id="Mq8n8Q39dogLgfWFoOgFjN">
                     <Canvas Id="J0ei1Nwm1MYL8Ty3Fh69VA" CanvasType="Group">
-                      <Node Bounds="401,178,598,1884" Id="LQpdBsrfsv3L9oUO99SiM6">
+                      <Node Bounds="401,178,646,1894" Id="LQpdBsrfsv3L9oUO99SiM6">
                         <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                           <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="MainMenuBar" />
@@ -7837,7 +7877,7 @@
                         <Pin Id="IfguqG0Am4kPdKTnSFW1y5" Name="Context" Kind="InputPin" />
                         <Pin Id="TnKireA5BIcOubXRdKjcjv" Name="Style" Kind="InputPin" />
                         <Pin Id="TCMIVqEalmVNbDEH0wa1dZ" Name="Context" Kind="OutputPin" />
-                        <ControlPoint Id="DYy2RUsnFxINniieYmghGX" Bounds="448,209" Alignment="Top" />
+                        <ControlPoint Id="DYy2RUsnFxINniieYmghGX" Bounds="448,184" Alignment="Top" />
                         <Patch Id="FFXYBmtDhnhMXeUEJHVpCt" ManuallySortedPins="true">
                           <Node Bounds="446,228,272,344" Id="O41pEEMreFuN3Io9hqd2mm">
                             <p:NodeReference LastCategoryFullName="ImGui.Widgets.Immediate" LastDependency="VL.ImGui.vl">
@@ -7849,6 +7889,7 @@
                             <Pin Id="AmkXaclcrsGMmtYmRdaLg5" Name="Enabled" Kind="InputPin" />
                             <Pin Id="EiCAcVgFBIaPHAcSGp7g8n" Name="Style" Kind="InputPin" />
                             <Pin Id="A9FflVhJ7vNP4P4XDO8tB2" Name="Context" Kind="OutputPin" />
+                            <ControlPoint Id="MXsTB4UFZhQLibwRsjCana" Bounds="530,234" Alignment="Top" />
                             <Patch Id="HyrYCCqw3QlOnUzXrajRGa" ManuallySortedPins="true">
                               <Patch Id="MyuU0bbSaAaQOfCHeASduC" Name="Create" ManuallySortedPins="true" />
                               <Patch Id="JMgjl4F91NkMZEQ5n0n5J9" Name="Update" ParticipatingElements="USlHbT4JANHP8hUpr1j9KD,P9KXGs4UUbSP1PkMejqzg1,Vj2b1Vvw6oYNm8xlg9s0PG" ManuallySortedPins="true" />
@@ -7857,7 +7898,7 @@
                                   <Choice Kind="TypeFlag" Name="String" />
                                 </p:TypeAnnotation>
                               </Pad>
-                              <Node Bounds="528,437,105,19" Id="Aqq4xUC6TtELVjnn3k8fkc">
+                              <Node Bounds="528,437,145,19" Id="Aqq4xUC6TtELVjnn3k8fkc">
                                 <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="ProcessNode" Name="MenuItem" />
@@ -7867,6 +7908,8 @@
                                 <Pin Id="Gnowl7d56KNOlkIR8LmHjp" Name="Label" Kind="InputPin" />
                                 <Pin Id="OPKEmRyZN3MQYrmWXCQnVb" Name="Shortcut" Kind="InputPin" DefaultValue="CTRL+," />
                                 <Pin Id="HurUwz1PcBlNL3RF1aaWKb" Name="Enabled" Kind="InputPin" DefaultValue="True" />
+                                <Pin Id="AirHb7bjPrtOCeQYwsnPem" Name="Selectable" Kind="InputPin" />
+                                <Pin Id="TBu0i2WevBdMO6FUNqjXlc" Name="Is Selected" Kind="InputPin" />
                                 <Pin Id="V2myFppw1VtQNiQ2GImMcO" Name="Style" Kind="InputPin" />
                                 <Pin Id="CRe2YEOwUx0M3nedI9caph" Name="Context" Kind="OutputPin" />
                                 <Pin Id="UA3gKev5NZYOXZyz3wjzEo" Name="Bang" Kind="OutputPin" />
@@ -7913,10 +7956,12 @@
                                   <Choice Kind="ApplicationStatefulRegion" Name="If" />
                                 </p:NodeReference>
                                 <Pin Id="C1rcUsBD3g2OreosMdpW1K" Name="Condition" Kind="InputPin" />
+                                <ControlPoint Id="Gxz0zL7AmXNNgclDuBR3h1" Bounds="530,402" Alignment="Bottom" />
+                                <ControlPoint Id="HaLnxax58CXPGguJyuBkft" Bounds="530,254" Alignment="Top" />
                                 <Patch Id="C7qbyPuLcVSMLaoyD6ZY9H" ManuallySortedPins="true">
                                   <Patch Id="MIq4LOK0jgCQTdYRAR6tQy" Name="Create" ManuallySortedPins="true" />
                                   <Patch Id="AsGuRWdYed2OHRBf9Kywxp" Name="Then" ManuallySortedPins="true" />
-                                  <Node Bounds="528,293,105,19" Id="AbAzczutGrrOkFVHCGlgu3">
+                                  <Node Bounds="528,293,145,19" Id="AbAzczutGrrOkFVHCGlgu3">
                                     <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <Choice Kind="ProcessNode" Name="MenuItem" />
@@ -7926,6 +7971,8 @@
                                     <Pin Id="GZEuVZOAq0PMomRIpPDoId" Name="Label" Kind="InputPin" />
                                     <Pin Id="PocAyxb04pNNatNOtr0lYC" Name="Shortcut" Kind="InputPin" />
                                     <Pin Id="G95FKYyQ1cLM8wkWrwCyUD" Name="Enabled" Kind="InputPin" />
+                                    <Pin Id="AwNvJz3yYjsLMfdsF3gGoD" Name="Selectable" Kind="InputPin" />
+                                    <Pin Id="JVojMA1hHu9LNMERYQ99sC" Name="Is Selected" Kind="InputPin" />
                                     <Pin Id="Lp1n6JFgOw4Oas1smQPG6R" Name="Style" Kind="InputPin" />
                                     <Pin Id="IDLYAm8LY2lOZ275rNuC0L" Name="Context" Kind="OutputPin" />
                                     <Pin Id="Nh2tkInEmkmMG06JbdLY3C" Name="Bang" Kind="OutputPin" />
@@ -7941,7 +7988,7 @@
                                       <Choice Kind="TypeFlag" Name="String" />
                                     </p:TypeAnnotation>
                                   </Pad>
-                                  <Node Bounds="528,368,105,19" Id="EwxfSSn8jF8PrDz3GXIaNl">
+                                  <Node Bounds="528,368,145,19" Id="EwxfSSn8jF8PrDz3GXIaNl">
                                     <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <Choice Kind="ProcessNode" Name="MenuItem" />
@@ -7951,17 +7998,16 @@
                                     <Pin Id="JF7zdzQtSAKOgahxqGztAJ" Name="Label" Kind="InputPin" />
                                     <Pin Id="VtjPnBtVPwqNawxt1lJlet" Name="Shortcut" Kind="InputPin" />
                                     <Pin Id="NnhDItWrSEYO1zGuRSod9e" Name="Enabled" Kind="InputPin" />
+                                    <Pin Id="KyLfaVC8XmbM06vf3CAq0b" Name="Selectable" Kind="InputPin" />
+                                    <Pin Id="ORzqyAN9di1LzeVS1wjGP7" Name="Is Selected" Kind="InputPin" />
                                     <Pin Id="LaGIea23DeLMWmqZfakuLb" Name="Style" Kind="InputPin" />
                                     <Pin Id="MLlDbwewlMqMx9YZgbRkcZ" Name="Context" Kind="OutputPin" />
                                     <Pin Id="GEfDPWUqTvtMu9WtrGlaw5" Name="Bang" Kind="OutputPin" />
                                     <Pin Id="Exp5ro0gih6PsahoVZ1N6o" Name="Value" Kind="OutputPin" />
                                   </Node>
                                 </Patch>
-                                <ControlPoint Id="Gxz0zL7AmXNNgclDuBR3h1" Bounds="530,402" Alignment="Bottom" />
-                                <ControlPoint Id="HaLnxax58CXPGguJyuBkft" Bounds="530,263" Alignment="Top" />
                               </Node>
                             </Patch>
-                            <ControlPoint Id="MXsTB4UFZhQLibwRsjCana" Bounds="530,236" Alignment="Top" />
                           </Node>
                           <Pad Id="Qeyqvm7o1UuNXBJdwETs2E" Comment="Label" Bounds="537,206,39,15" ShowValueBox="true" isIOBox="true" Value="File">
                             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
@@ -7978,10 +8024,11 @@
                             <Pin Id="HetkmK4JU72NrQAfqjKJsq" Name="Enabled" Kind="InputPin" />
                             <Pin Id="Lkg2L3S0u2bM2Fjz1fqmvR" Name="Style" Kind="InputPin" />
                             <Pin Id="GaY3CjCJADXLlEzckSDd6i" Name="Context" Kind="OutputPin" />
+                            <ControlPoint Id="HspgdOwvZs0P4iVTQFakIR" Bounds="494,662" Alignment="Top" />
                             <Patch Id="ItutXmlUqvONh2UHZwRIi9" ManuallySortedPins="true">
                               <Patch Id="UkldBGFHcLTOQ4lSQUN3ZJ" Name="Create" ManuallySortedPins="true" />
                               <Patch Id="N6i4b14HZKOMKPCbLuWs1X" Name="Update" ParticipatingElements="VQ4yysmdrAnMypUoqtzoYE,V3qcyQ7Y5pKLaopZL5oxBT,JKQD01ULpPyN83aED5rN74,JF7o5iYZMzFMPQcHmX5F0t,C0Np9VbNsh2LfA7cj402wa,Pmp9kSZXZwxOxi7G66i690,Ccun4dqU1W8OvOXRcdOKEp,GYZaAh655K9L4TIb43IKvX,C7ihyZ0CxzWOHaJXYFuOvC,UmHvdS3DIeGMnBPROHL9H4" ManuallySortedPins="true" />
-                              <Node Bounds="492,702,105,19" Id="PgkAupvIzKAQHB1GCEjaWG">
+                              <Node Bounds="492,702,145,19" Id="PgkAupvIzKAQHB1GCEjaWG">
                                 <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="ProcessNode" Name="MenuItem" />
@@ -7991,17 +8038,19 @@
                                 <Pin Id="UtSrgMfz9AAL25p5rXtzsA" Name="Label" Kind="InputPin" />
                                 <Pin Id="Iq68u5UvakGLXfRTtfDwQO" Name="Shortcut" Kind="InputPin" DefaultValue="" />
                                 <Pin Id="E6s7tIc4lk1O5ZO31J9tRR" Name="Enabled" Kind="InputPin" />
+                                <Pin Id="EiJ5JLeU2DZN5vaMmRxvPl" Name="Selectable" Kind="InputPin" />
+                                <Pin Id="P4FvzMlUHC8QXmBYjjo4Jl" Name="Is Selected" Kind="InputPin" />
                                 <Pin Id="RUz2hTQngVJPnA7RznVArS" Name="Style" Kind="InputPin" />
                                 <Pin Id="Qbb0gQRGQyPOicJ4068Hbg" Name="Context" Kind="OutputPin" />
                                 <Pin Id="FtMJ823mqO5OW2oCCn4DR6" Name="Bang" Kind="OutputPin" />
                                 <Pin Id="AtRnZ0GvNYVMy6FpS5566E" Name="Value" Kind="OutputPin" />
                               </Node>
-                              <Pad Id="I2azmfJ0WUBOTZyvwHcxPe" Comment="Label" Bounds="534,685,151,8" ShowValueBox="true" isIOBox="true" Value="Show package repositories">
+                              <Pad Id="I2azmfJ0WUBOTZyvwHcxPe" Comment="Label" Bounds="534,685,151,15" ShowValueBox="true" isIOBox="true" Value="Show package repositories">
                                 <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                                   <Choice Kind="TypeFlag" Name="String" />
                                 </p:TypeAnnotation>
                               </Pad>
-                              <Node Bounds="492,819,105,19" Id="GON1Q3UflobLFJTELReLD7">
+                              <Node Bounds="492,819,145,19" Id="GON1Q3UflobLFJTELReLD7">
                                 <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="ProcessNode" Name="MenuItem" />
@@ -8011,17 +8060,19 @@
                                 <Pin Id="DAYumYG7JRFOrvComr0TXc" Name="Label" Kind="InputPin" />
                                 <Pin Id="RNy4xsZvL67M1Gn11R7ElD" Name="Shortcut" Kind="InputPin" />
                                 <Pin Id="Ec8nc8nLDp0LgGgciyrF6h" Name="Enabled" Kind="InputPin" />
+                                <Pin Id="BGov1yhpIklPmFlcHWNTCc" Name="Selectable" Kind="InputPin" />
+                                <Pin Id="U2T0FNRUgC7NTLpLcxRP5T" Name="Is Selected" Kind="InputPin" />
                                 <Pin Id="DAqwtHysS5WP76wJ2uQeh2" Name="Style" Kind="InputPin" />
                                 <Pin Id="AHeXjyoitheLd7iHwuMKhg" Name="Context" Kind="OutputPin" />
                                 <Pin Id="F3XtrppGUezNrxGnEROSl8" Name="Bang" Kind="OutputPin" />
                                 <Pin Id="QDNKqnkqpllP3nrgayR975" Name="Value" Kind="OutputPin" />
                               </Node>
-                              <Pad Id="Jri2PjKPsxuNIt8QZVQ51b" Comment="Label" Bounds="534,804,164,4" ShowValueBox="true" isIOBox="true" Value="Show default nugets">
+                              <Pad Id="Jri2PjKPsxuNIt8QZVQ51b" Comment="Label" Bounds="534,804,164,15" ShowValueBox="true" isIOBox="true" Value="Show default nugets">
                                 <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                                   <Choice Kind="TypeFlag" Name="String" />
                                 </p:TypeAnnotation>
                               </Pad>
-                              <Node Bounds="492,933,105,19" Id="PxOOpk2ji8sQBvGeu4l01x">
+                              <Node Bounds="492,933,145,19" Id="PxOOpk2ji8sQBvGeu4l01x">
                                 <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="ProcessNode" Name="MenuItem" />
@@ -8031,6 +8082,8 @@
                                 <Pin Id="G1AKL6Wp3DhQLHpyRnVTHS" Name="Label" Kind="InputPin" />
                                 <Pin Id="Un6ilSvvmiALUj57rFI9gc" Name="Shortcut" Kind="InputPin" />
                                 <Pin Id="B8r4JteMvWWOJNIQ3Bq8NW" Name="Enabled" Kind="InputPin" />
+                                <Pin Id="S5h2UpWPr9LM8k5m3GROKJ" Name="Selectable" Kind="InputPin" />
+                                <Pin Id="TrYWv6I9QcjOl15gLjFrEn" Name="Is Selected" Kind="InputPin" />
                                 <Pin Id="MjcBivmeo6MPVN5q3pls0Y" Name="Style" Kind="InputPin" />
                                 <Pin Id="K5VDk2mMN7ELPOHGhdjRYO" Name="Context" Kind="OutputPin" />
                                 <Pin Id="TMn4A9dTzkrMhHTyWRqReu" Name="Bang" Kind="OutputPin" />
@@ -8041,7 +8094,7 @@
                                   <Choice Kind="TypeFlag" Name="String" />
                                 </p:TypeAnnotation>
                               </Pad>
-                              <Node Bounds="492,1043,105,19" Id="FxYwkTRR5d0PABCliih4CU">
+                              <Node Bounds="492,1043,145,19" Id="FxYwkTRR5d0PABCliih4CU">
                                 <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="ProcessNode" Name="MenuItem" />
@@ -8051,6 +8104,8 @@
                                 <Pin Id="Ahzd2jMwq4uMV2cGTVm9yW" Name="Label" Kind="InputPin" />
                                 <Pin Id="OeUvN53zrRLPkCUaGSq9ii" Name="Shortcut" Kind="InputPin" DefaultValue="" />
                                 <Pin Id="LnxdnSBLo1ZMePO6pNHWzx" Name="Enabled" Kind="InputPin" />
+                                <Pin Id="Mriks1ul4iPMjit2UOM3vd" Name="Selectable" Kind="InputPin" />
+                                <Pin Id="KwetT82m5vXLpRh98tEhy1" Name="Is Selected" Kind="InputPin" />
                                 <Pin Id="REVXRTIlFOfPp6Fn8LkQBR" Name="Style" Kind="InputPin" />
                                 <Pin Id="BUCGSwGUU4vNomCbpcDjIL" Name="Context" Kind="OutputPin" />
                                 <Pin Id="MeMynhhXHmCMGzc2WB2xh0" Name="Bang" Kind="OutputPin" />
@@ -8061,7 +8116,7 @@
                                   <Choice Kind="TypeFlag" Name="String" />
                                 </p:TypeAnnotation>
                               </Pad>
-                              <Node Bounds="492,1136,105,19" Id="MQxKgJzaGcoPUWSl9pgB44">
+                              <Node Bounds="492,1136,145,19" Id="MQxKgJzaGcoPUWSl9pgB44">
                                 <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="ProcessNode" Name="MenuItem" />
@@ -8071,6 +8126,8 @@
                                 <Pin Id="KQtfgJSJ8dZPoe5ZrMPLMs" Name="Label" Kind="InputPin" />
                                 <Pin Id="ETZ04iVBgoTNYfGoQBSLRQ" Name="Shortcut" Kind="InputPin" DefaultValue="ALT+E" />
                                 <Pin Id="I1hipu6gO9rMQAerCawtGO" Name="Enabled" Kind="InputPin" />
+                                <Pin Id="UJbg73g9kC9QT1Lk6JGW1p" Name="Selectable" Kind="InputPin" />
+                                <Pin Id="BjWxqVJdDNUMZPFSSEAvqw" Name="Is Selected" Kind="InputPin" />
                                 <Pin Id="EIig8R3QgYoOgvBIs9yiJq" Name="Style" Kind="InputPin" />
                                 <Pin Id="ALmjV21Gh0HLjinc1QSH4R" Name="Context" Kind="OutputPin" />
                                 <Pin Id="MH3PAZQKVxBMBTSnGWDPst" Name="Bang" Kind="OutputPin" />
@@ -8081,7 +8138,7 @@
                                   <Choice Kind="TypeFlag" Name="String" />
                                 </p:TypeAnnotation>
                               </Pad>
-                              <Node Bounds="492,1359,105,19" Id="EW968D5z0H1MAtQTgBsgYy">
+                              <Node Bounds="492,1359,145,19" Id="EW968D5z0H1MAtQTgBsgYy">
                                 <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="ProcessNode" Name="MenuItem" />
@@ -8091,6 +8148,8 @@
                                 <Pin Id="UhNQuMPTSCuPsJi2kcFWAB" Name="Label" Kind="InputPin" />
                                 <Pin Id="A740PyI8ExzOJ7FdWaiLg1" Name="Shortcut" Kind="InputPin" DefaultValue="SHIFT+F5" />
                                 <Pin Id="NnHDTcwHohmM1uos2pcjKF" Name="Enabled" Kind="InputPin" />
+                                <Pin Id="Tut2LE8FHqhPt2wQn9UzjT" Name="Selectable" Kind="InputPin" />
+                                <Pin Id="RHrGS8qU6FrMuO6KtcjMOA" Name="Is Selected" Kind="InputPin" />
                                 <Pin Id="GaVtRywbc6pORRe1Gxmkjo" Name="Style" Kind="InputPin" />
                                 <Pin Id="FLn4yocEdC7QK2frNntAFS" Name="Context" Kind="OutputPin" />
                                 <Pin Id="VCXSpAlZLmZP4sh6OtQ8s5" Name="Bang" Kind="OutputPin" />
@@ -8129,7 +8188,7 @@
                                 <Pin Id="TEFkUF1xPL9LhcvtPVRtyX" Name="Output" Kind="StateOutputPin" />
                                 <Pin Id="LDUqDPFtORrLaClCJi6tKj" Name="Apply" Kind="InputPin" />
                               </Node>
-                              <Node Bounds="475,1081,72,19" Id="KbrR0Et8bxON0jzoeRtcpU">
+                              <Node Bounds="475,1081,72,26" Id="KbrR0Et8bxON0jzoeRtcpU">
                                 <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -8159,7 +8218,7 @@
                                 <Pin Id="Nw0mnMbOxYyLdCeMGQDba5" Name="Output" Kind="StateOutputPin" />
                                 <Pin Id="S3rBQbAbVsHNWDZGQa6gjq" Name="Apply" Kind="InputPin" />
                               </Node>
-                              <Node Bounds="493,1257,105,19" Id="TwF8PpQNAMqPbMTm8s5ckQ">
+                              <Node Bounds="493,1257,145,19" Id="TwF8PpQNAMqPbMTm8s5ckQ">
                                 <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="ProcessNode" Name="MenuItem" />
@@ -8169,6 +8228,8 @@
                                 <Pin Id="H4a0S8Ce92UOcFlHjb5wdN" Name="Label" Kind="InputPin" />
                                 <Pin Id="KL0HKjsgeWWMDk8rbeYYQH" Name="Shortcut" Kind="InputPin" DefaultValue="CTRL+U" />
                                 <Pin Id="NOayoIOmgdTMBP9vVvIgJW" Name="Enabled" Kind="InputPin" />
+                                <Pin Id="Rt9Ovf4KsOkLKDNWbIRHTF" Name="Selectable" Kind="InputPin" />
+                                <Pin Id="Hr50LgB1xmoMAlyDzsiPjw" Name="Is Selected" Kind="InputPin" />
                                 <Pin Id="VkEnLoR4Ri4Ptr0C6TKyqj" Name="Style" Kind="InputPin" />
                                 <Pin Id="G84yaHt2A3yPVHcWhSd5EM" Name="Context" Kind="OutputPin" />
                                 <Pin Id="EEpxv5IlYm7QDEOa7crtkn" Name="Bang" Kind="OutputPin" />
@@ -8188,7 +8249,7 @@
                                 <Pin Id="R5jy2kYRENUNJnbc0Hjk3Z" Name="Output" Kind="StateOutputPin" />
                                 <Pin Id="HW94xa2rAydL7nqIUG1eBx" Name="Apply" Kind="InputPin" />
                               </Node>
-                              <Node Bounds="491,1471,105,19" Id="Q9rqOruacnyN8dolaMT4dN">
+                              <Node Bounds="491,1471,145,19" Id="Q9rqOruacnyN8dolaMT4dN">
                                 <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="ProcessNode" Name="MenuItem" />
@@ -8198,6 +8259,8 @@
                                 <Pin Id="EMu8WewuXrsMfR5ORd3d7k" Name="Label" Kind="InputPin" />
                                 <Pin Id="AmNeWfeNzvDMPdrprF4fAK" Name="Shortcut" Kind="InputPin" DefaultValue="F5" />
                                 <Pin Id="IHD5697pilCO3Zr8C7CZF3" Name="Enabled" Kind="InputPin" />
+                                <Pin Id="DE6Hvh55XMXP9wvw7DHziC" Name="Selectable" Kind="InputPin" />
+                                <Pin Id="LaLap1H7Hk0Ox41MlgZrzM" Name="Is Selected" Kind="InputPin" />
                                 <Pin Id="KYpeu0F8wZCLadDBBV4Bdp" Name="Style" Kind="InputPin" />
                                 <Pin Id="SKyd3CGiuNVOhOLWgN8vNv" Name="Context" Kind="OutputPin" />
                                 <Pin Id="CAQMuna9BxVOz9lKY4dZI2" Name="Bang" Kind="OutputPin" />
@@ -8218,14 +8281,13 @@
                                 <Pin Id="NWmqooYKt3WQNkmmok6n9K" Name="Apply" Kind="InputPin" />
                               </Node>
                             </Patch>
-                            <ControlPoint Id="HspgdOwvZs0P4iVTQFakIR" Bounds="494,663" Alignment="Top" />
                           </Node>
                           <Pad Id="L0c25gVlEwsQYxtOz7dQps" Comment="Label" Bounds="550,631,42,15" ShowValueBox="true" isIOBox="true" Value="Edit">
                             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="TypeFlag" Name="String" />
                             </p:TypeAnnotation>
                           </Pad>
-                          <Node Bounds="448,1671,168,371" Id="OlRhaMX9Vo2NaIgl58pABj">
+                          <Node Bounds="448,1671,186,381" Id="OlRhaMX9Vo2NaIgl58pABj">
                             <p:NodeReference LastCategoryFullName="ImGui.Widgets.Immediate" LastDependency="VL.ImGui.vl">
                               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                               <Choice Kind="ProcessAppFlag" Name="Menu" />
@@ -8235,10 +8297,11 @@
                             <Pin Id="NVQElBUs6u6MWm0MYn78H7" Name="Enabled" Kind="InputPin" />
                             <Pin Id="SuBNPoEc544LpquWPNQ2wc" Name="Style" Kind="InputPin" />
                             <Pin Id="JcPWztfwWWOPVBHJQmr3Tv" Name="Context" Kind="OutputPin" />
+                            <ControlPoint Id="MaBY0Gd8qi0PFTDDeZIGra" Bounds="478,2046" Alignment="Bottom" />
                             <Patch Id="VBC9UhpR6csOxWf0oL7Xox" ManuallySortedPins="true">
                               <Patch Id="MiHBQEyEFNVNUKGKaNbXr9" Name="Create" ManuallySortedPins="true" />
                               <Patch Id="P9vkEBjiwfLNjWia4jkXBE" Name="Update" ParticipatingElements="JUdf89imcc5MmmbhQtriuq,GQxPYp7AGdSMbQ4iPyeKjN,Sit7MhkiemHLU59YMzVuzk,CBDsOoFhPRfPibueUgMJT7" ManuallySortedPins="true" />
-                              <Node Bounds="477,1947,105,19" Id="LtTvmlXpeBPQQS8vGYdkuz">
+                              <Node Bounds="477,1947,145,19" Id="LtTvmlXpeBPQQS8vGYdkuz">
                                 <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="ProcessNode" Name="MenuItem" />
@@ -8248,6 +8311,8 @@
                                 <Pin Id="GCRqms9exTNQGP1jVrwKyj" Name="Label" Kind="InputPin" />
                                 <Pin Id="SgaaR6VpdkVPxEM5TYOUL5" Name="Shortcut" Kind="InputPin" />
                                 <Pin Id="TF0IIrKhZbeO06q9ovmMbB" Name="Enabled" Kind="InputPin" />
+                                <Pin Id="JDiMW9NLjOAO2za7AEd36O" Name="Selectable" Kind="InputPin" />
+                                <Pin Id="KP1hshGPB1iNYzCcSoPCxW" Name="Is Selected" Kind="InputPin" />
                                 <Pin Id="SRjqf8a0cKwPEbVO1QGtSZ" Name="Style" Kind="InputPin" />
                                 <Pin Id="LVjrpZtCruZMWQyczYihCW" Name="Context" Kind="OutputPin" />
                                 <Pin Id="H40K4B92hgLNpfaUQR7SN1" Name="Bang" Kind="OutputPin" />
@@ -8258,7 +8323,7 @@
                                   <Choice Kind="TypeFlag" Name="String" />
                                 </p:TypeAnnotation>
                               </Pad>
-                              <Node Bounds="477,1714,105,19" Id="FCeKHONQ7EYO7u1uSk1TXR">
+                              <Node Bounds="477,1714,145,19" Id="FCeKHONQ7EYO7u1uSk1TXR">
                                 <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="ProcessNode" Name="MenuItem" />
@@ -8268,6 +8333,8 @@
                                 <Pin Id="DoKhMCrs4LxQIdYwFrNAG5" Name="Label" Kind="InputPin" />
                                 <Pin Id="QAUrCakoMBgMPBLNEEHtCP" Name="Shortcut" Kind="InputPin" />
                                 <Pin Id="LmJdYw2agLKO5VRPVAMThf" Name="Enabled" Kind="InputPin" />
+                                <Pin Id="Utw6TM3raCRMmblKzFF9eW" Name="Selectable" Kind="InputPin" />
+                                <Pin Id="Is3UWqTXBOqOxKITeqqgO3" Name="Is Selected" Kind="InputPin" />
                                 <Pin Id="UJvvQLUyJu0QcLLbAJJkfu" Name="Style" Kind="InputPin" />
                                 <Pin Id="LMuhaE05NhjNUpXMBJNKC8" Name="Context" Kind="OutputPin" />
                                 <Pin Id="TzrSC1MJnBcM6g35HKQ4gG" Name="Bang" Kind="OutputPin" />
@@ -8278,7 +8345,7 @@
                                   <Choice Kind="TypeFlag" Name="String" />
                                 </p:TypeAnnotation>
                               </Pad>
-                              <Node Bounds="477,1829,105,19" Id="H8dDm4lprneMrzJnvh4Wkv">
+                              <Node Bounds="477,1829,145,19" Id="H8dDm4lprneMrzJnvh4Wkv">
                                 <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="ProcessNode" Name="MenuItem" />
@@ -8288,6 +8355,8 @@
                                 <Pin Id="I7nfbD88lk6Mv7huhtQsud" Name="Label" Kind="InputPin" />
                                 <Pin Id="Miz3q0iehtoLlo6Wf1Y1Wn" Name="Shortcut" Kind="InputPin" />
                                 <Pin Id="NQX69ZSnzeyMxgeAIuyEWl" Name="Enabled" Kind="InputPin" />
+                                <Pin Id="SKdo7uNbnG4OTJOPOF1tyc" Name="Selectable" Kind="InputPin" />
+                                <Pin Id="SB6lW64Ph5rOd6xLZMFLCM" Name="Is Selected" Kind="InputPin" />
                                 <Pin Id="IgWAAp1DvF7MEavEdP2Qtc" Name="Style" Kind="InputPin" />
                                 <Pin Id="Mhgf78DMQaxMqjXxoqHiej" Name="Context" Kind="OutputPin" />
                                 <Pin Id="Sy4SCnrbkuUQZr9tigeZHB" Name="Bang" Kind="OutputPin" />
@@ -8314,7 +8383,7 @@
                                 <Pin Id="MJm75w5AHcMN3uzbI4lC2o" Name="Link" Kind="InputPin" DefaultValue="https://github.com/sebescudie/GammaLauncher/releases" />
                                 <Pin Id="Nylw442xpPlMdalFjt6lo2" Name="Open" Kind="InputPin" />
                               </Node>
-                              <Node Bounds="460,2003,72,19" Id="IQ5oa8rM716Mo2F2KI88Hp">
+                              <Node Bounds="460,2003,72,26" Id="IQ5oa8rM716Mo2F2KI88Hp">
                                 <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -8326,7 +8395,6 @@
                                 <Pin Id="IhrzP0hEZVXMCmRyT0K7ue" Name="Apply" Kind="InputPin" />
                               </Node>
                             </Patch>
-                            <ControlPoint Id="MaBY0Gd8qi0PFTDDeZIGra" Bounds="509,2036" Alignment="Bottom" />
                           </Node>
                           <Pad Id="GxFzDGEaa1WOeL6Yph7WHI" Comment="Label" Bounds="504,1648,36,15" ShowValueBox="true" isIOBox="true" Value="Help">
                             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
@@ -8340,15 +8408,6 @@
                               <CategoryReference Kind="Category" Name="Widgets" />
                               <Choice Kind="ProcessAppFlag" Name="Popup (Modal)" />
                             </p:NodeReference>
-                            <Pin Id="SYA0HkHZZ5wOfMAt2BBbjB" Name="Context" Kind="InputPin" />
-                            <Pin Id="THjnHFZ9IYQL8GUPWpf6Ax" Name="Label" Kind="InputPin" />
-                            <Pin Id="JnkmXwOwgTPPyQI5kl5lVK" Name="Has Close Button" Kind="InputPin" />
-                            <Pin Id="EZXmZQW2WQdMdXkUmgtkKX" Name="Bounds" Kind="InputPin" />
-                            <Pin Id="LWoiabHMTPxLePr3h8bFST" Name="Is Open" Kind="InputPin" />
-                            <Pin Id="E98JJ5gHw6XOZTzMt7rc70" Name="Style" Kind="InputPin" />
-                            <Pin Id="H7jGm5zgI0BPvvndiv3jK2" Name="Flags" Kind="InputPin" DefaultValue="NoResize" />
-                            <Pin Id="NSHvaLWnDzeLM3rtDAgS6l" Name="Context" Kind="OutputPin" />
-                            <Pin Id="Vx64IO4NLPgPqRXvJXnAkt" Name="Is Open" Kind="OutputPin" />
                             <Patch Id="M97jqqSX3qRLvr5Y1VP1Nb" ManuallySortedPins="true">
                               <Patch Id="EkI8Cd9Dy5fOxAynbEERzD" Name="Create" ManuallySortedPins="true" />
                               <Patch Id="O2WG9SIB7o6PPImPO23zFU" Name="Update" ParticipatingElements="P9N5PRJhxoxNbdsxKDBxAH,Bivv9aYgojuOt9cym3OWdF" ManuallySortedPins="true" />
@@ -8402,9 +8461,19 @@
                                 </p:TypeAnnotation>
                               </Pad>
                             </Patch>
-                            <ControlPoint Id="MogGspOxpBrPRr8Sn25clb" Bounds="852,1995" Alignment="Bottom" />
+                            <ControlPoint Id="MogGspOxpBrPRr8Sn25clb" Bounds="852,1996" Alignment="Bottom" />
+                            <Pin Id="SYA0HkHZZ5wOfMAt2BBbjB" Name="Context" Kind="InputPin" />
+                            <Pin Id="THjnHFZ9IYQL8GUPWpf6Ax" Name="Label" Kind="InputPin" />
+                            <Pin Id="R9fuN86EU0eQIUvzyxgQ6F" Name="Visible" Kind="InputPin" />
+                            <Pin Id="U1RWQbVSQK1OcDaZJyhLau" Name="Closing" Kind="InputPin" />
+                            <Pin Id="EZXmZQW2WQdMdXkUmgtkKX" Name="Bounds" Kind="InputPin" />
+                            <Pin Id="E98JJ5gHw6XOZTzMt7rc70" Name="Style" Kind="InputPin" />
+                            <Pin Id="H7jGm5zgI0BPvvndiv3jK2" Name="Flags" Kind="InputPin" DefaultValue="NoResize" />
+                            <Pin Id="NSHvaLWnDzeLM3rtDAgS6l" Name="Context" Kind="OutputPin" />
+                            <Pin Id="KZ4N64PcVDsLdKDKmPMhEx" Name="Close Clicked" Kind="OutputPin" />
+                            <Pin Id="RxG30Eq1nwbLdUK8xErSJL" Name="Content Is Visible" Kind="OutputPin" />
                           </Node>
-                          <Node Bounds="913,1716,53,19" Id="DDk1H1tDmWKQdKdhivCvmz">
+                          <Node Bounds="728,1696,53,19" Id="DDk1H1tDmWKQdKdhivCvmz">
                             <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
@@ -8415,8 +8484,8 @@
                             <Pin Id="VPlRdiGyOsWP9kI7VU9EnF" Name="Value" Kind="OutputPin" />
                           </Node>
                           <Patch Id="DUFlQY1ezCjN93BlLDZnGi" Name="Create" ManuallySortedPins="true" />
-                          <Patch Id="IT3RHVJShZYNSANZi3GGye" Name="Update" ParticipatingElements="RXJRQjrCg1vODIRtTlJmBo,EkcYHjPhnqzNCJZX755DtP,VXLvdkxrkbuNzLqwRmtjbN,LSkkEjdAwdPPccoGb9qLz8,AlnHURZhPpxPuH1OFKYFWf,SMSze92rH0nPSTZd8ZftuZ,MfrGTF9vtRBNVrLas5ga27" ManuallySortedPins="true" />
-                          <Node Bounds="847,1647,61,19" Id="QT6tVkKctjYPX45McJQDY2">
+                          <Patch Id="IT3RHVJShZYNSANZi3GGye" Name="Update" ParticipatingElements="RXJRQjrCg1vODIRtTlJmBo,EkcYHjPhnqzNCJZX755DtP,VXLvdkxrkbuNzLqwRmtjbN,LSkkEjdAwdPPccoGb9qLz8,AlnHURZhPpxPuH1OFKYFWf,MfrGTF9vtRBNVrLas5ga27,KJVViVjz7zOPAhWDOIj8Yh" ManuallySortedPins="true" />
+                          <Node Bounds="929,1632,61,19" Id="QT6tVkKctjYPX45McJQDY2">
                             <p:NodeReference LastCategoryFullName="2D.Rectangle" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="Rectangle (Join)" />
@@ -8426,23 +8495,33 @@
                             <Pin Id="R7VS3nNY6B5ObTmVoCfuM8" Name="Anchor" Kind="InputPin" />
                             <Pin Id="VrkOVqQfaDXL5SuEh3LDA2" Name="Output" Kind="StateOutputPin" />
                           </Node>
-                          <Pad Id="GtnOvREWrOHOtSmDfcb3cJ" Comment="Size" Bounds="877,1613,35,28" ShowValueBox="true" isIOBox="true" Value="2.54, 1.27">
+                          <Pad Id="GtnOvREWrOHOtSmDfcb3cJ" Comment="Size" Bounds="959,1598,35,28" ShowValueBox="true" isIOBox="true" Value="2.54, 2.76">
                             <p:TypeAnnotation LastCategoryFullName="2D" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="TypeFlag" Name="Vector2" />
                             </p:TypeAnnotation>
                           </Pad>
-                          <Pad Id="Ns1kA6QT5d6NHT9KiKZwxY" Comment="Position" Bounds="849,1579,41,28" ShowValueBox="true" isIOBox="true" Value="0.089999996, 0.5">
+                          <Pad Id="Ns1kA6QT5d6NHT9KiKZwxY" Comment="Position" Bounds="931,1564,41,28" ShowValueBox="true" isIOBox="true" Value="0.089999996, 0.5">
                             <p:TypeAnnotation LastCategoryFullName="2D" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="TypeFlag" Name="Vector2" />
                             </p:TypeAnnotation>
                           </Pad>
+                          <Node Bounds="900,1739,53,19" Id="VGP4pBhBqB8LLvfRKcskKB">
+                            <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
+                              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                              <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
+                              <Choice Kind="ProcessAppFlag" Name="Channel" />
+                            </p:NodeReference>
+                            <Pin Id="Pp7coh8LyFHODKiA19iorT" Name="Value" Kind="InputPin" />
+                            <Pin Id="N3DqgsU1WkiNPMAPlHsK51" Name="Output" Kind="OutputPin" />
+                            <Pin Id="LytFLrI0dAPQJUqoZMulZr" Name="Value" Kind="OutputPin" />
+                          </Node>
                         </Patch>
                       </Node>
                       <ControlPoint Id="Qe2VNwScgPtLbNgeg7zGMv" Bounds="402,2298" />
                       <ControlPoint Id="KHpVSH758BKMdnnmjyBAkP" Bounds="406,148" />
                       <ControlPoint Id="BghabUAyLepOT2P2nKdI8I" Bounds="830,1766" />
                       <ControlPoint Id="NyZ150Gv0R5Mr1N4zmkD3g" Bounds="244,1003" />
-                      <Node Bounds="208,619,106,26" Id="Qc6ziYZdZd3L5uLYICgloo">
+                      <Node Bounds="204,612,106,26" Id="Qc6ziYZdZd3L5uLYICgloo">
                         <p:NodeReference LastCategoryFullName="Main.App.App" LastDependency="GammaLauncher.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <CategoryReference Kind="Category" Name="App" />
@@ -8452,7 +8531,7 @@
                         <Pin Id="UPZaQvgoUtsMZIj6rXFjw4" Name="State Output" Kind="StateOutputPin" />
                         <Pin Id="Ipd3ng3ea2MMc2v0BxKVTn" Name="Output" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="309,658,41,19" Id="VmkCbQrw1zsQcAblOc7mI7">
+                      <Node Bounds="305,651,45,26" Id="VmkCbQrw1zsQcAblOc7mI7">
                         <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -8472,7 +8551,7 @@
                         <Pin Id="DSRS7bI7l8jOnYs5OXG3TG" Name="Output" Kind="StateOutputPin" />
                         <Pin Id="MUNEhAkvg89OBlWM7YvWRX" Name="Updates Tab Runtime" Kind="OutputPin" />
                       </Node>
-                      <ControlPoint Id="VFCmDi3MI8SLvt8hm4YgQk" Bounds="210,593" />
+                      <ControlPoint Id="VFCmDi3MI8SLvt8hm4YgQk" Bounds="206,586" />
                       <Node Bounds="345,695,119,26" Id="P3oyWfv3kUCONtvPjy4QXN">
                         <p:NodeReference LastCategoryFullName="Main.Runtime.ApplicationRuntime" LastDependency="GammaLauncher.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -8506,7 +8585,7 @@
                         <Pin Id="D5QCbwABS2yP3W8VNF0o8d" Name="Unfocused" Kind="OutputPin" />
                         <Pin Id="QEqhfHT3b1rOSSr4GXyLdo" Name="Accent" Kind="OutputPin" />
                       </Node>
-                      <Pad Id="KyhkoUYEb1qOtW8udkQHD1" Comment="Format" Bounds="1048,1702,349,204" ShowValueBox="true" isIOBox="true" Value="Version {0}&#xD;&#xA;&#xD;&#xA;Thanks to dottore, gregsn and domj for contributing!&#xD;&#xA;&#xD;&#xA;Third party C# libs :&#xD;&#xA;- Downloader (Behzad Khosravifar)&#xD;&#xA;- SemVer (Max Hauser)&#xD;&#xA;- RestSharp (alexey_zimarev, Ubiquitous)&#xD;&#xA;- Humanizer&#xD;&#xA;&#xD;&#xA;vvvv libs :&#xD;&#xA;- VL.ImGUI&#xD;&#xA;- VL.Skia&#xD;&#xA;">
+                      <Pad Id="KyhkoUYEb1qOtW8udkQHD1" Comment="Format" Bounds="1088,1889,349,204" ShowValueBox="true" isIOBox="true" Value="Version {0}&#xD;&#xA;&#xD;&#xA;Thanks to dottore, gregsn and domj for contributing!&#xD;&#xA;&#xD;&#xA;Third party C# libs :&#xD;&#xA;- Downloader (Behzad Khosravifar)&#xD;&#xA;- SemVer (Max Hauser)&#xD;&#xA;- RestSharp (alexey_zimarev, Ubiquitous)&#xD;&#xA;- Humanizer&#xD;&#xA;&#xD;&#xA;vvvv libs :&#xD;&#xA;- VL.ImGUI&#xD;&#xA;- VL.Skia&#xD;&#xA;">
                         <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="String" />
                         </p:TypeAnnotation>
@@ -8582,7 +8661,6 @@
                     <Link Id="CBDsOoFhPRfPibueUgMJT7" Ids="TzrSC1MJnBcM6g35HKQ4gG,Nylw442xpPlMdalFjt6lo2" />
                     <Link Id="DtSFGJbVa9vPEaiwVeE6Ve" Ids="H40K4B92hgLNpfaUQR7SN1,IhrzP0hEZVXMCmRyT0K7ue" />
                     <Link Id="OSLKi7pwEEMOBZJ2QbDhOd" Ids="B7lq1skic9hNdPiTRGSh07,F5XeQD4DFE3LVZZW0lwLaD" />
-                    <Link Id="SMSze92rH0nPSTZd8ZftuZ" Ids="B7lq1skic9hNdPiTRGSh07,LWoiabHMTPxLePr3h8bFST" />
                     <Link Id="FJa14h5bN1sPbFqklnNP2k" Ids="Bmc7Tw0lvl7O16EYUQjkrd,BghabUAyLepOT2P2nKdI8I" IsHidden="true" />
                     <Link Id="LTVOy26QUMsMil1WF4WVQT" Ids="BghabUAyLepOT2P2nKdI8I,KEb0FXCe60xOLqYUIYXMyV" />
                     <Link Id="UJbrKDdD0x6LOn30ZEHEvw" Ids="Q7Quarfa3h0PUuxv1lJKPy,MS9QOUmTNFQOtNhvKX8v8c" />
@@ -8653,6 +8731,7 @@
                     <Link Id="VcIMUvPPcd4NOzsULFYLMr" Ids="KyhkoUYEb1qOtW8udkQHD1,FAy6iOKtgPtNFvFKJu08Hw" />
                     <Link Id="S7OS3YF6UwfNT0Nnuxh4wr" Ids="Mvj1oaUIo3RL70hlEnV44z,KKhazo9cfx2N7k5UQdChwA" />
                     <Link Id="O3svbiZ7HSaLDgXbx4tlQc" Ids="UoRbK3DKnwNOvNQdupbGJJ,E98JJ5gHw6XOZTzMt7rc70" />
+                    <Link Id="KJVViVjz7zOPAhWDOIj8Yh" Ids="B7lq1skic9hNdPiTRGSh07,R9fuN86EU0eQIUvzyxgQ6F" />
                   </Patch>
                 </Node>
                 <Node Bounds="459,454,105,19" Id="D0CpyGCX0snPKt1QQ1WfUk">
@@ -8824,7 +8903,7 @@
                   <Pin Id="QqOsBXwwBOGOMzsRDm8C9J" Name="State Output" Kind="StateOutputPin" />
                   <Pin Id="QKyTU2Ysh5aNKSJmoKL18G" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="251,955,41,19" Id="TlpTE4nxDgbNVBjmXIXbss">
+                <Node Bounds="251,955,45,26" Id="TlpTE4nxDgbNVBjmXIXbss">
                   <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="ClassType" Name="Channel" />
@@ -9080,7 +9159,6 @@
               <Link Id="KUtG9mSgfdgNdah5lWdiSh" Ids="DK86OpV2Z1SL9lVFFxcsQ3,Goujs4J64VUPXuXtSPbarl" />
               <Link Id="JYU7ByVbujYLkh4vEZLKCL" Ids="U5yE42cAVxUQeAR87IEKNe,UxvpA6TnI5oPDp3cIpLmSN" />
               <Link Id="Dpr700rJWnXL6TZ4F0pnVM" Ids="U5yE42cAVxUQeAR87IEKNe,UBfi6WzqJGVLPwFjuqgIN7" />
-              <Link Id="OzbonJMU3fiPL9q1aXgMMC" Ids="U5yE42cAVxUQeAR87IEKNe,Te39Jm17W3nP737I1dFFtZ" />
               <Link Id="T3leZNXKJmwQSrOxGrmy8W" Ids="C6uwlcSStudL5IpTxb0vNL,TWxDvjDm3jTMvPFTmU4O43" />
               <Link Id="O0G6j0epyK5OrWYW9BRdk6" Ids="EyXW35ALOHXNCeQ66dG7tk,KNDfN68OE7kNCtHhG9jAkw" />
               <Link Id="GTXgobaieO4N0M4f4B6dCb" Ids="CD91iVPoTUVLgaywPozHgI,Ry3v7BELgsSMnd1voaJY8s" />
@@ -9146,6 +9224,7 @@
               <Link Id="DHGZiqrJr7vMux2PdiMc4t" Ids="S8WhG6uZEWQOsWJWrhxbBw,Plv4kN0BPerLk6nTgAzDde" />
               <Link Id="TAS2Wu760ojLShcU6HPQka" Ids="S8WhG6uZEWQOsWJWrhxbBw,BK014BV8pwzPePlSdL3x6P" />
               <Link Id="U0qcq3MEZTLLMXv0I0QQm2" Ids="Q4rbf9WtYuyOzfgaAl28Cb,IyDt3cglaqdMTWckBKuVBF" />
+              <Link Id="OOsvwwEngmFOlj0inEmruc" Ids="U5yE42cAVxUQeAR87IEKNe,LuMJe9jJvmOMwPwuNQVaLH" />
             </Patch>
           </Node>
         </Canvas>
@@ -9823,7 +9902,7 @@
                   <Pin Id="Qq3ffYPPIi5QWKJ1RSaQw9" Name="Keyboard Device" Kind="InputPin" />
                 </Node>
                 <ControlPoint Id="PsiygbgJ75uMW4aODSi2rv" Bounds="118,120" />
-                <Node Bounds="217,189,41,19" Id="D54QNNkh3vrNAkfp1ic47j">
+                <Node Bounds="217,189,45,26" Id="D54QNNkh3vrNAkfp1ic47j">
                   <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -15296,7 +15375,7 @@
             <Pin Id="VUqK419WdeSL73H3YcC0hP" Name="Output" Kind="StateOutputPin" />
             <Pin Id="PXt4MhFPF7sM49glNMIYkB" Name="Initial Window Bounds" Kind="OutputPin" />
           </Node>
-          <Node Bounds="86,296,11,19" Id="KsPBahmoFh9NNY9cQdjWYM">
+          <Node Bounds="86,296,45,19" Id="KsPBahmoFh9NNY9cQdjWYM">
             <p:NodeReference LastCategoryFullName="Main.Editor.UI" LastDependency="GammaLauncher.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Editor" />
@@ -15334,15 +15413,15 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="Dx3hWrA5MJTP3PBl22Hc09" Location="VL.Skia" Version="2022.5.0-0676-g91d259b3a1" />
+  <NugetDependency Id="Dx3hWrA5MJTP3PBl22Hc09" Location="VL.Skia" Version="2023.5.0" />
   <PlatformDependency Id="PR2RZQLpnGKNZvYQVn3Ead" Location="mscorlib" />
   <PlatformDependency Id="Ow5sjuC3immNloZfvkN1g7" Location="System.Windows.Forms" />
   <PlatformDependency Id="HMEsYQpErI5OqaqpKnu53t" Location="System.Drawing" />
   <NugetDependency Id="A7QaxZnKLQBPrEoH3eQWQY" Location="RestSharp" Version="106.15.0" />
-  <NugetDependency Id="F8rLPob1tJWM13C9xxfQ3P" Location="VL.CoreLib.Windows" Version="2022.5.0-0676-g91d259b3a1" />
+  <NugetDependency Id="F8rLPob1tJWM13C9xxfQ3P" Location="VL.CoreLib.Windows" Version="2023.5.0" />
   <NugetDependency Id="Vnl8tgKwbGMP0yvGw64Adv" Location="Semver" Version="2.0.6" />
-  <NugetDependency Id="IscN5qIHnL6N2GQSwSz602" Location="VL.ImGui" Version="2022.5.0-0676-g91d259b3a1" />
-  <NugetDependency Id="DueOVdpuzHRN7xQZ6gn9H6" Location="VL.ImGui.Skia" Version="2022.5.0-0676-g91d259b3a1" />
+  <NugetDependency Id="IscN5qIHnL6N2GQSwSz602" Location="VL.ImGui" Version="2023.5.0" />
+  <NugetDependency Id="DueOVdpuzHRN7xQZ6gn9H6" Location="VL.ImGui.Skia" Version="2023.5.0" />
   <DocumentDependency Id="K4SG30vxDXFQCQQq5jLvaS" Location="./GammaLauncher.Proxies.vl" />
   <NugetDependency Id="ObULv8xpK0APMCczaZvh3u" Location="Downloader" Version="3.0.3" />
   <NugetDependency Id="ExFUESH6MHIL8sAEZQOefx" Location="VL.WinFormsUtils" Version="1.0.9" />

--- a/GammaLauncher.vl
+++ b/GammaLauncher.vl
@@ -4138,7 +4138,7 @@
                             <Patch Id="BtNOCa8A5FpLrm2PsdloST" ManuallySortedPins="true">
                               <Patch Id="A8KIgDjuWvqLTiMVmop6SD" Name="Create" ManuallySortedPins="true" />
                               <Patch Id="S9Jmnia2JoBOKoCIupUiYd" Name="Update" ManuallySortedPins="true" />
-                              <Node Bounds="411,248,25,19" Id="Hux2TJ2AGhwMhIaIc986sA">
+                              <Node Bounds="411,248,49,19" Id="Hux2TJ2AGhwMhIaIc986sA">
                                 <p:NodeReference LastCategoryFullName="Main.Editor.UI.Editor.Tabs" LastDependency="GammaLauncher.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="ProcessAppFlag" Name="Launch" />
@@ -4304,7 +4304,7 @@
                               </Pad>
                             </Patch>
                           </Node>
-                          <Node Bounds="557,822,136,26" Id="KDxt6kOav92Pvt7UKW1MRC">
+                          <Node Bounds="557,822,170,26" Id="KDxt6kOav92Pvt7UKW1MRC">
                             <p:NodeReference LastCategoryFullName="Main.Runtime.UpdatesTabRuntime" LastDependency="GammaLauncher.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="GetNewerGammaBuildsOnlineFlag" />
@@ -5011,7 +5011,7 @@
                                             <Pin Id="F8MQltonoTmL5tBRMyWgL1" Name="Context" Kind="OutputPin" />
                                             <Pin Id="VTn54p8mdgePsKOHY13LjP" Name="Value" Kind="OutputPin" />
                                           </Node>
-                                          <Node Bounds="361,657,80,80" Id="MRKLV8dgDNIPLm0JsDEzAx">
+                                          <Node Bounds="361,657,96,81" Id="MRKLV8dgDNIPLm0JsDEzAx">
                                             <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                                               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                               <CategoryReference Kind="Category" Name="Primitive" />
@@ -5021,7 +5021,7 @@
                                             <Patch Id="Biimm9jrxT1QZzcyrORroO" ManuallySortedPins="true">
                                               <Patch Id="E9UtoTQzaBdLlXR8fdmxJp" Name="Create" ManuallySortedPins="true" />
                                               <Patch Id="OmcT7C5skOmObWkQoLQwYw" Name="Then" ManuallySortedPins="true" />
-                                              <Node Bounds="392,690" Id="OVUTmwObujIMEs41PSRTKk">
+                                              <Node Bounds="392,690,49,19" Id="OVUTmwObujIMEs41PSRTKk">
                                                 <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                                   <Choice Kind="ProcessNode" Name="Tooltip (String)" />
@@ -5046,7 +5046,7 @@
                                           </Node>
                                         </Patch>
                                         <ControlPoint Id="S9jWsaN3LJZQSOrSNfmepd" Bounds="239,412" Alignment="Top" />
-                                        <ControlPoint Id="QK2RpY2X4dANl0dBmRUUp8" Bounds="239,935" Alignment="Bottom" />
+                                        <ControlPoint Id="QK2RpY2X4dANl0dBmRUUp8" Bounds="239,936" Alignment="Bottom" />
                                         <ControlPoint Id="B3w7O0GGEbEMyHbISlRSs2" Bounds="279,412" Alignment="Top" />
                                         <ControlPoint Id="Nyg9HdY5sFHNYuRVsSWo84" Bounds="317,412" Alignment="Top" />
                                         <ControlPoint Id="QbVcHORKtw3LfEyKX6z5qr" Bounds="422,412" Alignment="Top" />
@@ -5140,7 +5140,7 @@
                                     <Pin Id="M3UL6llKsl6NEBuqOpY5lE" Name="Border Size" Kind="InputPin" />
                                     <Pin Id="LYlYZvQwahGP7gDN7XfNu1" Name="Output" Kind="OutputPin" />
                                   </Node>
-                                  <Node Bounds="540,391,65,19" Id="HD7OUzE4OIGNgVSLIJEFbr">
+                                  <Node Bounds="540,391,85,19" Id="HD7OUzE4OIGNgVSLIJEFbr">
                                     <p:NodeReference LastCategoryFullName="Main.Editor.UI.Editor.Tabs" LastDependency="GammaLauncher.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <Choice Kind="ProcessAppFlag" Name="Palette" />
@@ -5922,7 +5922,7 @@
                               <Pin Id="CRMMaF352L7OpB8b3EK5H7" Name="Path" Kind="InputPin" DefaultValue="VVVV Installations Folder" />
                               <Pin Id="U7loAhPVH51LqYtQ2kkF0H" Name="Output" Kind="OutputPin" />
                             </Node>
-                            <Node Bounds="626,1064,448,857" Id="SpnOAw9kCjaOwmbQdxihzB">
+                            <Node Bounds="626,1064,548,440" Id="SpnOAw9kCjaOwmbQdxihzB">
                               <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                 <Choice Kind="ProcessAppFlag" Name="CollapsingHeader" />
@@ -5931,7 +5931,7 @@
                               <Patch Id="BGx35HKuQMULeTs5ucP4R6" ManuallySortedPins="true">
                                 <Patch Id="NRlmwz1l94BOGvyMDrVWHm" Name="Create" ManuallySortedPins="true" />
                                 <Patch Id="HxDn0ryaQfPM7p2Je0TWU4" Name="Update" ManuallySortedPins="true" />
-                                <Node Bounds="690,1721,85,19" Id="EUMXX9ESSG6O37rRVylwfj">
+                                <Node Bounds="691,1304,246,19" Id="EUMXX9ESSG6O37rRVylwfj">
                                   <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                     <CategoryReference Kind="Category" Name="Widgets" NeedsToBeDirectParent="true" />
@@ -5945,179 +5945,38 @@
                                   <Pin Id="INh1s4Oofn3Oejdsp17VKN" Name="Context" Kind="OutputPin" />
                                   <Pin Id="OlRvXwnfHByNjUL3BU65Uj" Name="Bang" Kind="OutputPin" />
                                 </Node>
-                                <Node Bounds="678,1086,384,564" Id="L7GPVtDvy4QLnu3MaYaxId">
+                                <Node Bounds="678,1102,415,141" Id="L7GPVtDvy4QLnu3MaYaxId">
                                   <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                     <CategoryReference Kind="Category" Name="Primitive" />
                                     <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
                                   </p:NodeReference>
                                   <Pin Id="S7kSM0gIn3SL20IGbiIuUa" Name="Break" Kind="OutputPin" />
-                                  <ControlPoint Id="Lgmfo52OsBFNL3llaJJdyn" Bounds="692,1644" Alignment="Bottom" />
-                                  <ControlPoint Id="PRBPIAbuQBRMAvTaPELcdj" Bounds="692,1092" Alignment="Top" />
-                                  <ControlPoint Id="LbHTeEEGDn5QBPPPhAZYq6" Bounds="782,1092" Alignment="Top" />
+                                  <ControlPoint Id="Lgmfo52OsBFNL3llaJJdyn" Bounds="693,1237" Alignment="Bottom" />
+                                  <ControlPoint Id="PRBPIAbuQBRMAvTaPELcdj" Bounds="692,1108" Alignment="Top" />
+                                  <ControlPoint Id="LbHTeEEGDn5QBPPPhAZYq6" Bounds="782,1108" Alignment="Top" />
                                   <Patch Id="RXHWwmwJ3alOdO4DR9hGJc" ManuallySortedPins="true">
                                     <Patch Id="QKsLuFJLrMiPjaSdewYuAn" Name="Create" ManuallySortedPins="true" />
                                     <Patch Id="C9d3VoZTQJpP0ENsybbato" Name="Update" ManuallySortedPins="true">
                                       <Pin Id="AE9AT2dRwRpL55BRhhWi5L" Name="Index" Kind="InputPin" />
                                     </Patch>
                                     <Patch Id="UjG4ZPWVh0SOxjWXVx75Gs" Name="Dispose" ManuallySortedPins="true" />
-                                    <Node Bounds="690,1295,145,19" Id="O072gaEli5XQdVFtlS6kZF">
-                                      <p:NodeReference LastCategoryFullName="Main.Utils" LastDependency="GammaLauncher.vl">
+                                    <ControlPoint Id="McTQCLa0bPbNsFbbVaOwui" Bounds="1044,1152" />
+                                    <Node Bounds="691,1192,356,19" Id="QuT4RvTElqXMHhzPIry9sE">
+                                      <p:NodeReference LastCategoryFullName="Main.Editor.UI.Editor.Tabs.Settings" LastDependency="GammaLauncher.vl">
                                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                        <CategoryReference Kind="Category" Name="Utils" NeedsToBeDirectParent="true">
-                                          <p:OuterCategoryReference Kind="Category" Name="Main" NeedsToBeDirectParent="true" />
-                                        </CategoryReference>
-                                        <Choice Kind="ProcessAppFlag" Name="FolderDialog" />
+                                        <Choice Kind="ProcessAppFlag" Name="PackageRepositoriesEntry" />
                                       </p:NodeReference>
-                                      <Pin Id="PyUawTGQjNYNkYYP4LOLKz" Name="Context" Kind="InputPin" />
-                                      <Pin Id="Q6WyXMRqTUcLBOTLftD3Go" Name="Channel" Kind="InputPin" />
-                                      <Pin Id="MjzpdyZfCyJL4zBWwap8L6" Name="Label" Kind="InputPin" />
-                                      <Pin Id="VnA1hkH08ueMde4HvPuAH8" Name="Max Length" Kind="InputPin" />
-                                      <Pin Id="D23ZQVoCge2O1U4CDttDkv" Name="Flags" Kind="InputPin" />
-                                      <Pin Id="BbU6PEu0pM3L7ADBICiQuf" Name="Style" Kind="InputPin" />
-                                      <Pin Id="DdPdrVuxmHFMEEzlFdwyDC" Name="Button Style" Kind="InputPin" />
-                                      <Pin Id="JsR0x8B7p8cPKMUHWLvnrm" Name="Button Label" Kind="InputPin" />
-                                      <Pin Id="RubiYd6avaMLedHNS1zSVC" Name="Context" Kind="OutputPin" />
-                                      <Pin Id="Bt0VsPEnM7rPrUEEMK8O6H" Name="Value" Kind="OutputPin" />
-                                    </Node>
-                                    <Node Bounds="690,1350,59,19" Id="A075q69pOXuMFgn9J5hiWt">
-                                      <p:NodeReference LastCategoryFullName="ImGui.Commands" LastDependency="VL.ImGui.vl">
-                                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                        <Choice Kind="ProcessNode" Name="SameLine" />
-                                      </p:NodeReference>
-                                      <Pin Id="CzlcRoBrQIlON420HRazQt" Name="Context" Kind="InputPin" />
-                                      <Pin Id="CU23faWMqfWMBewXrsttBR" Name="Offset" Kind="InputPin" />
-                                      <Pin Id="PU1y9Qc6ne7OVbieT3nXA1" Name="Spacing" Kind="InputPin" />
-                                      <Pin Id="NWvyUTdM8uiNmFyY6qPfsM" Name="Context" Kind="OutputPin" />
-                                    </Node>
-                                    <Node Bounds="690,1446,85,19" Id="CyZw6ZV1eLhOZm40bJJOiP">
-                                      <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
-                                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                        <CategoryReference Kind="Category" Name="Widgets" NeedsToBeDirectParent="true" />
-                                        <Choice Kind="ProcessAppFlag" Name="Button" />
-                                      </p:NodeReference>
-                                      <Pin Id="PHwSsUc94twNx6OGvvJHIK" Name="Context" Kind="InputPin" />
-                                      <Pin Id="A7QiJNIVETpLWMpKQSHUZJ" Name="Channel" Kind="InputPin" />
-                                      <Pin Id="Rvyk7rYmh6KLAMrj80fYmH" Name="Label" Kind="InputPin" DefaultValue="X" />
-                                      <Pin Id="HPAizfgyLT1QM0MSb6ajnm" Name="Size" Kind="InputPin" />
-                                      <Pin Id="GT5vwxNXQ4EOwEqwuBM5uG" Name="Style" Kind="InputPin" />
-                                      <Pin Id="CqgZ0o868QMLPLTFMgzcJl" Name="Context" Kind="OutputPin" />
-                                      <Pin Id="I5ZugFFLRn2N5ZtAd5D3a8" Name="Bang" Kind="OutputPin" />
-                                    </Node>
-                                    <Node Bounds="710,1213,43,19" Id="SSsdlpfAOe9QRxMG8twZst">
-                                      <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
-                                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                        <Choice Kind="ProcessAppFlag" Name="Select (ByPath)" />
-                                      </p:NodeReference>
-                                      <Pin Id="PR9pAtx7uzkPJroVxCoiM2" Name="Input" Kind="InputPin" />
-                                      <Pin Id="DA9N0qGp32APzeXa3Sl1JN" Name="Path" Kind="InputPin" DefaultValue="Package Repositories Folder[0]" />
-                                      <Pin Id="ChPbQkhY9IMMZG0FpkBoTB" Name="Output" Kind="OutputPin" />
-                                    </Node>
-                                    <Node Bounds="830,1257,85,19" Id="RBnrwU5q3hrLcnDuQh1BOx">
-                                      <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
-                                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                        <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
-                                        <Choice Kind="OperationCallFlag" Name="Format" />
-                                      </p:NodeReference>
-                                      <Pin Id="TxIg5ysVKdANjniAS3Cp5d" Name="Format" Kind="InputPin" DefaultValue="...##BrowseButton{0}" />
-                                      <Pin Id="TWBhmTI6rVyOdZ6dgGIpvs" Name="Input" Kind="StateInputPin" />
-                                      <Pin Id="DfGJuxd2zSdOHBtJcuveAe" Name="Input 2" Kind="InputPin" />
-                                      <Pin Id="DFuDDUULuL9LpjUCnq7AYb" Name="Input 3" Kind="InputPin" />
-                                      <Pin Id="Ns7Anx74caBLpGbCetbI1z" Name="Input 4" Kind="InputPin" />
-                                      <Pin Id="DdxNdjb9PYUNK6XrnaoiKJ" Name="Output" Kind="StateOutputPin" />
-                                    </Node>
-                                    <ControlPoint Id="McTQCLa0bPbNsFbbVaOwui" Bounds="1013,1121" />
-                                    <Node Bounds="768,1141,55,19" Id="CaU8upBTp9MM7wYwyln7f6">
-                                      <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
-                                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                        <Choice Kind="OperationCallFlag" Name="ToString" />
-                                      </p:NodeReference>
-                                      <Pin Id="QVNTQ1P1gfYOzdlkw4U6rA" Name="Input" Kind="InputPin" />
-                                      <Pin Id="NhKvcB8RfVkM3kefOuY2Z1" Name="Result" Kind="OutputPin" />
-                                    </Node>
-                                    <Node Bounds="770,1489,257,139" Id="MUSd01kxDXLPiv3bv2sFyD">
-                                      <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
-                                        <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                                        <CategoryReference Kind="Category" Name="Primitive" />
-                                        <Choice Kind="ApplicationStatefulRegion" Name="If" />
-                                      </p:NodeReference>
-                                      <Pin Id="DptBOCrv8FtPS9RtSzpYWW" Name="Condition" Kind="InputPin" />
-                                      <Patch Id="HENk8jMInjLOqY3Nf9wNMJ" ManuallySortedPins="true">
-                                        <Patch Id="JRzt9HWCSgINj2IKXIt47S" Name="Create" ManuallySortedPins="true" />
-                                        <Patch Id="GgxyqFpLhTWO2m6FTi7IjW" Name="Then" ManuallySortedPins="true" />
-                                        <Node Bounds="832,1540,183,26" Id="NiJzi42bHwBOxn7TdSSCon">
-                                          <p:NodeReference LastCategoryFullName="Main.Model.SettingsTabModel" LastDependency="GammaLauncher.vl">
-                                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                            <Choice Kind="OperationCallFlag" Name="RemovePackageRepositoriesFolderAt" />
-                                          </p:NodeReference>
-                                          <Pin Id="EFcjik1BWluPKbF0X0J8Aa" Name="Input" Kind="StateInputPin" />
-                                          <Pin Id="DFr1lLubWW4L1V7aHkqg3f" Name="Index" Kind="InputPin" />
-                                          <Pin Id="HRrtosEyGvYPHXPmTjDi4H" Name="Output" Kind="StateOutputPin" />
-                                        </Node>
-                                        <Node Bounds="782,1512,45,26" Id="IgsWhfU2HylLOsJ2odZtsO">
-                                          <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
-                                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                            <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
-                                            <Choice Kind="OperationCallFlag" Name="Value" />
-                                          </p:NodeReference>
-                                          <Pin Id="SEyyPrsfJ1fLslV6Kjr8q0" Name="Input" Kind="StateInputPin" />
-                                          <Pin Id="K1TeJv3nkZWLuvDzOsE9pG" Name="Output" Kind="StateOutputPin" />
-                                          <Pin Id="KWlJxZfrNHmMdIhmQYfZTo" Name="Value" Kind="OutputPin" />
-                                        </Node>
-                                        <Node Bounds="782,1582,55,26" Id="FkBMfRXeFVEOm8DdunI2fq">
-                                          <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
-                                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                            <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
-                                            <Choice Kind="OperationCallFlag" Name="SetValue" />
-                                          </p:NodeReference>
-                                          <Pin Id="IwFwT1y9G9PPJchHPy0RLc" Name="Input" Kind="StateInputPin" />
-                                          <Pin Id="JpcRWdnpBHLMNW2TJuLMfb" Name="Value" Kind="InputPin" />
-                                          <Pin Id="Eple0OrhThVPXnePfeJM98" Name="Output" Kind="StateOutputPin" />
-                                        </Node>
-                                      </Patch>
-                                    </Node>
-                                    <Node Bounds="737,1257,85,19" Id="Nm2bYaCvaD4NHiNzKIsTwO">
-                                      <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
-                                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                        <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
-                                        <Choice Kind="OperationCallFlag" Name="Format" />
-                                      </p:NodeReference>
-                                      <Pin Id="Koo5m3GRMlwPdnjvGZaDys" Name="Format" Kind="InputPin" DefaultValue="##RepoPath{0}" />
-                                      <Pin Id="Hhv063TSiKNOr34KExweaC" Name="Input" Kind="StateInputPin" />
-                                      <Pin Id="NB5NdCuOjb7MhskEM9nxQa" Name="Input 2" Kind="InputPin" />
-                                      <Pin Id="Fl4TnY4nbaIMuSTEyKOdRs" Name="Input 3" Kind="InputPin" />
-                                      <Pin Id="Je0GU8YLlxqO1E5B0WAqsp" Name="Input 4" Kind="InputPin" />
-                                      <Pin Id="PYIErtHtZfzOAiR7sO5QRr" Name="Output" Kind="StateOutputPin" />
-                                    </Node>
-                                    <Node Bounds="730,1413,85,19" Id="MkDhtX2FQcmOWidGwOvkVn">
-                                      <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
-                                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                        <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
-                                        <Choice Kind="OperationCallFlag" Name="Format" />
-                                      </p:NodeReference>
-                                      <Pin Id="KAcYJylaqx7L5CvJ2BaFhS" Name="Format" Kind="InputPin" DefaultValue="X##DeleteButton{0}" />
-                                      <Pin Id="AAzqHbAhXnoLQHq6XUX5wS" Name="Input" Kind="StateInputPin" />
-                                      <Pin Id="PpwWdBSQqgeO8RLILg5WR8" Name="Input 2" Kind="InputPin" />
-                                      <Pin Id="C1RHka0ZSiFPqtQfnjQfe3" Name="Input 3" Kind="InputPin" />
-                                      <Pin Id="E2A6bx1VpqzPzbqbGHoF1q" Name="Input 4" Kind="InputPin" />
-                                      <Pin Id="OU9iUFMage7O4uueWOAX0o" Name="Output" Kind="StateOutputPin" />
-                                    </Node>
-                                    <Node Bounds="748,1178,85,19" Id="IBF9ObYkIdbLaTfantPGUi">
-                                      <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
-                                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                        <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
-                                        <Choice Kind="OperationCallFlag" Name="Format" />
-                                      </p:NodeReference>
-                                      <Pin Id="TvIyp6yttLtPjfRgelimbd" Name="Format" Kind="InputPin" DefaultValue="Package Repositories Folder[{0}]" />
-                                      <Pin Id="RJPfosv6dfrNkBKCgbRGl8" Name="Input" Kind="StateInputPin" />
-                                      <Pin Id="Al2o2VzT4QINibHkGNt7lz" Name="Input 2" Kind="InputPin" />
-                                      <Pin Id="PhmCbWis1LLNyVtzQwI4AP" Name="Input 3" Kind="InputPin" />
-                                      <Pin Id="BPX0s97o1GwN3InoPaimaQ" Name="Input 4" Kind="InputPin" />
-                                      <Pin Id="SAK9tesIzcuNSmPBJguF27" Name="Output" Kind="StateOutputPin" />
+                                      <Pin Id="F12QwHZBFCMNi2LYAUwwed" Name="Context" Kind="InputPin" />
+                                      <Pin Id="UH3Z8ELjQ7hPgCaAVLvtYv" Name="Model" Kind="InputPin" />
+                                      <Pin Id="ScDowj7ZIfWNZmLb4N5Bdw" Name="Frame Style" Kind="InputPin" />
+                                      <Pin Id="GfcLJxeCFoTOpdrZbjprwX" Name="Button Style" Kind="InputPin" />
+                                      <Pin Id="JqDNfWLOI7ZOwIORICro4o" Name="Index" Kind="InputPin" />
+                                      <Pin Id="O1tYUekLN1UOkRpbIr2TFH" Name="Context" Kind="OutputPin" />
                                     </Node>
                                   </Patch>
                                 </Node>
-                                <Node Bounds="770,1757,230,144" Id="JHLuIXRiB2OOpV0mJDclJW">
+                                <Node Bounds="932,1340,230,144" Id="JHLuIXRiB2OOpV0mJDclJW">
                                   <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                     <CategoryReference Kind="Category" Name="Primitive" />
@@ -6127,7 +5986,7 @@
                                   <Patch Id="BgH5X1dn6p8OElLjepoQFF" ManuallySortedPins="true">
                                     <Patch Id="DGHnxzVuuqkNnE4Kpn1Hln" Name="Create" ManuallySortedPins="true" />
                                     <Patch Id="LALjL68qBLtNp02dsa8kyx" Name="Then" ManuallySortedPins="true" />
-                                    <Node Bounds="782,1780,45,26" Id="QQIzVNHmAo7NRiYym4JTBL">
+                                    <Node Bounds="944,1363,45,26" Id="QQIzVNHmAo7NRiYym4JTBL">
                                       <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                         <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -6137,7 +5996,7 @@
                                       <Pin Id="VNjYJZc7lbeNQtVZn3Y6OI" Name="Output" Kind="StateOutputPin" />
                                       <Pin Id="QLWZ2HrDmtSNmKutQAug7q" Name="Value" Kind="OutputPin" />
                                     </Node>
-                                    <Node Bounds="832,1813,156,26" Id="E04RtnYmX4pOWtyLiV9tck">
+                                    <Node Bounds="994,1396,156,26" Id="E04RtnYmX4pOWtyLiV9tck">
                                       <p:NodeReference LastCategoryFullName="Main.Model.SettingsTabModel" LastDependency="GammaLauncher.vl">
                                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                         <Choice Kind="OperationCallFlag" Name="AddPackageRepositoriesFolder" />
@@ -6146,7 +6005,7 @@
                                       <Pin Id="KrQiT2HYTqZPgdlwbqYpmf" Name="Item" Kind="InputPin" />
                                       <Pin Id="VaygddSVEAdNTZP8k1Q7en" Name="Output" Kind="StateOutputPin" />
                                     </Node>
-                                    <Node Bounds="782,1855,55,26" Id="Sb91Noc3NV4OCK4iBodQeU">
+                                    <Node Bounds="944,1438,55,26" Id="Sb91Noc3NV4OCK4iBodQeU">
                                       <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                         <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -6189,12 +6048,7 @@
                               <Pin Id="OsajJ5BU4y6PsLaLuPerJs" Name="Input" Kind="StateInputPin" />
                               <Pin Id="HWfyCmQ3a9QLl4QhF1H0tL" Name="Package Repositories Folder" Kind="OutputPin" />
                             </Node>
-                            <ControlPoint Id="OmSjM56eHIrP5r3xDnmkxC" Bounds="433,575" />
-                            <ControlPoint Id="QpC8rCllSBVPTuIIui4lwF" Bounds="435,1287" />
-                            <ControlPoint Id="OV8nOennsQ7QM0SRsErl5A" Bounds="459,1532" />
                             <ControlPoint Id="RL3coR6pdbVNToPXQQJ1yd" Bounds="460,575" />
-                            <ControlPoint Id="P1SukSKALkAP4iVxCLDfYx" Bounds="493,575" />
-                            <ControlPoint Id="KWv1KQrHVeyO1KFva1JpWU" Bounds="492,1108" />
                             <Node Bounds="626,540,65,19" Id="UUMhSWbERZpO4EO0clA0OR">
                               <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -6389,16 +6243,26 @@
                               <Pin Id="JmOulICL1q4LicI9Hjj4ZR" Name="Output" Kind="StateOutputPin" />
                               <Pin Id="Kv1wWHTA1sAPcwKZS9VoK8" Name="Launch Tab Runtime" Kind="OutputPin" />
                             </Node>
-                            <Node Bounds="626,2088,448,448" Id="Bi0ONTT1j7OOUrFhKNPM9p">
+                            <Node Bounds="629,1732,634,435" Id="Bi0ONTT1j7OOUrFhKNPM9p">
                               <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                 <Choice Kind="ProcessAppFlag" Name="CollapsingHeader" />
                               </p:NodeReference>
-                              <ControlPoint Id="BxFUAWGB2wwOhnQQMc6TMZ" Bounds="692,2094" Alignment="Top" />
+                              <ControlPoint Id="BxFUAWGB2wwOhnQQMc6TMZ" Bounds="695,1738" Alignment="Top" />
+                              <Pin Id="UCTr7LmH3vGMAsZYCX2Ukq" Name="Context" Kind="InputPin" />
+                              <Pin Id="BL6bjrD4dGQQT81s218KFN" Name="Label" Kind="InputPin" DefaultValue="Editable Packages" />
+                              <Pin Id="Oq2HTbbwrXALCOaK4536ri" Name="Visible" Kind="InputPin" />
+                              <Pin Id="EBT6xCwb165PguEgYtx9Oo" Name="Collapsed" Kind="InputPin" />
+                              <Pin Id="Qn3cq0nLpKgPGXpD9chuOf" Name="Closing" Kind="InputPin" />
+                              <Pin Id="UDdvfgvcLLcPmSayPzZknJ" Name="Style" Kind="InputPin" />
+                              <Pin Id="BeSmanyU4V2NMiOCyMlKL8" Name="Flags" Kind="InputPin" DefaultValue="SpanAvailWidth" />
+                              <Pin Id="Sgmckc5AxWbN19WAczxT95" Name="Context" Kind="OutputPin" />
+                              <Pin Id="Dpy6VULIYwdQQ5xuzfT4TT" Name="Close Clicked" Kind="OutputPin" />
+                              <Pin Id="PZqtRAZ1LOKPtNwienxJFt" Name="Content Is Visible" Kind="OutputPin" />
                               <Patch Id="JQ5JT7eYsCbMWHQx9MWhHX" ManuallySortedPins="true">
                                 <Patch Id="A5pRTs3mEuVNeXrMW37K8d" Name="Create" ManuallySortedPins="true" />
                                 <Patch Id="J6MAjZ9bM3tP3znnS5rGah" Name="Update" ManuallySortedPins="true" />
-                                <Node Bounds="690,2336,85,19" Id="REkhpZ3PCPEMsVvBEXjAoA">
+                                <Node Bounds="694,1943,381,19" Id="REkhpZ3PCPEMsVvBEXjAoA">
                                   <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                     <CategoryReference Kind="Category" Name="Widgets" NeedsToBeDirectParent="true" />
@@ -6412,24 +6276,24 @@
                                   <Pin Id="JiLpZjbgHRFLRgoPVvRy8n" Name="Context" Kind="OutputPin" />
                                   <Pin Id="TtEyrXAASVIMxXJPW2PdxX" Name="Bang" Kind="OutputPin" />
                                 </Node>
-                                <Node Bounds="678,2110,384,177" Id="NUGvU3tw7m7LMxTJjRNlJc">
+                                <Node Bounds="681,1797,384,114" Id="NUGvU3tw7m7LMxTJjRNlJc">
                                   <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                     <CategoryReference Kind="Category" Name="Primitive" />
                                     <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
                                   </p:NodeReference>
                                   <Pin Id="JtX9iQvq4XzO5qiMAOsGNu" Name="Break" Kind="OutputPin" />
-                                  <ControlPoint Id="R9sOaQ6PDGbNmJwJKcqujB" Bounds="693,2281" Alignment="Bottom" />
-                                  <ControlPoint Id="LaKc3uVTRVxNE7XPXZnejN" Bounds="692,2116" Alignment="Top" />
-                                  <ControlPoint Id="AiYF1flsZEVNbAgl6YL6OZ" Bounds="779,2116" Alignment="Top" />
+                                  <ControlPoint Id="R9sOaQ6PDGbNmJwJKcqujB" Bounds="696,1905" Alignment="Bottom" />
+                                  <ControlPoint Id="LaKc3uVTRVxNE7XPXZnejN" Bounds="695,1803" Alignment="Top" />
+                                  <ControlPoint Id="AiYF1flsZEVNbAgl6YL6OZ" Bounds="782,1803" Alignment="Top" />
                                   <Patch Id="CUnMBVjuxI5LmokkgKR4bc" ManuallySortedPins="true">
                                     <Patch Id="VfOCq2DJBO2MVWWczFJjRZ" Name="Create" ManuallySortedPins="true" />
                                     <Patch Id="CKMjzcnh0NqN0tdSnWQ5Oa" Name="Update" ManuallySortedPins="true">
                                       <Pin Id="U7ogho0tSL6K99iOFPvDT4" Name="Index" Kind="InputPin" />
                                     </Patch>
                                     <Patch Id="QidVvE4BHtMQImRdEpczZK" Name="Dispose" ManuallySortedPins="true" />
-                                    <ControlPoint Id="FcsbiGVX4rnMbBCKTGpWuz" Bounds="1013,2195" />
-                                    <Node Bounds="691,2218,325,19" Id="LUXlwShGeTaPhpJNL5FlrT">
+                                    <ControlPoint Id="FcsbiGVX4rnMbBCKTGpWuz" Bounds="1016,1839" />
+                                    <Node Bounds="694,1862,325,19" Id="LUXlwShGeTaPhpJNL5FlrT">
                                       <p:NodeReference LastCategoryFullName="Main.Editor.UI.Editor.Tabs.Settings" LastDependency="GammaLauncher.vl">
                                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                         <Choice Kind="ProcessAppFlag" Name="EditablePackageEntry" />
@@ -6443,7 +6307,7 @@
                                     </Node>
                                   </Patch>
                                 </Node>
-                                <Node Bounds="770,2372,230,144" Id="CZ2gDbB0OygOIaeRgGcItI">
+                                <Node Bounds="1070,1983,181,164" Id="CZ2gDbB0OygOIaeRgGcItI">
                                   <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                     <CategoryReference Kind="Category" Name="Primitive" />
@@ -6453,7 +6317,7 @@
                                   <Patch Id="NAQ6ccO8UnLODiBZdATLfH" ManuallySortedPins="true">
                                     <Patch Id="J9Esj93mPG9QViCokIHNvG" Name="Create" ManuallySortedPins="true" />
                                     <Patch Id="HYSzw3tHxy1OOSul0PxThl" Name="Then" ManuallySortedPins="true" />
-                                    <Node Bounds="782,2395,45,26" Id="LuF1DpPdNo5POVacLrzsux">
+                                    <Node Bounds="1082,2006,45,26" Id="LuF1DpPdNo5POVacLrzsux">
                                       <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                         <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -6463,7 +6327,7 @@
                                       <Pin Id="N9uV98zojjLPii95A5szCy" Name="Output" Kind="StateOutputPin" />
                                       <Pin Id="KxeRjcFLB8INVjUnpWXzhc" Name="Value" Kind="OutputPin" />
                                     </Node>
-                                    <Node Bounds="832,2428,156,26" Id="CgJ6LBE1oOQM4QHDTbza9O">
+                                    <Node Bounds="1132,2059,107,26" Id="CgJ6LBE1oOQM4QHDTbza9O">
                                       <p:NodeReference LastCategoryFullName="Main.Model.SettingsTabModel" LastDependency="GammaLauncher.vl">
                                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                         <Choice Kind="OperationCallFlag" Name="AddEditablePackage" />
@@ -6472,7 +6336,7 @@
                                       <Pin Id="HKwrZ2ZZkk4QHOoEFOduZ6" Name="Item" Kind="InputPin" />
                                       <Pin Id="E55DU2Xx8LEOZVOTUTLJv9" Name="Output" Kind="StateOutputPin" />
                                     </Node>
-                                    <Node Bounds="782,2470,55,26" Id="C1rVIcwWBUaOdUoCJhQJkt">
+                                    <Node Bounds="1082,2101,55,26" Id="C1rVIcwWBUaOdUoCJhQJkt">
                                       <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                         <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -6485,24 +6349,14 @@
                                   </Patch>
                                 </Node>
                               </Patch>
-                              <Pin Id="UCTr7LmH3vGMAsZYCX2Ukq" Name="Context" Kind="InputPin" />
-                              <Pin Id="BL6bjrD4dGQQT81s218KFN" Name="Label" Kind="InputPin" DefaultValue="Editable Packages" />
-                              <Pin Id="Oq2HTbbwrXALCOaK4536ri" Name="Visible" Kind="InputPin" />
-                              <Pin Id="EBT6xCwb165PguEgYtx9Oo" Name="Collapsed" Kind="InputPin" />
-                              <Pin Id="Qn3cq0nLpKgPGXpD9chuOf" Name="Closing" Kind="InputPin" />
-                              <Pin Id="UDdvfgvcLLcPmSayPzZknJ" Name="Style" Kind="InputPin" />
-                              <Pin Id="BeSmanyU4V2NMiOCyMlKL8" Name="Flags" Kind="InputPin" DefaultValue="SpanAvailWidth" />
-                              <Pin Id="Sgmckc5AxWbN19WAczxT95" Name="Context" Kind="OutputPin" />
-                              <Pin Id="Dpy6VULIYwdQQ5xuzfT4TT" Name="Close Clicked" Kind="OutputPin" />
-                              <Pin Id="PZqtRAZ1LOKPtNwienxJFt" Name="Content Is Visible" Kind="OutputPin" />
                             </Node>
                             <ControlPoint Id="Iv5y2s3RxO3QJvhGOpySfl" Bounds="412,564" />
-                            <Pad Id="LkrMtExgm5NPl3NiAheu5O" Bounds="411,1913" />
-                            <ControlPoint Id="MlHym66gG3APZgA9zgjRBo" Bounds="414,2265" />
-                            <ControlPoint Id="AfD6Tp4TaaSLDDQBDvCXyb" Bounds="1197,1268" />
-                            <Pad Id="AQEdaGgfiOUOgJE6816E8H" SlotId="N4FYsPZ4cxGO92b9tdsJUM" Bounds="1193,1944" />
-                            <ControlPoint Id="QZ2wTLhTp9HM6p8oEQMW0O" Bounds="1127,1806" />
-                            <Node Bounds="735,1965,45,26" Id="IgJRdrI9HqGQEaKWR7z2KY">
+                            <Pad Id="LkrMtExgm5NPl3NiAheu5O" Bounds="414,1557" />
+                            <ControlPoint Id="MlHym66gG3APZgA9zgjRBo" Bounds="417,1909" />
+                            <ControlPoint Id="AfD6Tp4TaaSLDDQBDvCXyb" Bounds="1227,1498" />
+                            <Pad Id="AQEdaGgfiOUOgJE6816E8H" SlotId="N4FYsPZ4cxGO92b9tdsJUM" Bounds="1062,1631" />
+                            <ControlPoint Id="QZ2wTLhTp9HM6p8oEQMW0O" Bounds="1464,1458" />
+                            <Node Bounds="740,1617,45,26" Id="IgJRdrI9HqGQEaKWR7z2KY">
                               <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -6512,7 +6366,7 @@
                               <Pin Id="V4DfoV55IKRQZYqmhha6z2" Name="Output" Kind="StateOutputPin" />
                               <Pin Id="TcjL3JNQqVbQVAPtwBjw6K" Name="Value" Kind="OutputPin" />
                             </Node>
-                            <Node Bounds="775,2005,153,26" Id="OYnBKDm8Vw7OMTmGKBj7pd">
+                            <Node Bounds="780,1658,153,26" Id="OYnBKDm8Vw7OMTmGKBj7pd">
                               <p:NodeReference LastCategoryFullName="Main.Model.SettingsTabModel" LastDependency="GammaLauncher.vl">
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 <Choice Kind="OperationCallFlag" Name="GetEditablePackages" />
@@ -6525,28 +6379,13 @@
     ************************ EditablePackageEntry ************************
 
 -->
-                            <Node Name="EditablePackageEntry" Bounds="1232,2242" Id="TZeTbWiET3tNXC5AHHU29H">
+                            <Node Name="EditablePackageEntry" Bounds="1318,1891" Id="TZeTbWiET3tNXC5AHHU29H">
                               <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                                 <Choice Kind="ContainerDefinition" Name="Process" />
                               </p:NodeReference>
                               <Patch Id="VgWLqzqil3xOredHUdNsmP">
                                 <Canvas Id="IWtwn1Xk9QBNbfsa24Ojz8" CanvasType="Group">
-                                  <Node Bounds="385,457,105,19" Id="GtDKcO5K65TLtBkREllqkS">
-                                    <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
-                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                      <Choice Kind="ProcessNode" Name="Input (String)" />
-                                    </p:NodeReference>
-                                    <Pin Id="QFgVxNQOo1nOL4GLKE9K5j" Name="Context" Kind="InputPin" />
-                                    <Pin Id="HtyiFWBKLggOnVbMVJItLY" Name="Channel" Kind="InputPin" />
-                                    <Pin Id="Iqg092856UQOD1DU7hE2mm" Name="Label" Kind="InputPin" />
-                                    <Pin Id="MXYOQJzeuvKLDojLbiptpr" Name="Max Length" Kind="InputPin" />
-                                    <Pin Id="V5FQ35yRVb5MywGxJhSrPC" Name="Flags" Kind="InputPin" />
-                                    <Pin Id="AJTMOU6rEYfLmKvam9fenj" Name="Style" Kind="InputPin" />
-                                    <Pin Id="PolUKEGAtqMMxEguKiOdAc" Name="Context" Kind="OutputPin" />
-                                    <Pin Id="Rceuocur8aFNDhgIceL2eF" Name="Bang" Kind="OutputPin" />
-                                    <Pin Id="Kwpep5f9MxPP5z9KE1dOZ4" Name="Value" Kind="OutputPin" />
-                                  </Node>
-                                  <Node Bounds="385,512,59,19" Id="HyH2uK2JdKTLGpQUf4eksO">
+                                  <Node Bounds="385,767,59,19" Id="HyH2uK2JdKTLGpQUf4eksO">
                                     <p:NodeReference LastCategoryFullName="ImGui.Commands" LastDependency="VL.ImGui.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <Choice Kind="ProcessNode" Name="SameLine" />
@@ -6556,7 +6395,7 @@
                                     <Pin Id="DeHV193rd0EQNyb2fraPbw" Name="Spacing" Kind="InputPin" />
                                     <Pin Id="AMEE0afzrvnN3HxParTztk" Name="Context" Kind="OutputPin" />
                                   </Node>
-                                  <Node Bounds="385,608,85,19" Id="Ic7ZG7UkqDgMn0XWYxw1mc">
+                                  <Node Bounds="385,863,85,19" Id="Ic7ZG7UkqDgMn0XWYxw1mc">
                                     <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <CategoryReference Kind="Category" Name="Widgets" NeedsToBeDirectParent="true" />
@@ -6570,7 +6409,7 @@
                                     <Pin Id="VHZk8cZwE8nNmlcj01knRe" Name="Context" Kind="OutputPin" />
                                     <Pin Id="LUl2hfwnnOaLnZ3XRV7xKf" Name="Bang" Kind="OutputPin" />
                                   </Node>
-                                  <Node Bounds="405,376,43,19" Id="CXUcgFrTjugOuEFATUx5Zu">
+                                  <Node Bounds="415,378,43,19" Id="CXUcgFrTjugOuEFATUx5Zu">
                                     <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <Choice Kind="ProcessAppFlag" Name="Select (ByPath)" />
@@ -6580,7 +6419,7 @@
                                     <Pin Id="OYpd9PUrLqvM9fN3YiIuAi" Name="Output" Kind="OutputPin" />
                                   </Node>
                                   <ControlPoint Id="PL8YnZCTdXdQZmcyyQoc7y" Bounds="708,283" />
-                                  <Node Bounds="463,308,55,19" Id="QFneJvRXglTLUxRbME1bES">
+                                  <Node Bounds="473,310,55,19" Id="QFneJvRXglTLUxRbME1bES">
                                     <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <Choice Kind="OperationCallFlag" Name="ToString" />
@@ -6588,7 +6427,7 @@
                                     <Pin Id="D76MwrN1gMcL3Gd3VjfPzN" Name="Input" Kind="InputPin" />
                                     <Pin Id="JoXRgkOe8rAPE1YIbka91n" Name="Result" Kind="OutputPin" />
                                   </Node>
-                                  <Node Bounds="465,682,257,164" Id="C9jGj1gRlyANzkpiki02QU">
+                                  <Node Bounds="465,937,257,164" Id="C9jGj1gRlyANzkpiki02QU">
                                     <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                       <CategoryReference Kind="Category" Name="Primitive" />
@@ -6598,7 +6437,7 @@
                                     <Patch Id="KmHancQIpXTMnEyyUNS66h" ManuallySortedPins="true">
                                       <Patch Id="BdNLL2P3aE2MUYyETKIKE6" Name="Create" ManuallySortedPins="true" />
                                       <Patch Id="PKmbmfuuIjfMOAbTHGO31y" Name="Then" ManuallySortedPins="true" />
-                                      <Node Bounds="527,755,183,26" Id="AkHKY1KwAwhLyIQ2t1qFel">
+                                      <Node Bounds="527,1010,183,26" Id="AkHKY1KwAwhLyIQ2t1qFel">
                                         <p:NodeReference LastCategoryFullName="Main.Model.SettingsTabModel" LastDependency="GammaLauncher.vl">
                                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                           <Choice Kind="OperationCallFlag" Name="RemoveEditablePackage" />
@@ -6607,7 +6446,7 @@
                                         <Pin Id="Qj4yDHdE3ghNKzP1pCinrH" Name="Index" Kind="InputPin" />
                                         <Pin Id="VEZ6pF6yIKRN3ygLSFqcDb" Name="Output" Kind="StateOutputPin" />
                                       </Node>
-                                      <Node Bounds="477,705,45,26" Id="NxCT4t2rOZXOo9MYS73jBO">
+                                      <Node Bounds="477,960,45,26" Id="NxCT4t2rOZXOo9MYS73jBO">
                                         <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                           <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -6617,7 +6456,7 @@
                                         <Pin Id="LSlHHg2yO1xNTjJxnYSKKt" Name="Output" Kind="StateOutputPin" />
                                         <Pin Id="N7jmFqwmWdWOBJx2p2DLxc" Name="Value" Kind="OutputPin" />
                                       </Node>
-                                      <Node Bounds="477,800,55,26" Id="C2qqTQuF8kgM6K5iLMGwFe">
+                                      <Node Bounds="477,1055,55,26" Id="C2qqTQuF8kgM6K5iLMGwFe">
                                         <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                           <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -6629,7 +6468,7 @@
                                       </Node>
                                     </Patch>
                                   </Node>
-                                  <Node Bounds="432,419,85,19" Id="P1HMUyr32oKLExSdO3K7X2">
+                                  <Node Bounds="444,421,85,19" Id="P1HMUyr32oKLExSdO3K7X2">
                                     <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
@@ -6642,7 +6481,7 @@
                                     <Pin Id="Ta6MnZowTWIO9UGyNjz33d" Name="Input 4" Kind="InputPin" />
                                     <Pin Id="FJoSyFOcw4XLxitTqKcuSg" Name="Output" Kind="StateOutputPin" />
                                   </Node>
-                                  <Node Bounds="425,575,85,19" Id="DKrM12aIwjpM8JkhSDafPX">
+                                  <Node Bounds="425,830,85,19" Id="DKrM12aIwjpM8JkhSDafPX">
                                     <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
@@ -6655,7 +6494,7 @@
                                     <Pin Id="NjEg91VP2EFLQbwN2W00ep" Name="Input 4" Kind="InputPin" />
                                     <Pin Id="AUrrhjNzOauLyyAV9QXcJC" Name="Output" Kind="StateOutputPin" />
                                   </Node>
-                                  <Node Bounds="443,345,85,19" Id="VXezhgnPedRPPkaMtCWW3e">
+                                  <Node Bounds="453,347,85,19" Id="VXezhgnPedRPPkaMtCWW3e">
                                     <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
@@ -6668,23 +6507,137 @@
                                     <Pin Id="Fl3alLBdUxXMtDvJgrZiqq" Name="Input 4" Kind="InputPin" />
                                     <Pin Id="QAMeE5WShtuLBNh7gbgWAg" Name="Output" Kind="StateOutputPin" />
                                   </Node>
-                                  <ControlPoint Id="L4SkuufLtFJOwO5mvvGFkG" Bounds="387,195" />
-                                  <ControlPoint Id="MWyxPwPgl3uL4uUyz767c3" Bounds="388,905" />
-                                  <ControlPoint Id="EGuiimVG0CUQcXqJXu28Fp" Bounds="479,654" />
-                                  <ControlPoint Id="QVDzwzdGD3uMUMvG56Fjbf" Bounds="407,332" />
+                                  <ControlPoint Id="L4SkuufLtFJOwO5mvvGFkG" Bounds="386,-71" />
+                                  <ControlPoint Id="MWyxPwPgl3uL4uUyz767c3" Bounds="388,1160" />
+                                  <ControlPoint Id="EGuiimVG0CUQcXqJXu28Fp" Bounds="479,909" />
+                                  <ControlPoint Id="QVDzwzdGD3uMUMvG56Fjbf" Bounds="417,334" />
                                   <ControlPoint Id="UpKC5nqLilcMdizUY5Viz6" Bounds="783,281" />
                                   <ControlPoint Id="L4B6cH7bFqVOfiOPD6Iypa" Bounds="892,282" />
+                                  <Node Bounds="384,79,162,19" Id="To7sKRtRcZkNnl42ePwpLy">
+                                    <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <Choice Kind="ProcessNode" Name="Checkbox" />
+                                    </p:NodeReference>
+                                    <Pin Id="A2lptISiR2gOy4alVk4E7Z" Name="Context" Kind="InputPin" />
+                                    <Pin Id="D5gMCBPHTchQK7AXCyy0B8" Name="Channel" Kind="InputPin" />
+                                    <Pin Id="H5m4lW9KCRnLo47yF9Njza" Name="Label" Kind="InputPin" />
+                                    <Pin Id="VbntwUbsRXnPHj7yxlEWeK" Name="Style" Kind="InputPin" />
+                                    <Pin Id="Dr8zYyCANLRONyoGRkTp7h" Name="Context" Kind="OutputPin" />
+                                    <Pin Id="Vbi1kY66HUINfdG0FNIFrM" Name="Bang" Kind="OutputPin" />
+                                    <Pin Id="HXEbwmPQVoPO2WpASHnEX9" Name="Value" Kind="OutputPin" />
+                                  </Node>
+                                  <Node Bounds="384,163,59,19" Id="LeSkaeL7SzNPL4uYqKZMS5">
+                                    <p:NodeReference LastCategoryFullName="ImGui.Commands" LastDependency="VL.ImGui.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <Choice Kind="ProcessNode" Name="SameLine" />
+                                    </p:NodeReference>
+                                    <Pin Id="A2EB6J42lUxLZVL3K7pUMa" Name="Context" Kind="InputPin" />
+                                    <Pin Id="S3u3M6IVj4UPzBePPzb6du" Name="Offset" Kind="InputPin" DefaultValue="0.34" />
+                                    <Pin Id="B34u149FZg6OYo0RGJaCvi" Name="Spacing" Kind="InputPin" />
+                                    <Pin Id="NJVd60Gfe5WPD07t4m7DpN" Name="Context" Kind="OutputPin" />
+                                  </Node>
+                                  <Node Bounds="541,212,37,19" Id="OIZgR2fxF3BNtsqTdLfKWZ">
+                                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <Choice Kind="OperationCallFlag" Name="NOT" />
+                                    </p:NodeReference>
+                                    <Pin Id="NAbis79HkCHO2RZhiy6ro2" Name="Input" Kind="StateInputPin" />
+                                    <Pin Id="SYDFhV7EwLqNZftUQ3KAkd" Name="Output" Kind="StateOutputPin" />
+                                  </Node>
+                                  <Node Bounds="541,50,97,19" Id="Ecapph7ZLncNapF9PS8cY8">
+                                    <p:NodeReference LastCategoryFullName="ImGui.Styling" LastDependency="VL.ImGui.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <Choice Kind="ProcessNode" Name="SetCheckboxStyle" />
+                                    </p:NodeReference>
+                                    <Pin Id="I8ApKKIfWK0P6bcstfdajz" Name="Input" Kind="InputPin" />
+                                    <Pin Id="LMXzTAgw98INAibv0wZeDl" Name="Checkmark" Kind="InputPin" />
+                                    <Pin Id="Aoizz5Z2tCfLZvAocv4GHL" Name="Output" Kind="OutputPin" />
+                                  </Node>
+                                  <Pad Id="JLycEWUhWrPLj7UOKP28ZU" Comment="Checkmark" Bounds="635,29,22,15" ShowValueBox="true" isIOBox="true" Value="0.9411765, 0.7411765, 0.050980393, 1">
+                                    <p:TypeAnnotation LastCategoryFullName="Color" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="TypeFlag" Name="RGBA" />
+                                    </p:TypeAnnotation>
+                                  </Pad>
+                                  <Node Bounds="384,125,284,19" Id="UAIzmS1kgUGNkCOWVEwMtl">
+                                    <p:NodeReference LastCategoryFullName="ImGui.Queries" LastDependency="VL.ImGui.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <Choice Kind="ProcessNode" Name="IsItemHovered" />
+                                    </p:NodeReference>
+                                    <Pin Id="CBknx8c8LxdM6dyfY51UL6" Name="Context" Kind="InputPin" />
+                                    <Pin Id="D3poBsVtwHoLVmwDCa8Y0e" Name="Flags" Kind="InputPin" />
+                                    <Pin Id="UPUBLlvNWobQAmPQpgXOjB" Name="Context" Kind="OutputPin" />
+                                    <Pin Id="Ga8Md74dZm5MGNVuNmFl3V" Name="Value" Kind="OutputPin" />
+                                  </Node>
+                                  <Node Bounds="663,188,82,80" Id="HzYzgJeusDNNKeRW9mygWG">
+                                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                                      <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                                      <CategoryReference Kind="Category" Name="Primitive" />
+                                      <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                                    </p:NodeReference>
+                                    <Pin Id="OMu2qt2ux0gPEVEjEPV2Fj" Name="Condition" Kind="InputPin" />
+                                    <Patch Id="RvRGHsSEabZLw4M9nakZED" ManuallySortedPins="true">
+                                      <Patch Id="R5yBXhUUbIrNqofMcdyQod" Name="Create" ManuallySortedPins="true" />
+                                      <Patch Id="RObXpDNoYMTMorWByic4WG" Name="Then" ManuallySortedPins="true" />
+                                      <Node Bounds="681,220,49,19" Id="U1KMuAfHV84QL3hzxB0IG7">
+                                        <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
+                                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                          <Choice Kind="ProcessNode" Name="Tooltip (String)" />
+                                        </p:NodeReference>
+                                        <Pin Id="OvAZsJTlVXAQWMHOQAqiaT" Name="Context" Kind="InputPin" />
+                                        <Pin Id="AKmqkQD90qEMXstjTeTROe" Name="Content" Kind="InputPin" DefaultValue="Enable or disable editing for this package" />
+                                        <Pin Id="JT79gPik2X9LwYa8AmHNla" Name="Style" Kind="InputPin" />
+                                        <Pin Id="Q7osx2zAqMFOZeCn4TM66a" Name="Context" Kind="OutputPin" />
+                                      </Node>
+                                    </Patch>
+                                  </Node>
+                                  <Node Bounds="663,155,62,19" Id="RjV8r5D1HlOM4O2i0yL0Pe">
+                                    <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <Choice Kind="ProcessAppFlag" Name="TimerFlop" />
+                                    </p:NodeReference>
+                                    <Pin Id="GX84aJBf5tHOnrDWp03D46" Name="Set" Kind="InputPin" />
+                                    <Pin Id="Njb0m7BJ18APBR30OimP75" Name="Reset" Kind="InputPin" />
+                                    <Pin Id="FmeZqhyCOp5NMbrEd9eqvX" Name="Time" Kind="InputPin" DefaultValue="0.8" />
+                                    <Pin Id="OwzUtp9BnHYPETHeQfRVBP" Name="Value" Kind="OutputPin" />
+                                    <Pin Id="TU5lhSFbpjzQEERpRluZYD" Name="Running" Kind="OutputPin" />
+                                  </Node>
+                                  <Node Bounds="375,491,171,86" Id="EPEeM6R7SEOOoVv9iyYeDm">
+                                    <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
+                                      <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                                      <CategoryReference Kind="Category" Name="Widgets" NeedsToBeDirectParent="true" />
+                                      <Choice Kind="ProcessAppFlag" Name="Disabled" />
+                                    </p:NodeReference>
+                                    <Patch Id="ELh2sIgcpnXMjjR6Pv2f5E" ManuallySortedPins="true">
+                                      <Patch Id="PO9ppFHJ1I9LUFR88vOKAA" Name="Create" ManuallySortedPins="true" />
+                                      <Patch Id="CLdHbzZGF9wLpce0CsByaH" Name="Update" ManuallySortedPins="true" />
+                                      <Node Bounds="387,527,147,19" Id="GtDKcO5K65TLtBkREllqkS">
+                                        <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
+                                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                          <Choice Kind="ProcessNode" Name="Input (String)" />
+                                        </p:NodeReference>
+                                        <Pin Id="QFgVxNQOo1nOL4GLKE9K5j" Name="Context" Kind="InputPin" />
+                                        <Pin Id="HtyiFWBKLggOnVbMVJItLY" Name="Channel" Kind="InputPin" />
+                                        <Pin Id="Iqg092856UQOD1DU7hE2mm" Name="Label" Kind="InputPin" />
+                                        <Pin Id="MXYOQJzeuvKLDojLbiptpr" Name="Max Length" Kind="InputPin" />
+                                        <Pin Id="V5FQ35yRVb5MywGxJhSrPC" Name="Flags" Kind="InputPin" />
+                                        <Pin Id="AJTMOU6rEYfLmKvam9fenj" Name="Style" Kind="InputPin" />
+                                        <Pin Id="PolUKEGAtqMMxEguKiOdAc" Name="Context" Kind="OutputPin" />
+                                        <Pin Id="Rceuocur8aFNDhgIceL2eF" Name="Bang" Kind="OutputPin" />
+                                        <Pin Id="Kwpep5f9MxPP5z9KE1dOZ4" Name="Value" Kind="OutputPin" />
+                                      </Node>
+                                    </Patch>
+                                    <Pin Id="EubGqCLn9XIQXMkZHRDAe3" Name="Context" Kind="InputPin" />
+                                    <Pin Id="S9asXxmS4MJP2F34qoiIsm" Name="Style" Kind="InputPin" />
+                                    <Pin Id="UD7MTEsn0TWOY82GWcQuCt" Name="Apply" Kind="InputPin" />
+                                    <Pin Id="Ifnnh3wHFKgP1VL7tKGinM" Name="Context" Kind="OutputPin" />
+                                    <ControlPoint Id="Por9hgUnYNANIOWvelVlcU" Bounds="389,571" Alignment="Bottom" />
+                                  </Node>
+                                  <ControlPoint Id="D8Lhlt0VTyhPefT5lzAGV2" Bounds="543,14" />
                                 </Canvas>
-                                <!--
-
-    ************************  ************************
-
--->
                                 <ProcessDefinition Id="UpIXeSV5iBzPAZbj6AxPvs">
                                   <Fragment Id="T5haXqutLlnMVCqt5ygI1F" Patch="PXAvzaUQHKGO6cHM208nq1" Enabled="true" />
                                   <Fragment Id="MexavGqpHgNQLtRsiWUjp2" Patch="Um1yf5P7tQCOv2vhgqMWu3" Enabled="true" />
                                 </ProcessDefinition>
-                                <Link Id="F4slUNUNOaHOx3JMvKIs5g" Ids="PolUKEGAtqMMxEguKiOdAc,KK2lbZonGcAN38jyKjij6J" />
                                 <Link Id="EQYpyP60t3oOHRZTTu8TrL" Ids="AMEE0afzrvnN3HxParTztk,MeTBeVs7WG4O7wDyGtmeoV" />
                                 <Link Id="TH1mZ2m6yvMOh3OCtAYGkz" Ids="OYpd9PUrLqvM9fN3YiIuAi,HtyiFWBKLggOnVbMVJItLY" />
                                 <Link Id="I7zCI62N7bZLUUSo28rfNQ" Ids="VVk0XMBGZXqN4MZCs1EH9t,PL8YnZCTdXdQZmcyyQoc7y" IsHidden="true" />
@@ -6700,7 +6653,6 @@
                                 <Link Id="T9Z7MKy6sEWPh7MnINCggO" Ids="AUrrhjNzOauLyyAV9QXcJC,LywqDvJqQxPNlqESViOYPm" />
                                 <Link Id="H5bqOXIX7YpNQmGFnfQ2de" Ids="JoXRgkOe8rAPE1YIbka91n,JRl4elGlvB6MAJVvv0ANjM" />
                                 <Link Id="UKoIytKvHAhOVH31YDmUJA" Ids="QAMeE5WShtuLBNh7gbgWAg,EdcSlJIxm0BQdS4lPrStcd" />
-                                <Link Id="PkCerC8B0ufPPJvVKwB1G3" Ids="L4SkuufLtFJOwO5mvvGFkG,QFgVxNQOo1nOL4GLKE9K5j" />
                                 <Link Id="GrG7rgB9T8SPs6gpykznM6" Ids="Pb2aiTFZ78lNSvRDnpNs6o,L4SkuufLtFJOwO5mvvGFkG" IsHidden="true" />
                                 <Link Id="FwGKGAhzwW0PAM2PJKGEBm" Ids="VHZk8cZwE8nNmlcj01knRe,MWyxPwPgl3uL4uUyz767c3" />
                                 <Link Id="SS5ZaQLjSrBMr99MUKYYpt" Ids="MWyxPwPgl3uL4uUyz767c3,B0oYoiRXijuLhhi3tzFMI4" IsHidden="true" />
@@ -6721,8 +6673,367 @@
                                 <Link Id="O31nitu6YSUOv1fua0lOFR" Ids="LfByQmTkoeXOkfrUPr9tnx,UpKC5nqLilcMdizUY5Viz6" IsHidden="true" />
                                 <Link Id="RZfOombNITIPM1X9THIH0H" Ids="L4B6cH7bFqVOfiOPD6Iypa,CNGCnMOqpP3MfqTTngso1T" />
                                 <Link Id="EhBCXCRJvunMcyT0MgL4qy" Ids="AhBK45UXrRPLrFsYXzgnHR,L4B6cH7bFqVOfiOPD6Iypa" IsHidden="true" />
+                                <Link Id="D1z1Q63N3NDQMRlBOmMTFQ" Ids="HXEbwmPQVoPO2WpASHnEX9,NAbis79HkCHO2RZhiy6ro2" />
+                                <Link Id="Cu2RZzLzaSKPTnSk9rz7dR" Ids="JLycEWUhWrPLj7UOKP28ZU,LMXzTAgw98INAibv0wZeDl" />
+                                <Link Id="CwYBuBYZz1INdn6PmV2DzY" Ids="Aoizz5Z2tCfLZvAocv4GHL,VbntwUbsRXnPHj7yxlEWeK" />
+                                <Link Id="V3zpnK7JnBKMp67hwIOVvj" Ids="Dr8zYyCANLRONyoGRkTp7h,CBknx8c8LxdM6dyfY51UL6" />
+                                <Link Id="Ur94FfDxxvhMfm0G20uL51" Ids="UPUBLlvNWobQAmPQpgXOjB,A2EB6J42lUxLZVL3K7pUMa" />
+                                <Link Id="JbxCgQoh9keL3T6Q4r8hgv" Ids="Ga8Md74dZm5MGNVuNmFl3V,GX84aJBf5tHOnrDWp03D46" />
+                                <Link Id="HFDJSVTrKDvOvxmclCsvkk" Ids="OwzUtp9BnHYPETHeQfRVBP,OMu2qt2ux0gPEVEjEPV2Fj" />
+                                <Link Id="Gj531Wi9MUOLYVk2gOT5Gj" Ids="L4SkuufLtFJOwO5mvvGFkG,A2lptISiR2gOy4alVk4E7Z" />
+                                <Link Id="BdyMdaWdxAOLxITZ83bzKW" Ids="NJVd60Gfe5WPD07t4m7DpN,QFgVxNQOo1nOL4GLKE9K5j" />
+                                <Link Id="CU5Tm13YgHELtXiJ8xnXEU" Ids="PolUKEGAtqMMxEguKiOdAc,Por9hgUnYNANIOWvelVlcU" />
+                                <Link Id="GoiF4MPPhqaMzloPkq6Izo" Ids="Por9hgUnYNANIOWvelVlcU,KK2lbZonGcAN38jyKjij6J" />
+                                <Link Id="INErfXNb3lcLGTC0TjhVNm" Ids="SYDFhV7EwLqNZftUQ3KAkd,UD7MTEsn0TWOY82GWcQuCt" />
+                                <Link Id="Bt6eF0NSrKyPOHf1qcstDZ" Ids="LfByQmTkoeXOkfrUPr9tnx,D8Lhlt0VTyhPefT5lzAGV2" IsHidden="true" />
+                                <Link Id="Ol9zx5RbAB0L3CUFZKzp9G" Ids="D8Lhlt0VTyhPefT5lzAGV2,I8ApKKIfWK0P6bcstfdajz" />
                               </Patch>
                             </Node>
+                            <!--
+
+    ************************ PackageRepositoriesEntry ************************
+
+-->
+                            <Node Name="PackageRepositoriesEntry" Bounds="1593,1384" Id="EHXPRVepfEcOE3APHGNOcM">
+                              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                                <Choice Kind="ContainerDefinition" Name="Process" />
+                              </p:NodeReference>
+                              <Patch Id="HgcU4G0wW5gMxx2ERlEZSQ">
+                                <Canvas Id="Ue4stJu4ydzPX2VEaTMASU" CanvasType="Group">
+                                  <Node Bounds="768,726,59,19" Id="OXWuz9J2XxSLR4hyGoXS1F">
+                                    <p:NodeReference LastCategoryFullName="ImGui.Commands" LastDependency="VL.ImGui.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <Choice Kind="ProcessNode" Name="SameLine" />
+                                    </p:NodeReference>
+                                    <Pin Id="Snf3Hm6IvwHQdHJHDJLOXi" Name="Context" Kind="InputPin" />
+                                    <Pin Id="TqW0CEcuAxYL4erCcj3JBg" Name="Offset" Kind="InputPin" />
+                                    <Pin Id="SXx2hAeinXINq9e3tSr7hR" Name="Spacing" Kind="InputPin" />
+                                    <Pin Id="RBZBWxVD7ubLMdIsgVYVoO" Name="Context" Kind="OutputPin" />
+                                  </Node>
+                                  <Node Bounds="768,824,85,19" Id="UJh8eUpQBNNLftaX2P8uEE">
+                                    <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <CategoryReference Kind="Category" Name="Widgets" NeedsToBeDirectParent="true" />
+                                      <Choice Kind="ProcessAppFlag" Name="Button" />
+                                    </p:NodeReference>
+                                    <Pin Id="KIaZnHTx9yrLyE0LJ4c2PA" Name="Context" Kind="InputPin" />
+                                    <Pin Id="E3ooaEMQ9x2Obrrx7sLjep" Name="Channel" Kind="InputPin" />
+                                    <Pin Id="Tbie6gJdtSPN4sceZEsgN8" Name="Label" Kind="InputPin" DefaultValue="X" />
+                                    <Pin Id="OQNZfvkpQsCOOucNijLejt" Name="Size" Kind="InputPin" />
+                                    <Pin Id="F9csE93BsojLjeQpJ789Xo" Name="Style" Kind="InputPin" />
+                                    <Pin Id="QCOR9pMZALNOKLEslUnrln" Name="Context" Kind="OutputPin" />
+                                    <Pin Id="CJSBi3zKLtxNWAGshg2M1I" Name="Bang" Kind="OutputPin" />
+                                  </Node>
+                                  <Node Bounds="788,417,43,19" Id="SKPYNPCUaQeNFHOkEjsSEq">
+                                    <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <Choice Kind="ProcessAppFlag" Name="Select (ByPath)" />
+                                    </p:NodeReference>
+                                    <Pin Id="NBBfRTd4TjON5NsofKgh8W" Name="Input" Kind="InputPin" />
+                                    <Pin Id="Ga2JV138YmLNWlXRPiJhuG" Name="Path" Kind="InputPin" DefaultValue="Package Repositories Folder[0]" />
+                                    <Pin Id="TyJ07eBJG3VM0y7f1nzlCO" Name="Output" Kind="OutputPin" />
+                                  </Node>
+                                  <Node Bounds="908,461,85,19" Id="GwUNwIQHSwSOV2tCbJqG3T">
+                                    <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
+                                      <Choice Kind="OperationCallFlag" Name="Format" />
+                                    </p:NodeReference>
+                                    <Pin Id="Q0AkcGidqhtM71YumWmJWB" Name="Format" Kind="InputPin" DefaultValue="...##BrowseButton{0}" />
+                                    <Pin Id="VuNjzFF37VJNdk4017AurH" Name="Input" Kind="StateInputPin" />
+                                    <Pin Id="IWR3QQLRr5nP5pvOOqhWD8" Name="Input 2" Kind="InputPin" />
+                                    <Pin Id="KqUXARHkJ3gNYmIw8vJVLe" Name="Input 3" Kind="InputPin" />
+                                    <Pin Id="DVCZD9NnqvKMm4QgITF562" Name="Input 4" Kind="InputPin" />
+                                    <Pin Id="AYefMxCcPzPQPj3r5frcOv" Name="Output" Kind="StateOutputPin" />
+                                  </Node>
+                                  <ControlPoint Id="UNEgUFSKLYYOyTeC8jwYpg" Bounds="1091,325" />
+                                  <Node Bounds="846,345,55,19" Id="GqMnWr92KvFMUSkAF4pCVK">
+                                    <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <Choice Kind="OperationCallFlag" Name="ToString" />
+                                    </p:NodeReference>
+                                    <Pin Id="PfRj81shys9O4eFyyMGjNu" Name="Input" Kind="InputPin" />
+                                    <Pin Id="AiG5eDyGmyKLQjZHos8uWx" Name="Result" Kind="OutputPin" />
+                                  </Node>
+                                  <Node Bounds="848,887,257,149" Id="RU0NQIjnyYzPNeBxNiEQAB">
+                                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                                      <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                                      <CategoryReference Kind="Category" Name="Primitive" />
+                                      <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                                    </p:NodeReference>
+                                    <Pin Id="OsYq2NeLHPdQFm1P6fhBmX" Name="Condition" Kind="InputPin" />
+                                    <Patch Id="FFgbUAr1NzvPmgne4ZJUtw" ManuallySortedPins="true">
+                                      <Patch Id="Ikxd5tY1UhJQZ9YPjTDqsp" Name="Create" ManuallySortedPins="true" />
+                                      <Patch Id="V20vv8YXmM6Legr47tLbel" Name="Then" ManuallySortedPins="true" />
+                                      <Node Bounds="910,953,183,26" Id="PhPgca0R2tSQAKL4sN831W">
+                                        <p:NodeReference LastCategoryFullName="Main.Model.SettingsTabModel" LastDependency="GammaLauncher.vl">
+                                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                          <Choice Kind="OperationCallFlag" Name="RemovePackageRepositoriesFolderAt" />
+                                        </p:NodeReference>
+                                        <Pin Id="FMJgkcZz8kkPkjs5YxmDAk" Name="Input" Kind="StateInputPin" />
+                                        <Pin Id="ToulhYPrvJEPzPAdWHoY4R" Name="Index" Kind="InputPin" />
+                                        <Pin Id="Q26ztZZqftJORCMZwLPtjR" Name="Output" Kind="StateOutputPin" />
+                                      </Node>
+                                      <Node Bounds="860,910,45,26" Id="TBXhx6LsbtnQJoxhGhxgu9">
+                                        <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
+                                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                          <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
+                                          <Choice Kind="OperationCallFlag" Name="Value" />
+                                        </p:NodeReference>
+                                        <Pin Id="HMVbgdIUEB6LNXrbTqN8zu" Name="Input" Kind="StateInputPin" />
+                                        <Pin Id="MZb8C2FatqtPHXVLo8tbnw" Name="Output" Kind="StateOutputPin" />
+                                        <Pin Id="Gl0uUNHW9ybNeVwqyjq3SX" Name="Value" Kind="OutputPin" />
+                                      </Node>
+                                      <Node Bounds="860,990,55,26" Id="L7O0S1BYjGfPph6gSC7Ny7">
+                                        <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
+                                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                          <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
+                                          <Choice Kind="OperationCallFlag" Name="SetValue" />
+                                        </p:NodeReference>
+                                        <Pin Id="A17Uk7szlH0MgljzxasBog" Name="Input" Kind="StateInputPin" />
+                                        <Pin Id="UIzHL4jyX1vMg2nXtGDsLt" Name="Value" Kind="InputPin" />
+                                        <Pin Id="V28vEohMDIXPyaYDMpwbpV" Name="Output" Kind="StateOutputPin" />
+                                      </Node>
+                                    </Patch>
+                                  </Node>
+                                  <Node Bounds="808,458,85,19" Id="LXa5L8I1BCuL8nUgOhWTPR">
+                                    <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
+                                      <Choice Kind="OperationCallFlag" Name="Format" />
+                                    </p:NodeReference>
+                                    <Pin Id="G0gwZv4jFmxPAHH66aa4JV" Name="Format" Kind="InputPin" DefaultValue="##RepoPath{0}" />
+                                    <Pin Id="HEOEN2KXHgIM52UJouNfQz" Name="Input" Kind="StateInputPin" />
+                                    <Pin Id="NE3VMhBi5xqMjloHABh5Lg" Name="Input 2" Kind="InputPin" />
+                                    <Pin Id="LalzOkW1RLkQQ80gnrryYk" Name="Input 3" Kind="InputPin" />
+                                    <Pin Id="JSgqBYCZ5X1MNVdC8eHJIg" Name="Input 4" Kind="InputPin" />
+                                    <Pin Id="P716jJiGYBWQZxXg3nRqQd" Name="Output" Kind="StateOutputPin" />
+                                  </Node>
+                                  <Node Bounds="808,761,85,19" Id="T8xByZ7KDMZMpsRBmnwZX8">
+                                    <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
+                                      <Choice Kind="OperationCallFlag" Name="Format" />
+                                    </p:NodeReference>
+                                    <Pin Id="Q10cwsPTOyUMejLc4K3M18" Name="Format" Kind="InputPin" DefaultValue="X##DeleteButton{0}" />
+                                    <Pin Id="CshTNFmka3wLPnQQ8cP25C" Name="Input" Kind="StateInputPin" />
+                                    <Pin Id="AilY59JMCzOMtBfgcwYEws" Name="Input 2" Kind="InputPin" />
+                                    <Pin Id="VvEQZfAYv5lMueiNCSIxXP" Name="Input 3" Kind="InputPin" />
+                                    <Pin Id="SnhZWMS6gEFMsZWerpeObK" Name="Input 4" Kind="InputPin" />
+                                    <Pin Id="EHxuyU0kVT1QQQgFTb7eQe" Name="Output" Kind="StateOutputPin" />
+                                  </Node>
+                                  <Node Bounds="826,382,85,19" Id="AuCzfP9JUdRNaxJ3bjQMxU">
+                                    <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
+                                      <Choice Kind="OperationCallFlag" Name="Format" />
+                                    </p:NodeReference>
+                                    <Pin Id="VU29ooVTeXHPO5iz4ZpoTI" Name="Format" Kind="InputPin" DefaultValue="Package Repositories Folder[{0}]" />
+                                    <Pin Id="ARGtfNOy2jCLG23hj8aj70" Name="Input" Kind="StateInputPin" />
+                                    <Pin Id="KNSeiMR0Hf4O0stPEDdfgD" Name="Input 2" Kind="InputPin" />
+                                    <Pin Id="Mf5pPXT7K3VOf7apEbxhVh" Name="Input 3" Kind="InputPin" />
+                                    <Pin Id="ODYY7zGkDz6QUh4d7Fc9BT" Name="Input 4" Kind="InputPin" />
+                                    <Pin Id="IsCct5UIfr8PFqVd32JCKq" Name="Output" Kind="StateOutputPin" />
+                                  </Node>
+                                  <ControlPoint Id="Hhb0b5wyf8wO7BWvRmgo9i" Bounds="769,13" />
+                                  <ControlPoint Id="Q1ZDRYVN4wlMest07lZa3w" Bounds="768,1147" />
+                                  <ControlPoint Id="KIM2lNxAU2uPhHawFMtywy" Bounds="862,868" />
+                                  <ControlPoint Id="ObBohnL7vWGN0oFDZiuhFp" Bounds="790,307" />
+                                  <Node Bounds="767,103,162,19" Id="HNOOtpcS1htLK1IV88NA05">
+                                    <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <Choice Kind="ProcessNode" Name="Checkbox" />
+                                    </p:NodeReference>
+                                    <Pin Id="INkcyne2CJ6LjPVcKFE5v6" Name="Context" Kind="InputPin" />
+                                    <Pin Id="EbqbUfu0mLiLsjcZe7cwZD" Name="Channel" Kind="InputPin" />
+                                    <Pin Id="AABR7ChuyDjMf971NoWZti" Name="Label" Kind="InputPin" />
+                                    <Pin Id="EF20eXmveRsLYj6ICGCvOj" Name="Style" Kind="InputPin" />
+                                    <Pin Id="Uo1q30Wvw7dP38PKM6Z3ek" Name="Context" Kind="OutputPin" />
+                                    <Pin Id="KJ0qRppnfNyLMmS1g1EXC4" Name="Bang" Kind="OutputPin" />
+                                    <Pin Id="RXbwbHlm4J2P68AYki1Xzh" Name="Value" Kind="OutputPin" />
+                                  </Node>
+                                  <Node Bounds="767,187,59,19" Id="Oph4BC1rUISP4SEUSIijXD">
+                                    <p:NodeReference LastCategoryFullName="ImGui.Commands" LastDependency="VL.ImGui.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <Choice Kind="ProcessNode" Name="SameLine" />
+                                    </p:NodeReference>
+                                    <Pin Id="HdbO43m9fyeP14cJ1kKOzb" Name="Context" Kind="InputPin" />
+                                    <Pin Id="RK5uGk25L8DLhHirGBASIZ" Name="Offset" Kind="InputPin" DefaultValue="0.34" />
+                                    <Pin Id="KPuO0LapMhcPDbG8SfYYKh" Name="Spacing" Kind="InputPin" />
+                                    <Pin Id="OGHomzRXy54OlsR9ijybye" Name="Context" Kind="OutputPin" />
+                                  </Node>
+                                  <Node Bounds="757,563,169,86" Id="O8NzinTteUOK96d3VQn6Wn">
+                                    <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
+                                      <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                                      <CategoryReference Kind="Category" Name="ImGui" />
+                                      <Choice Kind="ProcessAppFlag" Name="Disabled" />
+                                    </p:NodeReference>
+                                    <Patch Id="QTBUuGq5YV2LiJfNy1FnxI" ManuallySortedPins="true">
+                                      <Patch Id="CVYfnuuwz0GLIzMK0ct2i8" Name="Create" ManuallySortedPins="true" />
+                                      <Patch Id="E2uLTiPNTF3PmfuJsKcWSK" Name="Update" ManuallySortedPins="true" />
+                                      <Node Bounds="769,587,145,19" Id="G0eNOsVUy26QPGVA7tT9R7">
+                                        <p:NodeReference LastCategoryFullName="Main.Utils" LastDependency="GammaLauncher.vl">
+                                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                          <CategoryReference Kind="Category" Name="Utils" NeedsToBeDirectParent="true">
+                                            <p:OuterCategoryReference Kind="Category" Name="Main" NeedsToBeDirectParent="true" />
+                                          </CategoryReference>
+                                          <Choice Kind="ProcessAppFlag" Name="FolderDialog" />
+                                        </p:NodeReference>
+                                        <Pin Id="MWzTPqHZopRN9VK5QjBlr7" Name="Context" Kind="InputPin" />
+                                        <Pin Id="CFvZhip4k7kPCa2530nxfw" Name="Channel" Kind="InputPin" />
+                                        <Pin Id="UBYOF7iCKEyOZpBUrjieyh" Name="Label" Kind="InputPin" />
+                                        <Pin Id="AMNEGzuCyS6OxB2aN8zK5o" Name="Max Length" Kind="InputPin" />
+                                        <Pin Id="OOOkgSDo1kGNbLuNjWSlmz" Name="Flags" Kind="InputPin" />
+                                        <Pin Id="CpWMT9U3vDmMRqgYGbMYOj" Name="Style" Kind="InputPin" />
+                                        <Pin Id="RKvhF7Us4hiNPQ3KxFppqq" Name="Button Style" Kind="InputPin" />
+                                        <Pin Id="IcTyWajvUlQMp0bDXq3UOl" Name="Button Label" Kind="InputPin" />
+                                        <Pin Id="O0WGxla8MbpLZ2wpVEAamC" Name="Context" Kind="OutputPin" />
+                                        <Pin Id="HuhP9Y8aMSPN3qRsr6b968" Name="Value" Kind="OutputPin" />
+                                      </Node>
+                                    </Patch>
+                                    <Pin Id="TQAutInusR9OeJc4eWmk3f" Name="Context" Kind="InputPin" />
+                                    <Pin Id="ANrYRyIHxVsMnPnJjpZHgV" Name="Style" Kind="InputPin" />
+                                    <Pin Id="EW45IXtJvm3MtmAbuYuX8n" Name="Apply" Kind="InputPin" />
+                                    <Pin Id="R1FYFafHPFhLq1qre712iw" Name="Context" Kind="OutputPin" />
+                                    <ControlPoint Id="S5g2QJzKwHTMHO6CJkq3qe" Bounds="771,643" Alignment="Bottom" />
+                                  </Node>
+                                  <Node Bounds="924,236,37,19" Id="RVdYMxVq7ORM75taZvrb06">
+                                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <Choice Kind="OperationCallFlag" Name="NOT" />
+                                    </p:NodeReference>
+                                    <Pin Id="Urd9ypUVnNRNZ7zTzSm09z" Name="Input" Kind="StateInputPin" />
+                                    <Pin Id="KMPs7i1EwLrMqwJJoXuXmg" Name="Output" Kind="StateOutputPin" />
+                                  </Node>
+                                  <Node Bounds="924,74,97,19" Id="Qa5YQSqLLU3OYmL9kazZZz">
+                                    <p:NodeReference LastCategoryFullName="ImGui.Styling" LastDependency="VL.ImGui.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <Choice Kind="ProcessNode" Name="SetCheckboxStyle" />
+                                    </p:NodeReference>
+                                    <Pin Id="O3IpqCPJy6OP3Hu5f92Xz5" Name="Input" Kind="InputPin" />
+                                    <Pin Id="RYE20BqwiC9N3hrK0LG09P" Name="Checkmark" Kind="InputPin" />
+                                    <Pin Id="IQXqvPx4wibLJd1BqBGsFh" Name="Output" Kind="OutputPin" />
+                                  </Node>
+                                  <Pad Id="NqyC82q3ozjPmjtA0FLVrP" Comment="Checkmark" Bounds="1018,53,22,15" ShowValueBox="true" isIOBox="true" Value="0.9411765, 0.7411765, 0.050980393, 1">
+                                    <p:TypeAnnotation LastCategoryFullName="Color" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="TypeFlag" Name="RGBA" />
+                                    </p:TypeAnnotation>
+                                  </Pad>
+                                  <ControlPoint Id="CXricfyjzNvMIq4yOUgfVt" Bounds="926,53" />
+                                  <ControlPoint Id="V19JY2pEAdTNWQg1NHTHrW" Bounds="871,522" />
+                                  <ControlPoint Id="TJRvKzWfKx5LkE7dF96Wn1" Bounds="891,541" />
+                                  <ControlPoint Id="L8mFPyVbmAzMM9x79UaNFL" Bounds="850,801" />
+                                  <Node Bounds="767,149,284,19" Id="VJ32E9hZLSYMuhHz14MJ8x">
+                                    <p:NodeReference LastCategoryFullName="ImGui.Queries" LastDependency="VL.ImGui.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <Choice Kind="ProcessNode" Name="IsItemHovered" />
+                                    </p:NodeReference>
+                                    <Pin Id="VgjaNh2Oj8rLJoJppHl1bF" Name="Context" Kind="InputPin" />
+                                    <Pin Id="SIn6L4wnVzXLLIaJMGrv9F" Name="Flags" Kind="InputPin" />
+                                    <Pin Id="RZElBkxCxNcQZD5JxMO0hd" Name="Context" Kind="OutputPin" />
+                                    <Pin Id="EdlhaoIaeRBOMOOWrpETwa" Name="Value" Kind="OutputPin" />
+                                  </Node>
+                                  <Node Bounds="1046,212,82,80" Id="CVRfDoQosnsM7jzCxO0RSU">
+                                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                                      <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                                      <CategoryReference Kind="Category" Name="Primitive" />
+                                      <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                                    </p:NodeReference>
+                                    <Pin Id="IQWtY329yvINddFgcCWI8F" Name="Condition" Kind="InputPin" />
+                                    <Patch Id="Q8UZI76QovGMpmOisujblZ" ManuallySortedPins="true">
+                                      <Patch Id="MqD3KQZpZ0LNE6GHFEDLeN" Name="Create" ManuallySortedPins="true" />
+                                      <Patch Id="N7mLXzpNxvTOlsTsOpfT43" Name="Then" ManuallySortedPins="true" />
+                                      <Node Bounds="1064,244,49,19" Id="CqtkaQdzISULcA8oA1FGzA">
+                                        <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
+                                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                          <Choice Kind="ProcessNode" Name="Tooltip (String)" />
+                                        </p:NodeReference>
+                                        <Pin Id="A9ZnGCGBpngLQDQsvaop11" Name="Context" Kind="InputPin" />
+                                        <Pin Id="J3lDV52uGv3OTpCnlygiNw" Name="Content" Kind="InputPin" DefaultValue="Enable or disable this folder" />
+                                        <Pin Id="LnjbQ9jAANPP3G7N85YfEs" Name="Style" Kind="InputPin" />
+                                        <Pin Id="Eb2N5cy7vtjMDY9KcxxJyY" Name="Context" Kind="OutputPin" />
+                                      </Node>
+                                    </Patch>
+                                  </Node>
+                                  <Node Bounds="1046,179,62,19" Id="DcAY5n4BWZGL8xPmTO5UDG">
+                                    <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <Choice Kind="ProcessAppFlag" Name="TimerFlop" />
+                                    </p:NodeReference>
+                                    <Pin Id="JyJxTRhRsUZLeAWSlwzEgg" Name="Set" Kind="InputPin" />
+                                    <Pin Id="JZiKLL4LKfRPWsxL0oDaNK" Name="Reset" Kind="InputPin" />
+                                    <Pin Id="T5u0RQMGuoIMPcDParpt8s" Name="Time" Kind="InputPin" DefaultValue="0.8" />
+                                    <Pin Id="Fm5HM85ikmJOTGTVVqZzAM" Name="Value" Kind="OutputPin" />
+                                    <Pin Id="FfTiRsAbnTtLQm62Qf3HP7" Name="Running" Kind="OutputPin" />
+                                  </Node>
+                                </Canvas>
+                                <!--
+
+    ************************  ************************
+
+-->
+                                <ProcessDefinition Id="DafkhEPHTCCMqIfKwC2MGR">
+                                  <Fragment Id="EUYteL2dV9VPTLOk6fvoUj" Patch="SG2sI2EzgswMnBU9QBIP1A" Enabled="true" />
+                                  <Fragment Id="KqhIQPE0dptMhGvwHGsMdr" Patch="SqUKJfOKIZsOG7c3kYdpfP" Enabled="true" />
+                                </ProcessDefinition>
+                                <Link Id="K5c1UXsSy4eOnunEb4LeUn" Ids="RBZBWxVD7ubLMdIsgVYVoO,KIaZnHTx9yrLyE0LJ4c2PA" />
+                                <Link Id="TqdDygeDXZbOgj76X9qIMP" Ids="TyJ07eBJG3VM0y7f1nzlCO,CFvZhip4k7kPCa2530nxfw" />
+                                <Link Id="E9Dd1u4NesQPhGktISVH2U" Ids="JnKgrDCKCQvN8r1Xfd47SQ,UNEgUFSKLYYOyTeC8jwYpg" IsHidden="true" />
+                                <Link Id="Ua3ugn7EMedO3p4KEI0CSY" Ids="UNEgUFSKLYYOyTeC8jwYpg,PfRj81shys9O4eFyyMGjNu" />
+                                <Link Id="NrHMLJaYoZSNc34IN206wO" Ids="AiG5eDyGmyKLQjZHos8uWx,VuNjzFF37VJNdk4017AurH" />
+                                <Link Id="LcjhjunNtdMNusoOP2MAYz" Ids="AYefMxCcPzPQPj3r5frcOv,IcTyWajvUlQMp0bDXq3UOl" />
+                                <Link Id="BQm88xn2S3LNzU4zyzX02H" Ids="CJSBi3zKLtxNWAGshg2M1I,OsYq2NeLHPdQFm1P6fhBmX" />
+                                <Link Id="Mh4BsTAgU1GPh3yBXFgKzG" Ids="UNEgUFSKLYYOyTeC8jwYpg,ToulhYPrvJEPzPAdWHoY4R" />
+                                <Link Id="HXCX9yxumbDPd3ppe9vQIK" Ids="MZb8C2FatqtPHXVLo8tbnw,A17Uk7szlH0MgljzxasBog" />
+                                <Link Id="TNbT4w8wexrLhnyB7dSXxN" Ids="Gl0uUNHW9ybNeVwqyjq3SX,FMJgkcZz8kkPkjs5YxmDAk" />
+                                <Link Id="IxxtxmftYeUMuULouH2A9g" Ids="Q26ztZZqftJORCMZwLPtjR,UIzHL4jyX1vMg2nXtGDsLt" />
+                                <Link Id="FGGXddPDZglMuQjz1CZGj3" Ids="UNEgUFSKLYYOyTeC8jwYpg,HEOEN2KXHgIM52UJouNfQz" />
+                                <Link Id="Jgfz4ZNncUMMn3YuDljsrh" Ids="P716jJiGYBWQZxXg3nRqQd,UBYOF7iCKEyOZpBUrjieyh" />
+                                <Link Id="Jzm2QB1CZb0OHVPPvetDOS" Ids="UNEgUFSKLYYOyTeC8jwYpg,CshTNFmka3wLPnQQ8cP25C" />
+                                <Link Id="JaMXDnlBTNrMjlyRmTVWnG" Ids="EHxuyU0kVT1QQQgFTb7eQe,Tbie6gJdtSPN4sceZEsgN8" />
+                                <Link Id="LkAYPyA8u1YONaOv2vm4Sj" Ids="AiG5eDyGmyKLQjZHos8uWx,ARGtfNOy2jCLG23hj8aj70" />
+                                <Link Id="F6dfSFVUCE2LK4W0s6oGKT" Ids="IsCct5UIfr8PFqVd32JCKq,Ga2JV138YmLNWlXRPiJhuG" />
+                                <Link Id="Ux5rnHl1dHWMYJQaNo85e0" Ids="RQ7qkBUdjvcOwRRRFuT7ry,Hhb0b5wyf8wO7BWvRmgo9i" IsHidden="true" />
+                                <Link Id="HoojDWyU7eXNSw3SDateHM" Ids="QCOR9pMZALNOKLEslUnrln,Q1ZDRYVN4wlMest07lZa3w" />
+                                <Link Id="Vt8O4jS6mwYLFdpGAE15yo" Ids="Q1ZDRYVN4wlMest07lZa3w,TCepWlGwQTtOxBR9wvJApS" IsHidden="true" />
+                                <Link Id="SnxfgYy2kLbMr8VpB0kYMz" Ids="KIM2lNxAU2uPhHawFMtywy,HMVbgdIUEB6LNXrbTqN8zu" />
+                                <Link Id="SkDYAUVAjtIOASbvkHHG6w" Ids="LnJfg7Dx1TZLiqmQ7BZDFa,KIM2lNxAU2uPhHawFMtywy" IsHidden="true" />
+                                <Patch Id="SG2sI2EzgswMnBU9QBIP1A" Name="Create" />
+                                <Patch Id="SqUKJfOKIZsOG7c3kYdpfP" Name="Update" ManuallySortedPins="true">
+                                  <Pin Id="RQ7qkBUdjvcOwRRRFuT7ry" Name="Context" Kind="InputPin" Bounds="768,229" />
+                                  <Pin Id="LnJfg7Dx1TZLiqmQ7BZDFa" Name="Model" Kind="InputPin" Bounds="901,675" />
+                                  <Pin Id="KWQySbvEZ9xM81GkvwOC3F" Name="Frame Style" Kind="InputPin" Bounds="1198,323" />
+                                  <Pin Id="Hcmr7YkebiLQE5Bfkij34Z" Name="Button Style" Kind="InputPin" Bounds="1235,338" />
+                                  <Pin Id="JnKgrDCKCQvN8r1Xfd47SQ" Name="Index" Kind="InputPin" />
+                                  <Pin Id="TCepWlGwQTtOxBR9wvJApS" Name="Context" Kind="OutputPin" Bounds="766,931" />
+                                </Patch>
+                                <Link Id="LyfJBv0MVuKOZlOukQ78wh" Ids="LnJfg7Dx1TZLiqmQ7BZDFa,ObBohnL7vWGN0oFDZiuhFp" IsHidden="true" />
+                                <Link Id="Rat0RGaszwaLLp8FlNyfqc" Ids="ObBohnL7vWGN0oFDZiuhFp,NBBfRTd4TjON5NsofKgh8W" />
+                                <Link Id="J82hinZzgTSMaoiY0IC0Dx" Ids="Hhb0b5wyf8wO7BWvRmgo9i,INkcyne2CJ6LjPVcKFE5v6" />
+                                <Link Id="CbjDoh4BiYdN6cQXJWc27S" Ids="OGHomzRXy54OlsR9ijybye,MWzTPqHZopRN9VK5QjBlr7" />
+                                <Link Id="LYMifai6AazOGKNtawzEF5" Ids="O0WGxla8MbpLZ2wpVEAamC,S5g2QJzKwHTMHO6CJkq3qe" />
+                                <Link Id="Offxzy0VKbDM0EDbLFpym1" Ids="S5g2QJzKwHTMHO6CJkq3qe,Snf3Hm6IvwHQdHJHDJLOXi" />
+                                <Link Id="JQNFdGzRutJOh4OXWxI2D4" Ids="RXbwbHlm4J2P68AYki1Xzh,Urd9ypUVnNRNZ7zTzSm09z" />
+                                <Link Id="BJyiByysDB4MqyoMTIE5WE" Ids="KMPs7i1EwLrMqwJJoXuXmg,EW45IXtJvm3MtmAbuYuX8n" />
+                                <Link Id="GsnlzvTlRGtOEOdKbnutj0" Ids="NqyC82q3ozjPmjtA0FLVrP,RYE20BqwiC9N3hrK0LG09P" />
+                                <Link Id="A5Y0LKxLNHlMMjmp6qxac4" Ids="IQXqvPx4wibLJd1BqBGsFh,EF20eXmveRsLYj6ICGCvOj" />
+                                <Link Id="QaGgqJ5nIrFPa6jUtUuvcA" Ids="KWQySbvEZ9xM81GkvwOC3F,CXricfyjzNvMIq4yOUgfVt" IsHidden="true" />
+                                <Link Id="OppSBWy1yfCPbAXBF2boPD" Ids="CXricfyjzNvMIq4yOUgfVt,O3IpqCPJy6OP3Hu5f92Xz5" />
+                                <Link Id="AeM0Ju63hu7L5GlgeRd2Lm" Ids="KWQySbvEZ9xM81GkvwOC3F,V19JY2pEAdTNWQg1NHTHrW" IsHidden="true" />
+                                <Link Id="KdtjuZtB200NneeP4Eh0P3" Ids="V19JY2pEAdTNWQg1NHTHrW,CpWMT9U3vDmMRqgYGbMYOj" />
+                                <Link Id="Jxw5sEbl4UELIiKDEEPbKR" Ids="Hcmr7YkebiLQE5Bfkij34Z,TJRvKzWfKx5LkE7dF96Wn1" IsHidden="true" />
+                                <Link Id="CTVuabPRLbINDnbNdJw4xt" Ids="TJRvKzWfKx5LkE7dF96Wn1,RKvhF7Us4hiNPQ3KxFppqq" />
+                                <Link Id="OVSPgCL7KEWNPgpUeLzw4u" Ids="Hcmr7YkebiLQE5Bfkij34Z,L8mFPyVbmAzMM9x79UaNFL" IsHidden="true" />
+                                <Link Id="LTiXONAgQfhQKFy7sNzZTR" Ids="L8mFPyVbmAzMM9x79UaNFL,F9csE93BsojLjeQpJ789Xo" />
+                                <Link Id="LPiL3NuXhg8PZoXnX9E8Y1" Ids="Uo1q30Wvw7dP38PKM6Z3ek,VgjaNh2Oj8rLJoJppHl1bF" />
+                                <Link Id="UfBv5FgSdVmMcSV87SaD1U" Ids="RZElBkxCxNcQZD5JxMO0hd,HdbO43m9fyeP14cJ1kKOzb" />
+                                <Link Id="TxHUJwHdbAZQSpBCOt9p6j" Ids="EdlhaoIaeRBOMOOWrpETwa,JyJxTRhRsUZLeAWSlwzEgg" />
+                                <Link Id="ClAiXt3y6aPQJOmhx55YLh" Ids="Fm5HM85ikmJOTGTVVqZzAM,IQWtY329yvINddFgcCWI8F" />
+                              </Patch>
+                            </Node>
+                            <ControlPoint Id="OGUyZrKHdrpM5N2R2KwFn9" Bounds="462,1290" />
+                            <ControlPoint Id="AZrUUtqhBugP3fHYz46abL" Bounds="1457,1035" />
+                            <ControlPoint Id="ABHVjQ2v7RXNpEa0QDIvmG" Bounds="1217,775" />
                           </Canvas>
                           <ProcessDefinition Id="INp7VmAXDcsMimfR0Ou7vW">
                             <Fragment Id="JPXNsCELtzSNpdwJmQHyl7" Patch="SAiRMFrQjTYNo91tIzDiXw" Enabled="true" />
@@ -6738,40 +7049,19 @@
                           <Patch Id="SHkvs1zvwUQQZ4hBHJNdlh" Name="Update">
                             <Pin Id="EbBpDDUv2X1P6IqzLhrElw" Name="Application" Kind="InputPin" Bounds="474,121" />
                           </Patch>
-                          <Link Id="N4lTVO1wnolPf52zctEjw1" Ids="RubiYd6avaMLedHNS1zSVC,CzlcRoBrQIlON420HRazQt" />
-                          <Link Id="UO2Qon0jX4PMwQesJYBEQ1" Ids="NWvyUTdM8uiNmFyY6qPfsM,PHwSsUc94twNx6OGvvJHIK" />
                           <Link Id="IKmK04WQyfZPdwZSC41rao" Ids="PRBPIAbuQBRMAvTaPELcdj,Lgmfo52OsBFNL3llaJJdyn" IsFeedback="true" />
-                          <Link Id="UhEP47fLwX6MxQX5MJyAJ7" Ids="CqgZ0o868QMLPLTFMgzcJl,Lgmfo52OsBFNL3llaJJdyn" />
                           <Link Id="S2XegTtffqjO4Qpo8TQrgs" Ids="Lgmfo52OsBFNL3llaJJdyn,MDPw2rRs6W0MWcVQArS6fJ" />
                           <Link Id="DnanzezDPWdPkAQvSn0876" Ids="UCiScDY6yuHPkA8RgMRr27,HHq257H549ZNjTgIKeviSv" />
                           <Link Id="R7gHImDrZVwPtMj5StrOw1" Ids="DrBwkoEKvfTO2JuygpA6I0,OsajJ5BU4y6PsLaLuPerJs" />
                           <Link Id="GTMd1qKbcjaNtg1ydNWCks" Ids="HWfyCmQ3a9QLl4QhF1H0tL,LbHTeEEGDn5QBPPPhAZYq6" />
-                          <Link Id="DlCV3HMHCiiPculqEGhWqt" Ids="UCiScDY6yuHPkA8RgMRr27,P1SukSKALkAP4iVxCLDfYx,KWv1KQrHVeyO1KFva1JpWU,PR9pAtx7uzkPJroVxCoiM2" />
-                          <Link Id="PrGMmW4bjRuLGihkj3vAbV" Ids="ChPbQkhY9IMMZG0FpkBoTB,Q6WyXMRqTUcLBOTLftD3Go" />
-                          <Link Id="Lo4j1wjknDbOzgzji6M3Li" Ids="PRBPIAbuQBRMAvTaPELcdj,PyUawTGQjNYNkYYP4LOLKz" />
                           <Link Id="Ux89ntfdB8ONBNSzEEc3FL" Ids="Tu8kzWZENr6QBaDArKtXWV,PRBPIAbuQBRMAvTaPELcdj" />
                           <Link Id="Cx0Wls92I2uL2AfBS9js2D" Ids="AE9AT2dRwRpL55BRhhWi5L,McTQCLa0bPbNsFbbVaOwui" IsHidden="true" />
-                          <Link Id="MylK4xrMJcrQPY2NfF9Vgk" Ids="McTQCLa0bPbNsFbbVaOwui,QVNTQ1P1gfYOzdlkw4U6rA" />
-                          <Link Id="BostvV7lB6RLPCex31wXD7" Ids="NhKvcB8RfVkM3kefOuY2Z1,TWBhmTI6rVyOdZ6dgGIpvs" />
-                          <Link Id="Rq6LXi0BnvLNb15tRSdhDH" Ids="DdxNdjb9PYUNK6XrnaoiKJ,JsR0x8B7p8cPKMUHWLvnrm" />
                           <Link Id="IMyN6DUD3fbPSv1asvRwSm" Ids="OlRvXwnfHByNjUL3BU65Uj,E3eFkRV2U5wLuyIVIFcgbN" />
                           <Link Id="HztYpjBEyLBPU0I4Z5Fbbi" Ids="QLWZ2HrDmtSNmKutQAug7q,Q6EethrNmFVLLhZv74cgBv" />
                           <Link Id="KyR3zOu5zw8PYF99Jwka3l" Ids="VaygddSVEAdNTZP8k1Q7en,VxTBJ8fkpXDPvVwrMl5ZPq" />
                           <Link Id="Pd72Iye91sbLZ2XCqPTfqh" Ids="VNjYJZc7lbeNQtVZn3Y6OI,GO8M0urDzv6QUgFwGtHJmj" />
-                          <Link Id="BkCxZh4UjmHQWGR5iv5MTY" Ids="I5ZugFFLRn2N5ZtAd5D3a8,DptBOCrv8FtPS9RtSzpYWW" />
-                          <Link Id="PmpHJiAYQBIMS1BA4Lb1sD" Ids="McTQCLa0bPbNsFbbVaOwui,DFr1lLubWW4L1V7aHkqg3f" />
-                          <Link Id="HpmiCZqVI9DL9bOLTLYcMf" Ids="K1TeJv3nkZWLuvDzOsE9pG,IwFwT1y9G9PPJchHPy0RLc" />
-                          <Link Id="JvUH93W7IkNOzO3YzSAGyd" Ids="KWlJxZfrNHmMdIhmQYfZTo,EFcjik1BWluPKbF0X0J8Aa" />
-                          <Link Id="QDWLedhtDJJPSllvtQGGH7" Ids="HRrtosEyGvYPHXPmTjDi4H,JpcRWdnpBHLMNW2TJuLMfb" />
-                          <Link Id="Nu4BcdU9PDULDB1PBJCsuH" Ids="UCiScDY6yuHPkA8RgMRr27,OmSjM56eHIrP5r3xDnmkxC,QpC8rCllSBVPTuIIui4lwF,SEyyPrsfJ1fLslV6Kjr8q0" />
-                          <Link Id="HcenlquTXuDN0LNiaxl84p" Ids="McTQCLa0bPbNsFbbVaOwui,Hhv063TSiKNOr34KExweaC" />
-                          <Link Id="F3RYfQza1V4M4KaO7ZQ964" Ids="PYIErtHtZfzOAiR7sO5QRr,MjzpdyZfCyJL4zBWwap8L6" />
-                          <Link Id="VpNXUIp3UjmPM0s8FqodOG" Ids="McTQCLa0bPbNsFbbVaOwui,AAzqHbAhXnoLQHq6XUX5wS" />
-                          <Link Id="OkgxovMNPhbOgc8BVDg4I2" Ids="OU9iUFMage7O4uueWOAX0o,Rvyk7rYmh6KLAMrj80fYmH" />
-                          <Link Id="B6lPksgUzEkLWl2WEeWq1x" Ids="UCiScDY6yuHPkA8RgMRr27,RL3coR6pdbVNToPXQQJ1yd,OV8nOennsQ7QM0SRsErl5A,OEhE4kzEHbWNFEY5DG3LhG" />
+                          <Link Id="B6lPksgUzEkLWl2WEeWq1x" Ids="UCiScDY6yuHPkA8RgMRr27,RL3coR6pdbVNToPXQQJ1yd,OGUyZrKHdrpM5N2R2KwFn9,OEhE4kzEHbWNFEY5DG3LhG" />
                           <Link Id="MxbMpHVbyn8Ni4C1CwLNX7" Ids="FmHyUFVVV9iNiLH1FpmaeT,Bbs8YovYf4JNE98ixtLLE2" />
-                          <Link Id="G78vvlPBDC1NCGpST6fTsg" Ids="NhKvcB8RfVkM3kefOuY2Z1,RJPfosv6dfrNkBKCgbRGl8" />
-                          <Link Id="DF5sZN4SgRTP0vTw7hpOQp" Ids="SAK9tesIzcuNSmPBJguF27,DA9N0qGp32APzeXa3Sl1JN" />
                           <Link Id="KuVUEJIYKnLOLAPzKPUTW5" Ids="M0VDVSq7Vn9MbOyyy1SED3,ECAGrDpetnnPiCYvYokjxY" />
                           <Link Id="OdOR3AprpyPN6GYLvpNXcU" Ids="HoWAzfc3tPPNUbfbzf4en3,TME2FrU3gJ5PblAj4h4lEP" />
                           <Link Id="TKAmTrpBYpLODViCclYj5r" Ids="UCiScDY6yuHPkA8RgMRr27,ORqQzgwg4jvOgEowUrUI5N,VWFbM8yApe9OXvOWeUv0Dr,QxPmMgpTQtuP40KDBkbePw" />
@@ -6780,15 +7070,12 @@
                           <Link Id="Sj9ORaPH6fsOo80u39OBtN" Ids="FxUkJrfO9EBOBMMf0i75cr,ELhpGL7YxMQNsw09Wb2l5I" />
                           <Link Id="Q79rTPTvkTMLkytXq3ZYH0" Ids="N1ZPqUjUnGjMTMsig8Znq8,KpEhNvEiIhhLJqSNmvxG0M" />
                           <Link Id="OiJjJIWq2fjN0F4nwZqnqw" Ids="RAOrDgCLjwVPOJQiR3RXsZ,CKkM30rLCXcP3jHpzurVaf" />
-                          <Link Id="Tb9Vxe4W0foLZdgdxiv1jP" Ids="Jh4uO1x4gKvQIDsKQWFQOK,BbU6PEu0pM3L7ADBICiQuf" />
                           <Link Id="QdS5zzQgMmLLBiwgadjkZU" Ids="E6vILQtLtqwNPNxKQYnL3Y,DW8MEY4ahAZOgdVNCrBZUq" />
                           <Link Id="MxGILspvoBTOeh21uNgRb0" Ids="FxUkJrfO9EBOBMMf0i75cr,IP0kIy8X4PBPQLbZvFKNks" />
                           <Link Id="FHq11faF3QzMIYV9udgcH5" Ids="N1ZPqUjUnGjMTMsig8Znq8,QGMZfpXFFT4LGMZIrZoaq8" />
-                          <Link Id="T9H1wiTvisZPnOQaMkU4Yv" Ids="ELJRfXJMYFbMiPYSmAbyZ6,DdPdrVuxmHFMEEzlFdwyDC" />
                           <Link Id="K7fd3jJgXzpOLMMwTfpgZu" Ids="E6vILQtLtqwNPNxKQYnL3Y,TUYaqQWYWkdOg7ch9hqo02" />
                           <Link Id="CKdeXH9DTJ0QPIQSRd1xH5" Ids="FxUkJrfO9EBOBMMf0i75cr,DBWcw9vErOMLihZyXNA2TP" />
                           <Link Id="SdKUaYnArfiLK722Th0nsD" Ids="N1ZPqUjUnGjMTMsig8Znq8,OXIDieS8Q3wOZt446tdkz7" />
-                          <Link Id="VJrnUcDtBaqNjC6D7p7QkG" Ids="ELJRfXJMYFbMiPYSmAbyZ6,GT5vwxNXQ4EOwEqwuBM5uG" />
                           <Link Id="Edyama3accqOK8bK3u7Nza" Ids="ELJRfXJMYFbMiPYSmAbyZ6,DkvKIKTTbzmOz6zRiBWi5k" />
                           <Link Id="FU6pYMvhY1uOxuPpPeAlGF" Ids="ELJRfXJMYFbMiPYSmAbyZ6,KZpa50tcKF6L8dcy1Gf8q7" />
                           <Link Id="FtDEdKT6fi1Lkj8lpbiZlz" Ids="Jh4uO1x4gKvQIDsKQWFQOK,PwwlFjx1tgQM8fEKzy50zJ" />
@@ -6817,9 +7104,9 @@
                           <Link Id="AqZ5cYarqw4OTx6XAGsaV8" Ids="UCiScDY6yuHPkA8RgMRr27,Iv5y2s3RxO3QJvhGOpySfl,LkrMtExgm5NPl3NiAheu5O" />
                           <Link Id="DpcwLVB7HcQN4KKZHnoDBk" Ids="LkrMtExgm5NPl3NiAheu5O,MlHym66gG3APZgA9zgjRBo,QObzxOKx8Z4MuqgOX4HPq9" />
                           <Slot Id="N4FYsPZ4cxGO92b9tdsJUM" Name="Output" />
-                          <Link Id="BCMAREie1CALGjnoCXmYLP" Ids="ELJRfXJMYFbMiPYSmAbyZ6,AfD6Tp4TaaSLDDQBDvCXyb,AQEdaGgfiOUOgJE6816E8H" />
+                          <Link Id="BCMAREie1CALGjnoCXmYLP" Ids="ELJRfXJMYFbMiPYSmAbyZ6,ABHVjQ2v7RXNpEa0QDIvmG,AfD6Tp4TaaSLDDQBDvCXyb,AQEdaGgfiOUOgJE6816E8H" />
                           <Link Id="LmuqhzSAVlDPdHV6xYTpv0" Ids="AQEdaGgfiOUOgJE6816E8H,Sbho5VBKgSQNkMkeZKPO1I" />
-                          <Link Id="GVflbZAjCdwMKLtnpE0Hej" Ids="RAOrDgCLjwVPOJQiR3RXsZ,QZ2wTLhTp9HM6p8oEQMW0O,UDdvfgvcLLcPmSayPzZknJ" />
+                          <Link Id="GVflbZAjCdwMKLtnpE0Hej" Ids="RAOrDgCLjwVPOJQiR3RXsZ,AZrUUtqhBugP3fHYz46abL,QZ2wTLhTp9HM6p8oEQMW0O,UDdvfgvcLLcPmSayPzZknJ" />
                           <Link Id="OQYSKPQqivTM2U0mFAVPpL" Ids="TcjL3JNQqVbQVAPtwBjw6K,ET5buvw8CxdMdcus8AYwHR" />
                           <Link Id="AWQaOqBOvLBL0oYniYRuc3" Ids="LkrMtExgm5NPl3NiAheu5O,RadTw7a5CFWLsFIILKy00b" />
                           <Link Id="BsYvhpbL53gM3BWl8CwkgS" Ids="OuU2LLbJ6jbQdUnqHMRzBN,AiYF1flsZEVNbAgl6YL6OZ" />
@@ -6829,6 +7116,12 @@
                           <Link Id="ReNvy5CcePPPEsrzMT98K9" Ids="FcsbiGVX4rnMbBCKTGpWuz,PmzQBtGBo4YLgX4WNnXypg" />
                           <Link Id="FXOqMe94BxPNdtSGD0OV3J" Ids="Jh4uO1x4gKvQIDsKQWFQOK,KmgGJieMgiSNAEQz3vag2t" />
                           <Link Id="EPuoynIqCetNe2Go4NMAvD" Ids="AQEdaGgfiOUOgJE6816E8H,LJCJKVkgvxJPXin54dEjAG" />
+                          <Link Id="PSWuwHz3kM9MkisthQX9A2" Ids="PRBPIAbuQBRMAvTaPELcdj,F12QwHZBFCMNi2LYAUwwed" />
+                          <Link Id="LfQozFTOABxO9k93eosxId" Ids="O1tYUekLN1UOkRpbIr2TFH,Lgmfo52OsBFNL3llaJJdyn" />
+                          <Link Id="ARIUefzC1XhPkTiG6UZFUj" Ids="UCiScDY6yuHPkA8RgMRr27,UH3Z8ELjQ7hPgCaAVLvtYv" />
+                          <Link Id="FOt0wzxwZj0LHzF1HIDqqz" Ids="McTQCLa0bPbNsFbbVaOwui,JqDNfWLOI7ZOwIORICro4o" />
+                          <Link Id="SrYt4WPFIK3NJeAojvpXm0" Ids="Jh4uO1x4gKvQIDsKQWFQOK,ScDowj7ZIfWNZmLb4N5Bdw" />
+                          <Link Id="GO63dAjoQmkNseDjXlpvaw" Ids="ELJRfXJMYFbMiPYSmAbyZ6,GfcLJxeCFoTOpdrZbjprwX" />
                         </Patch>
                       </Node>
                       <!--
@@ -11993,7 +12286,7 @@
                 <Pin Id="AQGYTJ9XyPqPd9cy0CSIqf" Name="Result" Kind="OutputPin" />
                 <Pin Id="TP3ncK6yfOSMXi0LRbo7zS" Name="Ok" Kind="OutputPin" />
               </Node>
-              <Node Bounds="464,861,55,19" Id="TtYO7Hr8ucRNjSWq805xE6">
+              <Node Bounds="464,861,55,26" Id="TtYO7Hr8ucRNjSWq805xE6">
                 <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />

--- a/GammaLauncher.vl
+++ b/GammaLauncher.vl
@@ -5895,7 +5895,7 @@
                               </p:TypeAnnotation>
                             </Pad>
                             <ControlPoint Id="HVCOC9ltNmWOvL4BGELnKX" Bounds="561,345" />
-                            <Node Bounds="626,576,105,19" Id="TfHtrhNIH3iOgjK0pE5siD">
+                            <Node Bounds="626,576,125,19" Id="TfHtrhNIH3iOgjK0pE5siD">
                               <p:NodeReference LastCategoryFullName="Main.Utils" LastDependency="GammaLauncher.vl">
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 <CategoryReference Kind="Category" Name="Utils" NeedsToBeDirectParent="true">
@@ -5922,12 +5922,12 @@
                               <Pin Id="CRMMaF352L7OpB8b3EK5H7" Name="Path" Kind="InputPin" DefaultValue="VVVV Installations Folder" />
                               <Pin Id="U7loAhPVH51LqYtQ2kkF0H" Name="Output" Kind="OutputPin" />
                             </Node>
-                            <Node Bounds="626,1064,448,850" Id="SpnOAw9kCjaOwmbQdxihzB">
+                            <Node Bounds="626,1064,448,857" Id="SpnOAw9kCjaOwmbQdxihzB">
                               <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                 <Choice Kind="ProcessAppFlag" Name="CollapsingHeader" />
                               </p:NodeReference>
-                              <ControlPoint Id="Tu8kzWZENr6QBaDArKtXWV" Bounds="692,1071" Alignment="Top" />
+                              <ControlPoint Id="Tu8kzWZENr6QBaDArKtXWV" Bounds="692,1070" Alignment="Top" />
                               <Patch Id="BGx35HKuQMULeTs5ucP4R6" ManuallySortedPins="true">
                                 <Patch Id="NRlmwz1l94BOGvyMDrVWHm" Name="Create" ManuallySortedPins="true" />
                                 <Patch Id="HxDn0ryaQfPM7p2Je0TWU4" Name="Update" ManuallySortedPins="true" />
@@ -5953,8 +5953,8 @@
                                   </p:NodeReference>
                                   <Pin Id="S7kSM0gIn3SL20IGbiIuUa" Name="Break" Kind="OutputPin" />
                                   <ControlPoint Id="Lgmfo52OsBFNL3llaJJdyn" Bounds="692,1644" Alignment="Bottom" />
-                                  <ControlPoint Id="PRBPIAbuQBRMAvTaPELcdj" Bounds="692,1093" Alignment="Top" />
-                                  <ControlPoint Id="LbHTeEEGDn5QBPPPhAZYq6" Bounds="782,1093" Alignment="Top" />
+                                  <ControlPoint Id="PRBPIAbuQBRMAvTaPELcdj" Bounds="692,1092" Alignment="Top" />
+                                  <ControlPoint Id="LbHTeEEGDn5QBPPPhAZYq6" Bounds="782,1092" Alignment="Top" />
                                   <Patch Id="RXHWwmwJ3alOdO4DR9hGJc" ManuallySortedPins="true">
                                     <Patch Id="QKsLuFJLrMiPjaSdewYuAn" Name="Create" ManuallySortedPins="true" />
                                     <Patch Id="C9d3VoZTQJpP0ENsybbato" Name="Update" ManuallySortedPins="true">
@@ -6004,7 +6004,7 @@
                                       <Pin Id="CqgZ0o868QMLPLTFMgzcJl" Name="Context" Kind="OutputPin" />
                                       <Pin Id="I5ZugFFLRn2N5ZtAd5D3a8" Name="Bang" Kind="OutputPin" />
                                     </Node>
-                                    <Node Bounds="714,1212,43,19" Id="SSsdlpfAOe9QRxMG8twZst">
+                                    <Node Bounds="710,1213,43,19" Id="SSsdlpfAOe9QRxMG8twZst">
                                       <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                         <Choice Kind="ProcessAppFlag" Name="Select (ByPath)" />
@@ -6027,7 +6027,7 @@
                                       <Pin Id="DdxNdjb9PYUNK6XrnaoiKJ" Name="Output" Kind="StateOutputPin" />
                                     </Node>
                                     <ControlPoint Id="McTQCLa0bPbNsFbbVaOwui" Bounds="1013,1121" />
-                                    <Node Bounds="772,1144,55,19" Id="CaU8upBTp9MM7wYwyln7f6">
+                                    <Node Bounds="768,1141,55,19" Id="CaU8upBTp9MM7wYwyln7f6">
                                       <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                         <Choice Kind="OperationCallFlag" Name="ToString" />
@@ -6035,7 +6035,7 @@
                                       <Pin Id="QVNTQ1P1gfYOzdlkw4U6rA" Name="Input" Kind="InputPin" />
                                       <Pin Id="NhKvcB8RfVkM3kefOuY2Z1" Name="Result" Kind="OutputPin" />
                                     </Node>
-                                    <Node Bounds="770,1489,257,132" Id="MUSd01kxDXLPiv3bv2sFyD">
+                                    <Node Bounds="770,1489,257,139" Id="MUSd01kxDXLPiv3bv2sFyD">
                                       <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                                         <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                         <CategoryReference Kind="Category" Name="Primitive" />
@@ -6054,7 +6054,7 @@
                                           <Pin Id="DFr1lLubWW4L1V7aHkqg3f" Name="Index" Kind="InputPin" />
                                           <Pin Id="HRrtosEyGvYPHXPmTjDi4H" Name="Output" Kind="StateOutputPin" />
                                         </Node>
-                                        <Node Bounds="782,1512,41,19" Id="IgsWhfU2HylLOsJ2odZtsO">
+                                        <Node Bounds="782,1512,45,26" Id="IgsWhfU2HylLOsJ2odZtsO">
                                           <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                             <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -6064,7 +6064,7 @@
                                           <Pin Id="K1TeJv3nkZWLuvDzOsE9pG" Name="Output" Kind="StateOutputPin" />
                                           <Pin Id="KWlJxZfrNHmMdIhmQYfZTo" Name="Value" Kind="OutputPin" />
                                         </Node>
-                                        <Node Bounds="782,1582,55,19" Id="FkBMfRXeFVEOm8DdunI2fq">
+                                        <Node Bounds="782,1582,55,26" Id="FkBMfRXeFVEOm8DdunI2fq">
                                           <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                             <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -6102,7 +6102,7 @@
                                       <Pin Id="E2A6bx1VpqzPzbqbGHoF1q" Name="Input 4" Kind="InputPin" />
                                       <Pin Id="OU9iUFMage7O4uueWOAX0o" Name="Output" Kind="StateOutputPin" />
                                     </Node>
-                                    <Node Bounds="752,1181,85,19" Id="IBF9ObYkIdbLaTfantPGUi">
+                                    <Node Bounds="748,1178,85,19" Id="IBF9ObYkIdbLaTfantPGUi">
                                       <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
                                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                         <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
@@ -6117,7 +6117,7 @@
                                     </Node>
                                   </Patch>
                                 </Node>
-                                <Node Bounds="770,1757,230,137" Id="JHLuIXRiB2OOpV0mJDclJW">
+                                <Node Bounds="770,1757,230,144" Id="JHLuIXRiB2OOpV0mJDclJW">
                                   <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                     <CategoryReference Kind="Category" Name="Primitive" />
@@ -6127,7 +6127,7 @@
                                   <Patch Id="BgH5X1dn6p8OElLjepoQFF" ManuallySortedPins="true">
                                     <Patch Id="DGHnxzVuuqkNnE4Kpn1Hln" Name="Create" ManuallySortedPins="true" />
                                     <Patch Id="LALjL68qBLtNp02dsa8kyx" Name="Then" ManuallySortedPins="true" />
-                                    <Node Bounds="782,1780,41,19" Id="QQIzVNHmAo7NRiYym4JTBL">
+                                    <Node Bounds="782,1780,45,26" Id="QQIzVNHmAo7NRiYym4JTBL">
                                       <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                         <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -6146,7 +6146,7 @@
                                       <Pin Id="KrQiT2HYTqZPgdlwbqYpmf" Name="Item" Kind="InputPin" />
                                       <Pin Id="VaygddSVEAdNTZP8k1Q7en" Name="Output" Kind="StateOutputPin" />
                                     </Node>
-                                    <Node Bounds="782,1855,55,19" Id="Sb91Noc3NV4OCK4iBodQeU">
+                                    <Node Bounds="782,1855,55,26" Id="Sb91Noc3NV4OCK4iBodQeU">
                                       <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                         <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -6171,7 +6171,7 @@
                               <Pin Id="Q5BWMR8GsuDMOP8ccdUa6j" Name="Content Is Visible" Kind="OutputPin" />
                               <Pin Id="TeZlJj5fg5CN88PQTNetVf" Name="Has Close Button" Kind="InputPin" DefaultValue="False" />
                             </Node>
-                            <Node Bounds="745,461,41,19" Id="R1tz4VM5ThrMD6wuAGv6Ds">
+                            <Node Bounds="745,461,45,26" Id="R1tz4VM5ThrMD6wuAGv6Ds">
                               <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -6208,7 +6208,7 @@
                               <Pin Id="SCMmrFxyz5UQGmbQsp7PGi" Name="Style" Kind="InputPin" />
                               <Pin Id="FmHyUFVVV9iNiLH1FpmaeT" Name="Context" Kind="OutputPin" />
                             </Node>
-                            <Node Bounds="626,787,105,19" Id="G2xJbX9vb2TNFItv8DdbBt">
+                            <Node Bounds="626,787,125,19" Id="G2xJbX9vb2TNFItv8DdbBt">
                               <p:NodeReference LastCategoryFullName="Main.Utils" LastDependency="GammaLauncher.vl">
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 <CategoryReference Kind="Category" Name="Utils" NeedsToBeDirectParent="true">
@@ -6250,7 +6250,7 @@
                             </Node>
                             <ControlPoint Id="ORqQzgwg4jvOgEowUrUI5N" Bounds="567,575" />
                             <ControlPoint Id="VWFbM8yApe9OXvOWeUv0Dr" Bounds="568,740" />
-                            <Node Bounds="1172,423,65,19" Id="SZ53eB4X3DRQGlFoZjgQ4c">
+                            <Node Bounds="1172,423,85,19" Id="SZ53eB4X3DRQGlFoZjgQ4c">
                               <p:NodeReference LastCategoryFullName="Main.Editor.UI.Editor.Tabs" LastDependency="GammaLauncher.vl">
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 <CategoryReference Kind="Category" Name="Tabs" NeedsToBeDirectParent="true" />
@@ -6340,7 +6340,7 @@
                             </Node>
                             <ControlPoint Id="OLdF0T56q0qQQK0bqusN0p" Bounds="594,835" />
                             <ControlPoint Id="KMkj7SW1SeLMMzneORzPtz" Bounds="596,573" />
-                            <Node Bounds="708,628,80,86" Id="Rwb5yuFopaOLU5VOjq8aNP">
+                            <Node Bounds="708,628,166,86" Id="Rwb5yuFopaOLU5VOjq8aNP">
                               <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                 <Choice Kind="ProcessAppFlag" Name="ForEach (Channel)" />
@@ -6348,7 +6348,7 @@
                               <Patch Id="T3tHrsw1YLsNKpMP3uwFQ9" ManuallySortedPins="true">
                                 <Patch Id="RaExxVWfYmvOaLQ2QZRXEf" Name="Create" ManuallySortedPins="true" />
                                 <Patch Id="PCWBSP3k5gzPIPqPbSiySB" Name="Update" ManuallySortedPins="true" />
-                                <Node Bounds="742,667" Id="EQzs1rncL4YOm8Hxd9wRL0">
+                                <Node Bounds="742,667,120,26" Id="EQzs1rncL4YOm8Hxd9wRL0">
                                   <p:NodeReference LastCategoryFullName="Main.Runtime.LaunchTabRuntime" LastDependency="GammaLauncher.vl">
                                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                     <Choice Kind="OperationCallFlag" Name="ScanLocalVvvvVersions" />
@@ -6358,9 +6358,9 @@
                                 </Node>
                               </Patch>
                               <Pin Id="Er25PnQuWtYOceRciiDlWV" Name="At Least Run Once" Kind="InputPin" />
-                              <ControlPoint Id="AzrHCqSNQKgLLa9O7sCyY6" Bounds="725,635" Alignment="Top" />
+                              <ControlPoint Id="AzrHCqSNQKgLLa9O7sCyY6" Bounds="725,634" Alignment="Top" />
                             </Node>
-                            <Node Bounds="807,382" Id="M15ftclAhh5MbRnZNQ2U0t">
+                            <Node Bounds="807,382,106,26" Id="M15ftclAhh5MbRnZNQ2U0t">
                               <p:NodeReference LastCategoryFullName="Main.App.App" LastDependency="GammaLauncher.vl">
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 <Choice Kind="OperationCallFlag" Name="GetRuntimeChannel" />
@@ -6369,7 +6369,7 @@
                               <Pin Id="Ih7RxFI0VQbOZDokL3ONRG" Name="State Output" Kind="StateOutputPin" />
                               <Pin Id="LJZZVHC582IO6UCWGERosW" Name="Output" Kind="OutputPin" />
                             </Node>
-                            <Node Bounds="908,422,41,19" Id="BXtXUh2gwDTNbMOdAZWBzn">
+                            <Node Bounds="908,422,45,26" Id="BXtXUh2gwDTNbMOdAZWBzn">
                               <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -6389,16 +6389,16 @@
                               <Pin Id="JmOulICL1q4LicI9Hjj4ZR" Name="Output" Kind="StateOutputPin" />
                               <Pin Id="Kv1wWHTA1sAPcwKZS9VoK8" Name="Launch Tab Runtime" Kind="OutputPin" />
                             </Node>
-                            <Node Bounds="621,1996,448,850" Id="Bi0ONTT1j7OOUrFhKNPM9p">
+                            <Node Bounds="626,2088,448,448" Id="Bi0ONTT1j7OOUrFhKNPM9p">
                               <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                 <Choice Kind="ProcessAppFlag" Name="CollapsingHeader" />
                               </p:NodeReference>
-                              <ControlPoint Id="BxFUAWGB2wwOhnQQMc6TMZ" Bounds="687,2003" Alignment="Top" />
+                              <ControlPoint Id="BxFUAWGB2wwOhnQQMc6TMZ" Bounds="692,2094" Alignment="Top" />
                               <Patch Id="JQ5JT7eYsCbMWHQx9MWhHX" ManuallySortedPins="true">
                                 <Patch Id="A5pRTs3mEuVNeXrMW37K8d" Name="Create" ManuallySortedPins="true" />
                                 <Patch Id="J6MAjZ9bM3tP3znnS5rGah" Name="Update" ManuallySortedPins="true" />
-                                <Node Bounds="685,2654,85,19" Id="REkhpZ3PCPEMsVvBEXjAoA">
+                                <Node Bounds="690,2336,85,19" Id="REkhpZ3PCPEMsVvBEXjAoA">
                                   <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                     <CategoryReference Kind="Category" Name="Widgets" NeedsToBeDirectParent="true" />
@@ -6412,162 +6412,38 @@
                                   <Pin Id="JiLpZjbgHRFLRgoPVvRy8n" Name="Context" Kind="OutputPin" />
                                   <Pin Id="TtEyrXAASVIMxXJPW2PdxX" Name="Bang" Kind="OutputPin" />
                                 </Node>
-                                <Node Bounds="673,2019,384,564" Id="NUGvU3tw7m7LMxTJjRNlJc">
+                                <Node Bounds="678,2110,384,177" Id="NUGvU3tw7m7LMxTJjRNlJc">
                                   <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                     <CategoryReference Kind="Category" Name="Primitive" />
                                     <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
                                   </p:NodeReference>
                                   <Pin Id="JtX9iQvq4XzO5qiMAOsGNu" Name="Break" Kind="OutputPin" />
-                                  <ControlPoint Id="R9sOaQ6PDGbNmJwJKcqujB" Bounds="687,2577" Alignment="Bottom" />
-                                  <ControlPoint Id="LaKc3uVTRVxNE7XPXZnejN" Bounds="687,2026" Alignment="Top" />
-                                  <ControlPoint Id="AiYF1flsZEVNbAgl6YL6OZ" Bounds="777,2026" Alignment="Top" />
+                                  <ControlPoint Id="R9sOaQ6PDGbNmJwJKcqujB" Bounds="693,2281" Alignment="Bottom" />
+                                  <ControlPoint Id="LaKc3uVTRVxNE7XPXZnejN" Bounds="692,2116" Alignment="Top" />
+                                  <ControlPoint Id="AiYF1flsZEVNbAgl6YL6OZ" Bounds="779,2116" Alignment="Top" />
                                   <Patch Id="CUnMBVjuxI5LmokkgKR4bc" ManuallySortedPins="true">
                                     <Patch Id="VfOCq2DJBO2MVWWczFJjRZ" Name="Create" ManuallySortedPins="true" />
                                     <Patch Id="CKMjzcnh0NqN0tdSnWQ5Oa" Name="Update" ManuallySortedPins="true">
                                       <Pin Id="U7ogho0tSL6K99iOFPvDT4" Name="Index" Kind="InputPin" />
                                     </Patch>
                                     <Patch Id="QidVvE4BHtMQImRdEpczZK" Name="Dispose" ManuallySortedPins="true" />
-                                    <Node Bounds="685,2228,72,19" Id="FQtdIxNKVAMNmcoKBVZvL0">
-                                      <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
+                                    <ControlPoint Id="FcsbiGVX4rnMbBCKTGpWuz" Bounds="1013,2195" />
+                                    <Node Bounds="691,2218,325,19" Id="LUXlwShGeTaPhpJNL5FlrT">
+                                      <p:NodeReference LastCategoryFullName="Main.Editor.UI.Editor.Tabs.Settings" LastDependency="GammaLauncher.vl">
                                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                        <Choice Kind="ProcessNode" Name="Input (String)" />
+                                        <Choice Kind="ProcessAppFlag" Name="EditablePackageEntry" />
                                       </p:NodeReference>
-                                      <Pin Id="JtJDisn3pesLtB00nZKpLN" Name="Context" Kind="InputPin" />
-                                      <Pin Id="Hvgc81DDyEUO7164OLi6Nc" Name="Channel" Kind="InputPin" />
-                                      <Pin Id="NMUNuiM0roIOx1i4ydY2TG" Name="Label" Kind="InputPin" />
-                                      <Pin Id="CRRb0MPplpaMgri1DDmXPV" Name="Max Length" Kind="InputPin" />
-                                      <Pin Id="LMEuBBVZ25BLVwln20qi6D" Name="Flags" Kind="InputPin" />
-                                      <Pin Id="RXbMCcBjhLlNVUahVi4czw" Name="Style" Kind="InputPin" />
-                                      <Pin Id="JukKYS5x3PGLurvQWzH7PR" Name="Context" Kind="OutputPin" />
-                                      <Pin Id="GfatbrpzSlvMlNt2JgZFz6" Name="Bang" Kind="OutputPin" />
-                                      <Pin Id="Hc6jY0u6uzgO7kRyapVS5O" Name="Value" Kind="OutputPin" />
-                                    </Node>
-                                    <Node Bounds="685,2283,59,19" Id="BSfuzLFS4eKMVbE0tk5LIE">
-                                      <p:NodeReference LastCategoryFullName="ImGui.Commands" LastDependency="VL.ImGui.vl">
-                                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                        <Choice Kind="ProcessNode" Name="SameLine" />
-                                      </p:NodeReference>
-                                      <Pin Id="TAkZbs7zpPkLtnffbjYYbz" Name="Context" Kind="InputPin" />
-                                      <Pin Id="O7f8C7oTQUjQYt4NhIga4K" Name="Offset" Kind="InputPin" />
-                                      <Pin Id="JgMqmnJ4NbVPx5jQ9dUths" Name="Spacing" Kind="InputPin" />
-                                      <Pin Id="BXd8FE71RRaLACbgW5G3M1" Name="Context" Kind="OutputPin" />
-                                    </Node>
-                                    <Node Bounds="685,2379,85,19" Id="GzH6nYcaMJyNTqD1klm40o">
-                                      <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
-                                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                        <CategoryReference Kind="Category" Name="Widgets" NeedsToBeDirectParent="true" />
-                                        <Choice Kind="ProcessAppFlag" Name="Button" />
-                                      </p:NodeReference>
-                                      <Pin Id="Ke948FQwyr8LAM7nt6PBSK" Name="Context" Kind="InputPin" />
-                                      <Pin Id="CYZBHatzC10MvNXzmLZwQg" Name="Channel" Kind="InputPin" />
-                                      <Pin Id="FlpoM0cwo5bPUYIrweh5CC" Name="Label" Kind="InputPin" DefaultValue="X" />
-                                      <Pin Id="NifrinPcYLGPcwNM853eNd" Name="Size" Kind="InputPin" />
-                                      <Pin Id="A2FS3L41raZM6tWKl78lyw" Name="Style" Kind="InputPin" />
-                                      <Pin Id="R8qlO6KeRrnLFgHQpmPF9C" Name="Context" Kind="OutputPin" />
-                                      <Pin Id="RnRGenaSISXLFPT3lkdDcC" Name="Bang" Kind="OutputPin" />
-                                    </Node>
-                                    <Node Bounds="709,2145,43,19" Id="CVbspazxVyoPNGLGgWXDXY">
-                                      <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
-                                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                        <Choice Kind="ProcessAppFlag" Name="Select (ByPath)" />
-                                      </p:NodeReference>
-                                      <Pin Id="KI1pDaEmVUQOIcKAwkvkWp" Name="Input" Kind="InputPin" />
-                                      <Pin Id="VRAfGlpC1vtNZRsvHkoftu" Name="Path" Kind="InputPin" DefaultValue="Package Repositories Folder[0]" />
-                                      <Pin Id="Aw5K3duFNd3M7IJcoabnSe" Name="Output" Kind="OutputPin" />
-                                    </Node>
-                                    <ControlPoint Id="FcsbiGVX4rnMbBCKTGpWuz" Bounds="1008,2054" />
-                                    <Node Bounds="767,2077,55,19" Id="HyGk11DeF7DPd2kGyiGir7">
-                                      <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
-                                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                        <Choice Kind="OperationCallFlag" Name="ToString" />
-                                      </p:NodeReference>
-                                      <Pin Id="LrhlFEM80R2PTP3kiYuAHP" Name="Input" Kind="InputPin" />
-                                      <Pin Id="B7Bc3t2qBdHMeKRVbk568X" Name="Result" Kind="OutputPin" />
-                                    </Node>
-                                    <Node Bounds="765,2422,257,132" Id="FYiovajWHyWOpBezXmlroW">
-                                      <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
-                                        <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                                        <CategoryReference Kind="Category" Name="Primitive" />
-                                        <Choice Kind="ApplicationStatefulRegion" Name="If" />
-                                      </p:NodeReference>
-                                      <Pin Id="CEHvfSabPRoO7F1FfL4RRW" Name="Condition" Kind="InputPin" />
-                                      <Patch Id="CqJMX1DDOcIPYpuSee6huJ" ManuallySortedPins="true">
-                                        <Patch Id="T8jvFNoivUpMCxkpznN8Ri" Name="Create" ManuallySortedPins="true" />
-                                        <Patch Id="EwWEm4Egh10QNNM6kqJ2M1" Name="Then" ManuallySortedPins="true" />
-                                        <Node Bounds="827,2473,183,26" Id="RQabYeJit26QVGkF32xOJk">
-                                          <p:NodeReference LastCategoryFullName="Main.Model.SettingsTabModel" LastDependency="GammaLauncher.vl">
-                                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                            <Choice Kind="OperationCallFlag" Name="RemoveEditablePackage" />
-                                          </p:NodeReference>
-                                          <Pin Id="FT6Bv3cJSp0LfxZtg2Hr44" Name="Input" Kind="StateInputPin" />
-                                          <Pin Id="EBJKZwcwTa0QIGqqHvVSI3" Name="Index" Kind="InputPin" />
-                                          <Pin Id="BP1EdSBNnlGN3LRADHAbQJ" Name="Output" Kind="StateOutputPin" />
-                                        </Node>
-                                        <Node Bounds="777,2445,41,19" Id="GgvzjYok2wqNAs0OV8ArY6">
-                                          <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
-                                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                            <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
-                                            <Choice Kind="OperationCallFlag" Name="Value" />
-                                          </p:NodeReference>
-                                          <Pin Id="HBMuFeMa9xKNPWaKZxR4mh" Name="Input" Kind="StateInputPin" />
-                                          <Pin Id="FXgJP6rpVjSOFrEfz0EzBi" Name="Output" Kind="StateOutputPin" />
-                                          <Pin Id="BJAo528LzCYNj6Q9Bbqfub" Name="Value" Kind="OutputPin" />
-                                        </Node>
-                                        <Node Bounds="777,2515,55,19" Id="OG6uRmCSIMsOyWnmA9H4Ee">
-                                          <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
-                                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                            <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
-                                            <Choice Kind="OperationCallFlag" Name="SetValue" />
-                                          </p:NodeReference>
-                                          <Pin Id="MiR3sUXSuC4L4o0ECXbU9h" Name="Input" Kind="StateInputPin" />
-                                          <Pin Id="MlAj50DxVlbMaTQ1rKoITC" Name="Value" Kind="InputPin" />
-                                          <Pin Id="LlRsK2Iao6wMqnKj75ZFQJ" Name="Output" Kind="StateOutputPin" />
-                                        </Node>
-                                      </Patch>
-                                    </Node>
-                                    <Node Bounds="732,2190,85,19" Id="E2l2L5mUvI6P7q7dRKHQI4">
-                                      <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
-                                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                        <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
-                                        <Choice Kind="OperationCallFlag" Name="Format" />
-                                      </p:NodeReference>
-                                      <Pin Id="BNUyLabP5jrPeQTqddHvof" Name="Format" Kind="InputPin" DefaultValue="##EditablePack{0}" />
-                                      <Pin Id="PG3olv9GUIHN5wyVDfT2Ce" Name="Input" Kind="StateInputPin" />
-                                      <Pin Id="K3Mp5anfufcNzlNTNJiO9k" Name="Input 2" Kind="InputPin" />
-                                      <Pin Id="AC7tJQX321jMXyFLce9RhW" Name="Input 3" Kind="InputPin" />
-                                      <Pin Id="OjxdrpPuqxjQUbtGMstEzf" Name="Input 4" Kind="InputPin" />
-                                      <Pin Id="Cq7UUqgS0ukMJQMsh7vJYs" Name="Output" Kind="StateOutputPin" />
-                                    </Node>
-                                    <Node Bounds="725,2346,85,19" Id="BfsV8Vzh8meLyssm3zvxFj">
-                                      <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
-                                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                        <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
-                                        <Choice Kind="OperationCallFlag" Name="Format" />
-                                      </p:NodeReference>
-                                      <Pin Id="Ac34wKs3nH5LNiI61hvCdL" Name="Format" Kind="InputPin" DefaultValue="X##DeleteButton_{0}_editableP" />
-                                      <Pin Id="Omogcyh9rPTPbjqSB8jPIH" Name="Input" Kind="StateInputPin" />
-                                      <Pin Id="TUBUr2RqUZqLMXDOKKBpym" Name="Input 2" Kind="InputPin" />
-                                      <Pin Id="SAO1ofc7Dj9Nmcf0rz2PkG" Name="Input 3" Kind="InputPin" />
-                                      <Pin Id="AyfA98d9fZVL6JpqtotTCU" Name="Input 4" Kind="InputPin" />
-                                      <Pin Id="O3pNi6yhKV2MGqYkgKSeje" Name="Output" Kind="StateOutputPin" />
-                                    </Node>
-                                    <Node Bounds="747,2114,85,19" Id="EXupU91Ppk4NQjafaOaQfC">
-                                      <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
-                                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                        <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
-                                        <Choice Kind="OperationCallFlag" Name="Format" />
-                                      </p:NodeReference>
-                                      <Pin Id="Mu3a859FN8ANAUnFDNpOrU" Name="Format" Kind="InputPin" DefaultValue="Editable Packages[{0}]" />
-                                      <Pin Id="IwA5ouVuN3pQP49cDYN8W5" Name="Input" Kind="StateInputPin" />
-                                      <Pin Id="JJA0NWggYN7L5k7kSUk5kQ" Name="Input 2" Kind="InputPin" />
-                                      <Pin Id="SznlLpPRYaRMmBSOcIgGK5" Name="Input 3" Kind="InputPin" />
-                                      <Pin Id="DIcc0yaJLpcN7zpwimuP6K" Name="Input 4" Kind="InputPin" />
-                                      <Pin Id="O56NAl5KDx9LgM36unvOBs" Name="Output" Kind="StateOutputPin" />
+                                      <Pin Id="KJcgbOiCvrUQWXnCSESlsM" Name="Context" Kind="InputPin" />
+                                      <Pin Id="QrIm8gJWM2hQS4fUdGKRDK" Name="Model" Kind="InputPin" />
+                                      <Pin Id="KmgGJieMgiSNAEQz3vag2t" Name="Text Field Style" Kind="InputPin" />
+                                      <Pin Id="LJCJKVkgvxJPXin54dEjAG" Name="Button Style" Kind="InputPin" />
+                                      <Pin Id="PmzQBtGBo4YLgX4WNnXypg" Name="Index" Kind="InputPin" />
+                                      <Pin Id="NusfCdMtb2WNLsDqbAxOEL" Name="Context" Kind="OutputPin" />
                                     </Node>
                                   </Patch>
                                 </Node>
-                                <Node Bounds="765,2690,230,137" Id="CZ2gDbB0OygOIaeRgGcItI">
+                                <Node Bounds="770,2372,230,144" Id="CZ2gDbB0OygOIaeRgGcItI">
                                   <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                     <CategoryReference Kind="Category" Name="Primitive" />
@@ -6577,7 +6453,7 @@
                                   <Patch Id="NAQ6ccO8UnLODiBZdATLfH" ManuallySortedPins="true">
                                     <Patch Id="J9Esj93mPG9QViCokIHNvG" Name="Create" ManuallySortedPins="true" />
                                     <Patch Id="HYSzw3tHxy1OOSul0PxThl" Name="Then" ManuallySortedPins="true" />
-                                    <Node Bounds="777,2713,41,19" Id="LuF1DpPdNo5POVacLrzsux">
+                                    <Node Bounds="782,2395,45,26" Id="LuF1DpPdNo5POVacLrzsux">
                                       <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                         <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -6587,7 +6463,7 @@
                                       <Pin Id="N9uV98zojjLPii95A5szCy" Name="Output" Kind="StateOutputPin" />
                                       <Pin Id="KxeRjcFLB8INVjUnpWXzhc" Name="Value" Kind="OutputPin" />
                                     </Node>
-                                    <Node Bounds="827,2746,156,26" Id="CgJ6LBE1oOQM4QHDTbza9O">
+                                    <Node Bounds="832,2428,156,26" Id="CgJ6LBE1oOQM4QHDTbza9O">
                                       <p:NodeReference LastCategoryFullName="Main.Model.SettingsTabModel" LastDependency="GammaLauncher.vl">
                                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                         <Choice Kind="OperationCallFlag" Name="AddEditablePackage" />
@@ -6596,7 +6472,7 @@
                                       <Pin Id="HKwrZ2ZZkk4QHOoEFOduZ6" Name="Item" Kind="InputPin" />
                                       <Pin Id="E55DU2Xx8LEOZVOTUTLJv9" Name="Output" Kind="StateOutputPin" />
                                     </Node>
-                                    <Node Bounds="777,2788,55,19" Id="C1rVIcwWBUaOdUoCJhQJkt">
+                                    <Node Bounds="782,2470,55,26" Id="C1rVIcwWBUaOdUoCJhQJkt">
                                       <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                         <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -6619,18 +6495,14 @@
                               <Pin Id="Sgmckc5AxWbN19WAczxT95" Name="Context" Kind="OutputPin" />
                               <Pin Id="Dpy6VULIYwdQQ5xuzfT4TT" Name="Close Clicked" Kind="OutputPin" />
                               <Pin Id="PZqtRAZ1LOKPtNwienxJFt" Name="Content Is Visible" Kind="OutputPin" />
-                              <Pin Id="CISTm9JlV2YND2yfcXZKQu" Name="Has Close Button" Kind="InputPin" DefaultValue="False" />
                             </Node>
                             <ControlPoint Id="Iv5y2s3RxO3QJvhGOpySfl" Bounds="412,564" />
                             <Pad Id="LkrMtExgm5NPl3NiAheu5O" Bounds="411,1913" />
-                            <ControlPoint Id="MlHym66gG3APZgA9zgjRBo" Bounds="431,2472" />
-                            <ControlPoint Id="DIPGdc0e5eVQWXzOYH37yQ" Bounds="451,2311" />
-                            <ControlPoint Id="SfCzg1y5taULXzqMbrT0sW" Bounds="472,2100" />
+                            <ControlPoint Id="MlHym66gG3APZgA9zgjRBo" Bounds="414,2265" />
                             <ControlPoint Id="AfD6Tp4TaaSLDDQBDvCXyb" Bounds="1197,1268" />
                             <Pad Id="AQEdaGgfiOUOgJE6816E8H" SlotId="N4FYsPZ4cxGO92b9tdsJUM" Bounds="1193,1944" />
-                            <ControlPoint Id="P6HKqdkikXUQWRzSWsyCN0" Bounds="1233,1955" />
                             <ControlPoint Id="QZ2wTLhTp9HM6p8oEQMW0O" Bounds="1127,1806" />
-                            <Node Bounds="475,1908,41,19" Id="IgJRdrI9HqGQEaKWR7z2KY">
+                            <Node Bounds="735,1965,45,26" Id="IgJRdrI9HqGQEaKWR7z2KY">
                               <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -6640,13 +6512,216 @@
                               <Pin Id="V4DfoV55IKRQZYqmhha6z2" Name="Output" Kind="StateOutputPin" />
                               <Pin Id="TcjL3JNQqVbQVAPtwBjw6K" Name="Value" Kind="OutputPin" />
                             </Node>
-                            <Node Bounds="492,1954,153,26" Id="OYnBKDm8Vw7OMTmGKBj7pd">
+                            <Node Bounds="775,2005,153,26" Id="OYnBKDm8Vw7OMTmGKBj7pd">
                               <p:NodeReference LastCategoryFullName="Main.Model.SettingsTabModel" LastDependency="GammaLauncher.vl">
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 <Choice Kind="OperationCallFlag" Name="GetEditablePackages" />
                               </p:NodeReference>
                               <Pin Id="ET5buvw8CxdMdcus8AYwHR" Name="Input" Kind="StateInputPin" />
                               <Pin Id="OuU2LLbJ6jbQdUnqHMRzBN" Name="Editable Packages" Kind="OutputPin" />
+                            </Node>
+                            <!--
+
+    ************************ EditablePackageEntry ************************
+
+-->
+                            <Node Name="EditablePackageEntry" Bounds="1232,2242" Id="TZeTbWiET3tNXC5AHHU29H">
+                              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                                <Choice Kind="ContainerDefinition" Name="Process" />
+                              </p:NodeReference>
+                              <Patch Id="VgWLqzqil3xOredHUdNsmP">
+                                <Canvas Id="IWtwn1Xk9QBNbfsa24Ojz8" CanvasType="Group">
+                                  <Node Bounds="385,457,105,19" Id="GtDKcO5K65TLtBkREllqkS">
+                                    <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <Choice Kind="ProcessNode" Name="Input (String)" />
+                                    </p:NodeReference>
+                                    <Pin Id="QFgVxNQOo1nOL4GLKE9K5j" Name="Context" Kind="InputPin" />
+                                    <Pin Id="HtyiFWBKLggOnVbMVJItLY" Name="Channel" Kind="InputPin" />
+                                    <Pin Id="Iqg092856UQOD1DU7hE2mm" Name="Label" Kind="InputPin" />
+                                    <Pin Id="MXYOQJzeuvKLDojLbiptpr" Name="Max Length" Kind="InputPin" />
+                                    <Pin Id="V5FQ35yRVb5MywGxJhSrPC" Name="Flags" Kind="InputPin" />
+                                    <Pin Id="AJTMOU6rEYfLmKvam9fenj" Name="Style" Kind="InputPin" />
+                                    <Pin Id="PolUKEGAtqMMxEguKiOdAc" Name="Context" Kind="OutputPin" />
+                                    <Pin Id="Rceuocur8aFNDhgIceL2eF" Name="Bang" Kind="OutputPin" />
+                                    <Pin Id="Kwpep5f9MxPP5z9KE1dOZ4" Name="Value" Kind="OutputPin" />
+                                  </Node>
+                                  <Node Bounds="385,512,59,19" Id="HyH2uK2JdKTLGpQUf4eksO">
+                                    <p:NodeReference LastCategoryFullName="ImGui.Commands" LastDependency="VL.ImGui.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <Choice Kind="ProcessNode" Name="SameLine" />
+                                    </p:NodeReference>
+                                    <Pin Id="KK2lbZonGcAN38jyKjij6J" Name="Context" Kind="InputPin" />
+                                    <Pin Id="Vm5XHHlrm7QLrFLYjDpVib" Name="Offset" Kind="InputPin" />
+                                    <Pin Id="DeHV193rd0EQNyb2fraPbw" Name="Spacing" Kind="InputPin" />
+                                    <Pin Id="AMEE0afzrvnN3HxParTztk" Name="Context" Kind="OutputPin" />
+                                  </Node>
+                                  <Node Bounds="385,608,85,19" Id="Ic7ZG7UkqDgMn0XWYxw1mc">
+                                    <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <CategoryReference Kind="Category" Name="Widgets" NeedsToBeDirectParent="true" />
+                                      <Choice Kind="ProcessAppFlag" Name="Button" />
+                                    </p:NodeReference>
+                                    <Pin Id="MeTBeVs7WG4O7wDyGtmeoV" Name="Context" Kind="InputPin" />
+                                    <Pin Id="DTpdvwJuRnvQVe6AZtvnlR" Name="Channel" Kind="InputPin" />
+                                    <Pin Id="LywqDvJqQxPNlqESViOYPm" Name="Label" Kind="InputPin" DefaultValue="X" />
+                                    <Pin Id="PLNQ8Xb4V1LMSCcHFXBjAz" Name="Size" Kind="InputPin" />
+                                    <Pin Id="CNGCnMOqpP3MfqTTngso1T" Name="Style" Kind="InputPin" />
+                                    <Pin Id="VHZk8cZwE8nNmlcj01knRe" Name="Context" Kind="OutputPin" />
+                                    <Pin Id="LUl2hfwnnOaLnZ3XRV7xKf" Name="Bang" Kind="OutputPin" />
+                                  </Node>
+                                  <Node Bounds="405,376,43,19" Id="CXUcgFrTjugOuEFATUx5Zu">
+                                    <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <Choice Kind="ProcessAppFlag" Name="Select (ByPath)" />
+                                    </p:NodeReference>
+                                    <Pin Id="GErrkshTZipP7HysW5BWkm" Name="Input" Kind="InputPin" />
+                                    <Pin Id="EdcSlJIxm0BQdS4lPrStcd" Name="Path" Kind="InputPin" DefaultValue="Package Repositories Folder[0]" />
+                                    <Pin Id="OYpd9PUrLqvM9fN3YiIuAi" Name="Output" Kind="OutputPin" />
+                                  </Node>
+                                  <ControlPoint Id="PL8YnZCTdXdQZmcyyQoc7y" Bounds="708,283" />
+                                  <Node Bounds="463,308,55,19" Id="QFneJvRXglTLUxRbME1bES">
+                                    <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <Choice Kind="OperationCallFlag" Name="ToString" />
+                                    </p:NodeReference>
+                                    <Pin Id="D76MwrN1gMcL3Gd3VjfPzN" Name="Input" Kind="InputPin" />
+                                    <Pin Id="JoXRgkOe8rAPE1YIbka91n" Name="Result" Kind="OutputPin" />
+                                  </Node>
+                                  <Node Bounds="465,682,257,164" Id="C9jGj1gRlyANzkpiki02QU">
+                                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                                      <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                                      <CategoryReference Kind="Category" Name="Primitive" />
+                                      <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                                    </p:NodeReference>
+                                    <Pin Id="MKQwLvRz9tRO0pCC59Dmi0" Name="Condition" Kind="InputPin" />
+                                    <Patch Id="KmHancQIpXTMnEyyUNS66h" ManuallySortedPins="true">
+                                      <Patch Id="BdNLL2P3aE2MUYyETKIKE6" Name="Create" ManuallySortedPins="true" />
+                                      <Patch Id="PKmbmfuuIjfMOAbTHGO31y" Name="Then" ManuallySortedPins="true" />
+                                      <Node Bounds="527,755,183,26" Id="AkHKY1KwAwhLyIQ2t1qFel">
+                                        <p:NodeReference LastCategoryFullName="Main.Model.SettingsTabModel" LastDependency="GammaLauncher.vl">
+                                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                          <Choice Kind="OperationCallFlag" Name="RemoveEditablePackage" />
+                                        </p:NodeReference>
+                                        <Pin Id="TshvaKobAUILpeCa53NTcM" Name="Input" Kind="StateInputPin" />
+                                        <Pin Id="Qj4yDHdE3ghNKzP1pCinrH" Name="Index" Kind="InputPin" />
+                                        <Pin Id="VEZ6pF6yIKRN3ygLSFqcDb" Name="Output" Kind="StateOutputPin" />
+                                      </Node>
+                                      <Node Bounds="477,705,45,26" Id="NxCT4t2rOZXOo9MYS73jBO">
+                                        <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
+                                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                          <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
+                                          <Choice Kind="OperationCallFlag" Name="Value" />
+                                        </p:NodeReference>
+                                        <Pin Id="BXVilVBn21dPrrpQ511oEa" Name="Input" Kind="StateInputPin" />
+                                        <Pin Id="LSlHHg2yO1xNTjJxnYSKKt" Name="Output" Kind="StateOutputPin" />
+                                        <Pin Id="N7jmFqwmWdWOBJx2p2DLxc" Name="Value" Kind="OutputPin" />
+                                      </Node>
+                                      <Node Bounds="477,800,55,26" Id="C2qqTQuF8kgM6K5iLMGwFe">
+                                        <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
+                                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                          <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
+                                          <Choice Kind="OperationCallFlag" Name="SetValue" />
+                                        </p:NodeReference>
+                                        <Pin Id="APcOen6jFhJN3YwOKBxd9s" Name="Input" Kind="StateInputPin" />
+                                        <Pin Id="BSWmycZ3NJQPnpa30ixBEt" Name="Value" Kind="InputPin" />
+                                        <Pin Id="JPkwjBTDY2eLnnjdWCqyQV" Name="Output" Kind="StateOutputPin" />
+                                      </Node>
+                                    </Patch>
+                                  </Node>
+                                  <Node Bounds="432,419,85,19" Id="P1HMUyr32oKLExSdO3K7X2">
+                                    <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
+                                      <Choice Kind="OperationCallFlag" Name="Format" />
+                                    </p:NodeReference>
+                                    <Pin Id="OGkc8mWYcMPOU6Gt2k4fmU" Name="Format" Kind="InputPin" DefaultValue="##EditablePack{0}" />
+                                    <Pin Id="VQ7ZhBthdByOT9OdXQh9qw" Name="Input" Kind="StateInputPin" />
+                                    <Pin Id="V4kRrpgONSMLS45lolFk7o" Name="Input 2" Kind="InputPin" />
+                                    <Pin Id="BfOnxxVFnkxMwEnpiBFDHc" Name="Input 3" Kind="InputPin" />
+                                    <Pin Id="Ta6MnZowTWIO9UGyNjz33d" Name="Input 4" Kind="InputPin" />
+                                    <Pin Id="FJoSyFOcw4XLxitTqKcuSg" Name="Output" Kind="StateOutputPin" />
+                                  </Node>
+                                  <Node Bounds="425,575,85,19" Id="DKrM12aIwjpM8JkhSDafPX">
+                                    <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
+                                      <Choice Kind="OperationCallFlag" Name="Format" />
+                                    </p:NodeReference>
+                                    <Pin Id="Kv5hjPdYFweLLV3MUkDZUL" Name="Format" Kind="InputPin" DefaultValue="X##DeleteButton_{0}_editableP" />
+                                    <Pin Id="AIoo6WOqSXbOX43V2G06Bn" Name="Input" Kind="StateInputPin" />
+                                    <Pin Id="FKzFCklq9oeN5HrrxyCXCA" Name="Input 2" Kind="InputPin" />
+                                    <Pin Id="DbFvQI6ItbnM0OR29T9MZS" Name="Input 3" Kind="InputPin" />
+                                    <Pin Id="NjEg91VP2EFLQbwN2W00ep" Name="Input 4" Kind="InputPin" />
+                                    <Pin Id="AUrrhjNzOauLyyAV9QXcJC" Name="Output" Kind="StateOutputPin" />
+                                  </Node>
+                                  <Node Bounds="443,345,85,19" Id="VXezhgnPedRPPkaMtCWW3e">
+                                    <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                      <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
+                                      <Choice Kind="OperationCallFlag" Name="Format" />
+                                    </p:NodeReference>
+                                    <Pin Id="H2Go6fC6mkKLjkxhDqJDZm" Name="Format" Kind="InputPin" DefaultValue="Editable Packages[{0}]" />
+                                    <Pin Id="JRl4elGlvB6MAJVvv0ANjM" Name="Input" Kind="StateInputPin" />
+                                    <Pin Id="TlYzNMvlj0bNK1oynULNOs" Name="Input 2" Kind="InputPin" />
+                                    <Pin Id="Pp5zyqoLZ97NFhBaropmc1" Name="Input 3" Kind="InputPin" />
+                                    <Pin Id="Fl3alLBdUxXMtDvJgrZiqq" Name="Input 4" Kind="InputPin" />
+                                    <Pin Id="QAMeE5WShtuLBNh7gbgWAg" Name="Output" Kind="StateOutputPin" />
+                                  </Node>
+                                  <ControlPoint Id="L4SkuufLtFJOwO5mvvGFkG" Bounds="387,195" />
+                                  <ControlPoint Id="MWyxPwPgl3uL4uUyz767c3" Bounds="388,905" />
+                                  <ControlPoint Id="EGuiimVG0CUQcXqJXu28Fp" Bounds="479,654" />
+                                  <ControlPoint Id="QVDzwzdGD3uMUMvG56Fjbf" Bounds="407,332" />
+                                  <ControlPoint Id="UpKC5nqLilcMdizUY5Viz6" Bounds="783,281" />
+                                  <ControlPoint Id="L4B6cH7bFqVOfiOPD6Iypa" Bounds="892,282" />
+                                </Canvas>
+                                <!--
+
+    ************************  ************************
+
+-->
+                                <ProcessDefinition Id="UpIXeSV5iBzPAZbj6AxPvs">
+                                  <Fragment Id="T5haXqutLlnMVCqt5ygI1F" Patch="PXAvzaUQHKGO6cHM208nq1" Enabled="true" />
+                                  <Fragment Id="MexavGqpHgNQLtRsiWUjp2" Patch="Um1yf5P7tQCOv2vhgqMWu3" Enabled="true" />
+                                </ProcessDefinition>
+                                <Link Id="F4slUNUNOaHOx3JMvKIs5g" Ids="PolUKEGAtqMMxEguKiOdAc,KK2lbZonGcAN38jyKjij6J" />
+                                <Link Id="EQYpyP60t3oOHRZTTu8TrL" Ids="AMEE0afzrvnN3HxParTztk,MeTBeVs7WG4O7wDyGtmeoV" />
+                                <Link Id="TH1mZ2m6yvMOh3OCtAYGkz" Ids="OYpd9PUrLqvM9fN3YiIuAi,HtyiFWBKLggOnVbMVJItLY" />
+                                <Link Id="I7zCI62N7bZLUUSo28rfNQ" Ids="VVk0XMBGZXqN4MZCs1EH9t,PL8YnZCTdXdQZmcyyQoc7y" IsHidden="true" />
+                                <Link Id="J84usSVOt9mPwJwB3Ax4pm" Ids="PL8YnZCTdXdQZmcyyQoc7y,D76MwrN1gMcL3Gd3VjfPzN" />
+                                <Link Id="Mh9fb7t09uZLzDI9dWDn7c" Ids="LUl2hfwnnOaLnZ3XRV7xKf,MKQwLvRz9tRO0pCC59Dmi0" />
+                                <Link Id="GzGM1uYslIcPfKpmHCEd4N" Ids="PL8YnZCTdXdQZmcyyQoc7y,Qj4yDHdE3ghNKzP1pCinrH" />
+                                <Link Id="FJCGMDg83XbMCtz4GJaG9i" Ids="LSlHHg2yO1xNTjJxnYSKKt,APcOen6jFhJN3YwOKBxd9s" />
+                                <Link Id="FZj2v8DP2vPORLgue2BXaI" Ids="N7jmFqwmWdWOBJx2p2DLxc,TshvaKobAUILpeCa53NTcM" />
+                                <Link Id="K9C4oZoecrBOK65bxpjHMh" Ids="VEZ6pF6yIKRN3ygLSFqcDb,BSWmycZ3NJQPnpa30ixBEt" />
+                                <Link Id="PWJJe1MXkNwPwZGNyvoJmr" Ids="PL8YnZCTdXdQZmcyyQoc7y,VQ7ZhBthdByOT9OdXQh9qw" />
+                                <Link Id="GwUhLNtSXMfLGQkPocCQJ1" Ids="FJoSyFOcw4XLxitTqKcuSg,Iqg092856UQOD1DU7hE2mm" />
+                                <Link Id="UwFi0iRWMMWOxe6j61DBDa" Ids="PL8YnZCTdXdQZmcyyQoc7y,AIoo6WOqSXbOX43V2G06Bn" />
+                                <Link Id="T9Z7MKy6sEWPh7MnINCggO" Ids="AUrrhjNzOauLyyAV9QXcJC,LywqDvJqQxPNlqESViOYPm" />
+                                <Link Id="H5bqOXIX7YpNQmGFnfQ2de" Ids="JoXRgkOe8rAPE1YIbka91n,JRl4elGlvB6MAJVvv0ANjM" />
+                                <Link Id="UKoIytKvHAhOVH31YDmUJA" Ids="QAMeE5WShtuLBNh7gbgWAg,EdcSlJIxm0BQdS4lPrStcd" />
+                                <Link Id="PkCerC8B0ufPPJvVKwB1G3" Ids="L4SkuufLtFJOwO5mvvGFkG,QFgVxNQOo1nOL4GLKE9K5j" />
+                                <Link Id="GrG7rgB9T8SPs6gpykznM6" Ids="Pb2aiTFZ78lNSvRDnpNs6o,L4SkuufLtFJOwO5mvvGFkG" IsHidden="true" />
+                                <Link Id="FwGKGAhzwW0PAM2PJKGEBm" Ids="VHZk8cZwE8nNmlcj01knRe,MWyxPwPgl3uL4uUyz767c3" />
+                                <Link Id="SS5ZaQLjSrBMr99MUKYYpt" Ids="MWyxPwPgl3uL4uUyz767c3,B0oYoiRXijuLhhi3tzFMI4" IsHidden="true" />
+                                <Link Id="ACZJu9jLk3pMtNsUfcOhlP" Ids="EGuiimVG0CUQcXqJXu28Fp,BXVilVBn21dPrrpQ511oEa" />
+                                <Link Id="J93iaslqq4KQZTqsQhdrj0" Ids="I3NSpKw6lWvM92V4wMF81w,EGuiimVG0CUQcXqJXu28Fp" IsHidden="true" />
+                                <Patch Id="PXAvzaUQHKGO6cHM208nq1" Name="Create" />
+                                <Patch Id="Um1yf5P7tQCOv2vhgqMWu3" Name="Update" ManuallySortedPins="true">
+                                  <Pin Id="Pb2aiTFZ78lNSvRDnpNs6o" Name="Context" Kind="InputPin" Bounds="387,195" />
+                                  <Pin Id="I3NSpKw6lWvM92V4wMF81w" Name="Model" Kind="InputPin" Bounds="198,459" />
+                                  <Pin Id="LfByQmTkoeXOkfrUPr9tnx" Name="Text Field Style" Kind="InputPin" Bounds="787,296" />
+                                  <Pin Id="AhBK45UXrRPLrFsYXzgnHR" Name="Button Style" Kind="InputPin" Bounds="892,282" />
+                                  <Pin Id="VVk0XMBGZXqN4MZCs1EH9t" Name="Index" Kind="InputPin" />
+                                  <Pin Id="B0oYoiRXijuLhhi3tzFMI4" Name="Context" Kind="OutputPin" Bounds="387,905" />
+                                </Patch>
+                                <Link Id="Gt3H5y426dMNsonDdSCJoL" Ids="I3NSpKw6lWvM92V4wMF81w,QVDzwzdGD3uMUMvG56Fjbf" IsHidden="true" />
+                                <Link Id="PVLkt0J6cFmMnKsZUiW4Pa" Ids="QVDzwzdGD3uMUMvG56Fjbf,GErrkshTZipP7HysW5BWkm" />
+                                <Link Id="T7vbsvWHf1uPVtuY36Sz7q" Ids="UpKC5nqLilcMdizUY5Viz6,AJTMOU6rEYfLmKvam9fenj" />
+                                <Link Id="O31nitu6YSUOv1fua0lOFR" Ids="LfByQmTkoeXOkfrUPr9tnx,UpKC5nqLilcMdizUY5Viz6" IsHidden="true" />
+                                <Link Id="RZfOombNITIPM1X9THIH0H" Ids="L4B6cH7bFqVOfiOPD6Iypa,CNGCnMOqpP3MfqTTngso1T" />
+                                <Link Id="EhBCXCRJvunMcyT0MgL4qy" Ids="AhBK45UXrRPLrFsYXzgnHR,L4B6cH7bFqVOfiOPD6Iypa" IsHidden="true" />
+                              </Patch>
                             </Node>
                           </Canvas>
                           <ProcessDefinition Id="INp7VmAXDcsMimfR0Ou7vW">
@@ -6730,45 +6805,30 @@
                           <Link Id="UTygdItFbUdOJ1BYPt6i5o" Ids="LJZZVHC582IO6UCWGERosW,KsmIZKI9GOvMnZXsgdgMEa" />
                           <Link Id="DR2qIRhhDBTNE6DNN2Hs4A" Ids="EJtfxuRL6n8PnXRg9NvBiG,VXiZNJHekCeNsGyK0MOnhd" />
                           <Link Id="LBaqJSQvDThQXmW9Tx6eRz" Ids="Kv1wWHTA1sAPcwKZS9VoK8,SP4jGrzhURYMh3oItbH9vs" />
-                          <Link Id="RGttjVCkt90MUn2f5sukvm" Ids="JukKYS5x3PGLurvQWzH7PR,TAkZbs7zpPkLtnffbjYYbz" />
-                          <Link Id="CA6UBoWpyyJOxd7y2Z48SR" Ids="BXd8FE71RRaLACbgW5G3M1,Ke948FQwyr8LAM7nt6PBSK" />
                           <Link Id="GygRk54rZifLllAblGui9b" Ids="LaKc3uVTRVxNE7XPXZnejN,R9sOaQ6PDGbNmJwJKcqujB" IsFeedback="true" />
-                          <Link Id="KSsDRXMlSW3PXsuvkeWJOp" Ids="R8qlO6KeRrnLFgHQpmPF9C,R9sOaQ6PDGbNmJwJKcqujB" />
                           <Link Id="MO7fAvu2U2ML4eX2QSi2WO" Ids="R9sOaQ6PDGbNmJwJKcqujB,ANGXRYEOnt1LMURLPQHaJ1" />
-                          <Link Id="GexMj2Gk5EzO24Qyr0Eq3c" Ids="Aw5K3duFNd3M7IJcoabnSe,Hvgc81DDyEUO7164OLi6Nc" />
-                          <Link Id="JtItfDzBesaLnotYf6pNNr" Ids="LaKc3uVTRVxNE7XPXZnejN,JtJDisn3pesLtB00nZKpLN" />
                           <Link Id="MnMDd8nRqavNVZivUbTmAl" Ids="BxFUAWGB2wwOhnQQMc6TMZ,LaKc3uVTRVxNE7XPXZnejN" />
                           <Link Id="PVmrzaR55MsP4xCeeanCJ1" Ids="U7ogho0tSL6K99iOFPvDT4,FcsbiGVX4rnMbBCKTGpWuz" IsHidden="true" />
-                          <Link Id="HWA9prlPYLFN74mQ7WyaKU" Ids="FcsbiGVX4rnMbBCKTGpWuz,LrhlFEM80R2PTP3kiYuAHP" />
                           <Link Id="JBhsNseyvrVQGny7avJMT2" Ids="TtEyrXAASVIMxXJPW2PdxX,VtD2T8TTcEKMQyBRC34y9I" />
                           <Link Id="TtjDthy3aYBMmfyRgJUDiI" Ids="KxeRjcFLB8INVjUnpWXzhc,M4iF3OS5IJdMarjcjXesHr" />
                           <Link Id="UY1p8CxwLeKOSFncZCsK3j" Ids="E55DU2Xx8LEOZVOTUTLJv9,RJrqUGE58TBPUH10Gp4aAl" />
                           <Link Id="IhttI4FqmAyOLAv6u8hwmj" Ids="N9uV98zojjLPii95A5szCy,Ck3AfoWHcYbOee9q7LcbBx" />
-                          <Link Id="TCrQZA4JnAwN2qVI8U067D" Ids="RnRGenaSISXLFPT3lkdDcC,CEHvfSabPRoO7F1FfL4RRW" />
-                          <Link Id="QebWRu4O3w5P4lRhCqtBJG" Ids="FcsbiGVX4rnMbBCKTGpWuz,EBJKZwcwTa0QIGqqHvVSI3" />
-                          <Link Id="S0m6XNKIOGjNPQgLzfQRCI" Ids="FXgJP6rpVjSOFrEfz0EzBi,MiR3sUXSuC4L4o0ECXbU9h" />
-                          <Link Id="UQW33uwT3nRQD6WusubVLg" Ids="BJAo528LzCYNj6Q9Bbqfub,FT6Bv3cJSp0LfxZtg2Hr44" />
-                          <Link Id="BtqAdcjRoZ3QA2SDNQ3a9v" Ids="BP1EdSBNnlGN3LRADHAbQJ,MlAj50DxVlbMaTQ1rKoITC" />
-                          <Link Id="Q3OZULJx4NaQUdlNH6aA56" Ids="FcsbiGVX4rnMbBCKTGpWuz,PG3olv9GUIHN5wyVDfT2Ce" />
-                          <Link Id="QE5Luud4MDJMPUCDJtHKpl" Ids="Cq7UUqgS0ukMJQMsh7vJYs,NMUNuiM0roIOx1i4ydY2TG" />
-                          <Link Id="AkGtwN9vc4XNXKWqxuB4Jz" Ids="FcsbiGVX4rnMbBCKTGpWuz,Omogcyh9rPTPbjqSB8jPIH" />
-                          <Link Id="HgMjAggYxb7QTqA1AAVu6w" Ids="O3pNi6yhKV2MGqYkgKSeje,FlpoM0cwo5bPUYIrweh5CC" />
-                          <Link Id="A76n8cweyBuMAZNOEH1bg7" Ids="B7Bc3t2qBdHMeKRVbk568X,IwA5ouVuN3pQP49cDYN8W5" />
-                          <Link Id="FJ7TXEwI0tKQWxAhvpxJcb" Ids="O56NAl5KDx9LgM36unvOBs,VRAfGlpC1vtNZRsvHkoftu" />
                           <Link Id="Vlg5MOpAmFjPHnltzinDI5" Ids="CGpf39Xn8CELBO3HeuyvdR,UCTr7LmH3vGMAsZYCX2Ukq" />
                           <Link Id="AqZ5cYarqw4OTx6XAGsaV8" Ids="UCiScDY6yuHPkA8RgMRr27,Iv5y2s3RxO3QJvhGOpySfl,LkrMtExgm5NPl3NiAheu5O" />
                           <Link Id="DpcwLVB7HcQN4KKZHnoDBk" Ids="LkrMtExgm5NPl3NiAheu5O,MlHym66gG3APZgA9zgjRBo,QObzxOKx8Z4MuqgOX4HPq9" />
-                          <Link Id="F2zxjl9t4mqQLVSX7D4jOr" Ids="LkrMtExgm5NPl3NiAheu5O,DIPGdc0e5eVQWXzOYH37yQ,HBMuFeMa9xKNPWaKZxR4mh" />
-                          <Link Id="Q3lTXfKvSB7P7t9MyDJTcU" Ids="LkrMtExgm5NPl3NiAheu5O,SfCzg1y5taULXzqMbrT0sW,KI1pDaEmVUQOIcKAwkvkWp" />
                           <Slot Id="N4FYsPZ4cxGO92b9tdsJUM" Name="Output" />
                           <Link Id="BCMAREie1CALGjnoCXmYLP" Ids="ELJRfXJMYFbMiPYSmAbyZ6,AfD6Tp4TaaSLDDQBDvCXyb,AQEdaGgfiOUOgJE6816E8H" />
-                          <Link Id="AKHXNDvn0JxK991rDqhdE1" Ids="AQEdaGgfiOUOgJE6816E8H,A2FS3L41raZM6tWKl78lyw" />
                           <Link Id="LmuqhzSAVlDPdHV6xYTpv0" Ids="AQEdaGgfiOUOgJE6816E8H,Sbho5VBKgSQNkMkeZKPO1I" />
-                          <Link Id="DtTXbsKhoqlMtbfqQiJlZj" Ids="Jh4uO1x4gKvQIDsKQWFQOK,P6HKqdkikXUQWRzSWsyCN0,RXbMCcBjhLlNVUahVi4czw" />
                           <Link Id="GVflbZAjCdwMKLtnpE0Hej" Ids="RAOrDgCLjwVPOJQiR3RXsZ,QZ2wTLhTp9HM6p8oEQMW0O,UDdvfgvcLLcPmSayPzZknJ" />
                           <Link Id="OQYSKPQqivTM2U0mFAVPpL" Ids="TcjL3JNQqVbQVAPtwBjw6K,ET5buvw8CxdMdcus8AYwHR" />
                           <Link Id="AWQaOqBOvLBL0oYniYRuc3" Ids="LkrMtExgm5NPl3NiAheu5O,RadTw7a5CFWLsFIILKy00b" />
                           <Link Id="BsYvhpbL53gM3BWl8CwkgS" Ids="OuU2LLbJ6jbQdUnqHMRzBN,AiYF1flsZEVNbAgl6YL6OZ" />
+                          <Link Id="BaEZGvjQIuyQWooDSz3OkX" Ids="LaKc3uVTRVxNE7XPXZnejN,KJcgbOiCvrUQWXnCSESlsM" />
+                          <Link Id="SEqyzY3ZNsEP367SePArLq" Ids="NusfCdMtb2WNLsDqbAxOEL,R9sOaQ6PDGbNmJwJKcqujB" />
+                          <Link Id="MmVIVFHoHihOfZJf4y9Iti" Ids="LkrMtExgm5NPl3NiAheu5O,QrIm8gJWM2hQS4fUdGKRDK" />
+                          <Link Id="ReNvy5CcePPPEsrzMT98K9" Ids="FcsbiGVX4rnMbBCKTGpWuz,PmzQBtGBo4YLgX4WNnXypg" />
+                          <Link Id="FXOqMe94BxPNdtSGD0OV3J" Ids="Jh4uO1x4gKvQIDsKQWFQOK,KmgGJieMgiSNAEQz3vag2t" />
+                          <Link Id="EPuoynIqCetNe2Go4NMAvD" Ids="AQEdaGgfiOUOgJE6816E8H,LJCJKVkgvxJPXin54dEjAG" />
                         </Patch>
                       </Node>
                       <!--

--- a/GammaLauncher.vl
+++ b/GammaLauncher.vl
@@ -21,16 +21,13 @@
               <ControlPoint Id="Gs0ZLfFXwOlMdqpfHQTPxC" Bounds="213,581" />
               <ControlPoint Id="AY4JTWIrsD9MQ6olpJqvZw" Bounds="213,490" />
               <ControlPoint Id="TM8XmjNnIcjLM4uUNNNETw" Bounds="367,486" />
-              <Pad Id="IhFhgHG1M80PdNrhrafOJV" SlotId="PRVYonqIN8HLQbxA212MIO" Bounds="576,540" />
-              <ControlPoint Id="V8dlmMkxUHLM8B2xBjGmVm" Bounds="576,484" />
-              <ControlPoint Id="LBXoassUyaROV1a8FCbZPn" Bounds="576,593" />
-              <ControlPoint Id="FLOBfgzpQkuLDq4gnVX4tL" Bounds="610,509" />
+              <Pad Id="IhFhgHG1M80PdNrhrafOJV" SlotId="PRVYonqIN8HLQbxA212MIO" Bounds="681,540" />
+              <ControlPoint Id="V8dlmMkxUHLM8B2xBjGmVm" Bounds="681,484" />
+              <ControlPoint Id="LBXoassUyaROV1a8FCbZPn" Bounds="681,593" />
+              <ControlPoint Id="FLOBfgzpQkuLDq4gnVX4tL" Bounds="715,509" />
+              <Pad Id="SaAYYUU4q4XNTXYtjMmzL9" SlotId="BjfuAeqUdGiLc2dKp96PsJ" Bounds="526,540" />
+              <ControlPoint Id="Q7TgrdKwZTFPg0tqA1e49S" Bounds="526,483" />
             </Canvas>
-            <Patch Id="UeVkUKbB99rOPSx1n1EH1B" Name="Create" ParticipatingElements="Ltce6H8ourDLLLnH9BNSju,QZ5R4jYCTSTL6cpKf9930u,IOm4KfMzUp7PD8VqrbzhGX">
-              <Pin Id="OjNu7BqIZkuLoZ80MlBW9N" Name="Launch Tab Model" Kind="InputPin" />
-              <Pin Id="DN0TFFHDpZgL0TW5SmLkwi" Name="Settings Model" Kind="InputPin" />
-              <Pin Id="SCxWhtd0zTRQFu558X48HR" Name="Window Bounds" Kind="InputPin" Bounds="610,509" />
-            </Patch>
             <ProcessDefinition Id="HwyYPlPJeANPWLlJB7Q2Jl" IsHidden="true">
               <Fragment Id="Lb6hwjRfpafMXN1ENL1bSu" Patch="UeVkUKbB99rOPSx1n1EH1B" Enabled="true" />
               <Fragment Id="ARsuOOeJZrhNJqReeFeQ7f" Patch="TiF5HXH1Bt4LlxRMsHFmik" />
@@ -48,21 +45,6 @@
               <Fragment Id="IXK842P98xuPVu2906mESS" Patch="MFtqPAHsQA7MPbD9CN8xPd" />
               <Fragment Id="HSzDkAcSK7fN0JzxLE70zA" Patch="AS6cKY5dDtuMioQJDIBwoq" />
             </ProcessDefinition>
-            <Patch Id="TiF5HXH1Bt4LlxRMsHFmik" Name="GetKey" />
-            <Patch Id="QVRw4qx3VUHLPBiT0Ko0z1" Name="GetVersion" />
-            <Patch Id="T45FRdA3myoMLvgJC9CebK" Name="GetSettings" />
-            <Patch Id="RyX90aPI2fAPZI9qcTQscZ" Name="GetStartupParameters" />
-            <Patch Id="LspiuLak1T8OWYWKxFTC4C" Name="SetSettings" />
-            <Patch Id="J3ixiNqEgQJMcUxia44u1U" Name="SetStartupParameters" />
-            <Patch Id="Khqc3zpkhD0PQT6WiScazI" Name="SetBurgerOpen" />
-            <Patch Id="Hkqprw8VQTOLhEGWsRk4RM" Name="GetBurgerOpen" />
-            <Patch Id="IAg5c7QaS4cME8SKMC3SSY" Name="CloseBurger" />
-            <Patch Id="KrBCQ226JaPNaSeSz7QI7r" Name="SetWindowBounds">
-              <Pin Id="MNdULRJwH3rLlT7aApI6FZ" Name="Window Bounds" Kind="InputPin" />
-            </Patch>
-            <Patch Id="TqHLqYVk2JPOWVXIcfNWiB" Name="GetWindowBounds" ParticipatingElements="DNCRb5jSMmrLvINA4w0qe6">
-              <Pin Id="OlMb9vMVhofLRxyBnXkQY1" Name="Window Bounds" Kind="OutputPin" />
-            </Patch>
             <Slot Id="KREiaHhFYijLGzdj3oxshV" Name="Launch Tab Model">
               <p:TypeAnnotation p:Type="TypeReference">
                 <Choice Kind="TypeFlag" Name="LaunchTabModel" />
@@ -73,17 +55,10 @@
                 <Choice Kind="TypeFlag" Name="SettingsTabModel" />
               </p:TypeAnnotation>
             </Slot>
-            <Patch Id="BRn3OgC5NoPNn6JZSHTgCL" Name="GetAmm" />
             <Link Id="MYu5aJJUadGNBtB7q25QEr" Ids="IvB4Ho0TdBrLTVrGPdNFLG,FvhzwGH6WKlOgHDfwVLc7J" />
             <Link Id="BHgwRmHtHfpPrO1JY64SE5" Ids="FvhzwGH6WKlOgHDfwVLc7J,ClTeBizVETWNyWFDKrQdFa" IsHidden="true" />
-            <Patch Id="MFtqPAHsQA7MPbD9CN8xPd" Name="GetSettingsTabModel" ParticipatingElements="MYu5aJJUadGNBtB7q25QEr">
-              <Pin Id="ClTeBizVETWNyWFDKrQdFa" Name="Settings Tab Model" Kind="OutputPin" />
-            </Patch>
             <Link Id="O5q1JSlN81WQaWAlCbHXFv" Ids="Ftcnv2ue3ITOhTh41TzEQu,Gs0ZLfFXwOlMdqpfHQTPxC" />
             <Link Id="CKBnavKb1vvMIGZxKjywUI" Ids="Gs0ZLfFXwOlMdqpfHQTPxC,AvWRKrqGsfNLuzJFok604u" IsHidden="true" />
-            <Patch Id="AS6cKY5dDtuMioQJDIBwoq" Name="GetLaunchTabModel" ParticipatingElements="O5q1JSlN81WQaWAlCbHXFv">
-              <Pin Id="AvWRKrqGsfNLuzJFok604u" Name="Launch Tab Model" Kind="OutputPin" />
-            </Patch>
             <Link Id="Ltce6H8ourDLLLnH9BNSju" Ids="AY4JTWIrsD9MQ6olpJqvZw,Ftcnv2ue3ITOhTh41TzEQu" />
             <Link Id="V2afH3DUuCqMR1a7KHB2Mo" Ids="OjNu7BqIZkuLoZ80MlBW9N,AY4JTWIrsD9MQ6olpJqvZw" IsHidden="true" />
             <Link Id="QZ5R4jYCTSTL6cpKf9930u" Ids="TM8XmjNnIcjLM4uUNNNETw,IvB4Ho0TdBrLTVrGPdNFLG" />
@@ -100,6 +75,41 @@
             <Link Id="B4aQsY7SnvuMblepq4SCu5" Ids="LBXoassUyaROV1a8FCbZPn,OlMb9vMVhofLRxyBnXkQY1" IsHidden="true" />
             <Link Id="BnRM8xnX1YJOCWTfC9Oomr" Ids="FLOBfgzpQkuLDq4gnVX4tL,IhFhgHG1M80PdNrhrafOJV" />
             <Link Id="BNOkz0PqjowPB5hq9TRydA" Ids="SCxWhtd0zTRQFu558X48HR,FLOBfgzpQkuLDq4gnVX4tL" IsHidden="true" />
+            <Slot Id="BjfuAeqUdGiLc2dKp96PsJ" Name="Version">
+              <p:TypeAnnotation p:Type="TypeReference">
+                <Choice Kind="TypeFlag" Name="String" />
+              </p:TypeAnnotation>
+            </Slot>
+            <Link Id="BFmLmesp0weQdADMsJpvPu" Ids="Q7TgrdKwZTFPg0tqA1e49S,SaAYYUU4q4XNTXYtjMmzL9" />
+            <Link Id="ULYHGlF22vGLIOnUAF6SyP" Ids="MtH0IPowHU4MZSe2Ag45A2,Q7TgrdKwZTFPg0tqA1e49S" IsHidden="true" />
+            <Patch Id="UeVkUKbB99rOPSx1n1EH1B" Name="Create" ParticipatingElements="Ltce6H8ourDLLLnH9BNSju,QZ5R4jYCTSTL6cpKf9930u,IOm4KfMzUp7PD8VqrbzhGX,BFmLmesp0weQdADMsJpvPu">
+              <Pin Id="OjNu7BqIZkuLoZ80MlBW9N" Name="Launch Tab Model" Kind="InputPin" />
+              <Pin Id="DN0TFFHDpZgL0TW5SmLkwi" Name="Settings Model" Kind="InputPin" />
+              <Pin Id="MtH0IPowHU4MZSe2Ag45A2" Name="Version" Kind="InputPin" />
+              <Pin Id="SCxWhtd0zTRQFu558X48HR" Name="Window Bounds" Kind="InputPin" Bounds="610,509" />
+            </Patch>
+            <Patch Id="TiF5HXH1Bt4LlxRMsHFmik" Name="GetKey" />
+            <Patch Id="QVRw4qx3VUHLPBiT0Ko0z1" Name="GetVersion" />
+            <Patch Id="T45FRdA3myoMLvgJC9CebK" Name="GetSettings" />
+            <Patch Id="RyX90aPI2fAPZI9qcTQscZ" Name="GetStartupParameters" />
+            <Patch Id="LspiuLak1T8OWYWKxFTC4C" Name="SetSettings" />
+            <Patch Id="J3ixiNqEgQJMcUxia44u1U" Name="SetStartupParameters" />
+            <Patch Id="Khqc3zpkhD0PQT6WiScazI" Name="SetBurgerOpen" />
+            <Patch Id="Hkqprw8VQTOLhEGWsRk4RM" Name="GetBurgerOpen" />
+            <Patch Id="IAg5c7QaS4cME8SKMC3SSY" Name="CloseBurger" />
+            <Patch Id="KrBCQ226JaPNaSeSz7QI7r" Name="SetWindowBounds">
+              <Pin Id="MNdULRJwH3rLlT7aApI6FZ" Name="Window Bounds" Kind="InputPin" />
+            </Patch>
+            <Patch Id="TqHLqYVk2JPOWVXIcfNWiB" Name="GetWindowBounds" ParticipatingElements="DNCRb5jSMmrLvINA4w0qe6">
+              <Pin Id="OlMb9vMVhofLRxyBnXkQY1" Name="Window Bounds" Kind="OutputPin" />
+            </Patch>
+            <Patch Id="BRn3OgC5NoPNn6JZSHTgCL" Name="GetAmm" />
+            <Patch Id="MFtqPAHsQA7MPbD9CN8xPd" Name="GetSettingsTabModel" ParticipatingElements="MYu5aJJUadGNBtB7q25QEr">
+              <Pin Id="ClTeBizVETWNyWFDKrQdFa" Name="Settings Tab Model" Kind="OutputPin" />
+            </Patch>
+            <Patch Id="AS6cKY5dDtuMioQJDIBwoq" Name="GetLaunchTabModel" ParticipatingElements="O5q1JSlN81WQaWAlCbHXFv">
+              <Pin Id="AvWRKrqGsfNLuzJFok604u" Name="Launch Tab Model" Kind="OutputPin" />
+            </Patch>
           </Patch>
         </Node>
         <!--
@@ -10397,12 +10407,12 @@
                     <CategoryReference Kind="Category" Name="Primitive" />
                   </p:NodeReference>
                   <Pin Id="JG2a7uPtWBiMvxcTs9CugQ" Name="Condition" Kind="InputPin" />
-                  <ControlPoint Id="SJvEfMMbjfKNAEhsDI7DRY" Bounds="260,385" Name="Settings Model" Alignment="Top" />
+                  <ControlPoint Id="SJvEfMMbjfKNAEhsDI7DRY" Bounds="260,384" Name="Settings Model" Alignment="Top" />
                   <ControlPoint Id="Fq57GRQtPz1LnL7kdlIICP" Bounds="304,797" Name="Settings Model" Alignment="Bottom" />
                   <Patch Id="JOaenPtiGW1MSvhcIpf9Je" ManuallySortedPins="true">
                     <Patch Id="I9O6N9jxUjxNYWJAomYx4O" Name="Create" ManuallySortedPins="true" />
                     <Patch Id="GfbcYfKIeuoNQpHsumDbp9" Name="Then" ManuallySortedPins="true" />
-                    <Node Bounds="338,566,85,26" Id="K89wLm3c0MCO7QgkPW1ULd">
+                    <Node Bounds="325,562,105,26" Id="K89wLm3c0MCO7QgkPW1ULd">
                       <p:NodeReference LastCategoryFullName="Main.Model.SettingsTabModel" LastDependency="GammaLauncher.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <CategoryReference Kind="RecordType" Name="SettingsTabModel" />
@@ -10416,7 +10426,7 @@
                       <Pin Id="B8Kn0mE6c4WQJuunCJ43Xs" Name="Nugets Override Folder" Kind="InputPin" />
                       <Pin Id="VEJNCLkN7DjNVh8vjVPcOe" Name="Output" Kind="StateOutputPin" />
                     </Node>
-                    <Node Bounds="418,533,61,19" Id="NqY974wCcbkQFrwAVec8m5">
+                    <Node Bounds="345,532,61,19" Id="NqY974wCcbkQFrwAVec8m5">
                       <p:NodeReference LastCategoryFullName="2D.Rectangle" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="Rectangle (Join)" />
@@ -10430,7 +10440,7 @@
                       <Pin Id="U5CVTYY2j8pMvVYHPakN92" Name="Anchor" Kind="InputPin" />
                       <Pin Id="RGbpm7ZS6f2OB7ZbZsQ4OW" Name="Output" Kind="StateOutputPin" />
                     </Node>
-                    <Node Bounds="548,471,87,19" Id="KBQ0n67OMmlNOUhlz0DUgI">
+                    <Node Bounds="548,471,87,26" Id="KBQ0n67OMmlNOUhlz0DUgI">
                       <p:NodeReference LastCategoryFullName="IO.Path" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="CreateDirectory" />
@@ -10547,6 +10557,7 @@
                       </p:NodeReference>
                       <Pin Id="N9Sx6AzmPpdLVbUV4eTHe0" Name="Launch Tab Model" Kind="InputPin" />
                       <Pin Id="UFxS5nwx7KaO2k1cnTUg0e" Name="Settings Model" Kind="InputPin" />
+                      <Pin Id="QdiSts2plUKL5JyY6lZ5kO" Name="Version" Kind="InputPin" />
                       <Pin Id="GO5poXW75ZoOEqBHPgouod" Name="Window Bounds" Kind="InputPin" />
                       <Pin Id="D4ZxIbSB8hmPy6xpPwJNbp" Name="Output" Kind="StateOutputPin" />
                     </Node>
@@ -10582,7 +10593,7 @@
                   <Pin Id="TKL0jVcFRBNM6LJG3pNs0k" Name="Result" Kind="OutputPin" />
                 </Node>
                 <ControlPoint Id="Pf7KVPKFy0KPrZoC6Va0cJ" Bounds="253,866" />
-                <Node Bounds="251,894,55,19" Id="AbVTwHQiBbpOYStu4vK1cp">
+                <Node Bounds="251,894,55,26" Id="AbVTwHQiBbpOYStu4vK1cp">
                   <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="ClassType" Name="Channel" />
@@ -10603,7 +10614,7 @@
                   <Pin Id="BoujfuUY0i5MjA9qGHqI4Q" Name="Input" Kind="StateInputPin" />
                   <Pin Id="H5PhSY9qbFsQUFoh332msG" Name="Exists" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="450,879" Id="CfOjgtY75QAPV6LLRdKofO">
+                <Node Bounds="450,879,101,26" Id="CfOjgtY75QAPV6LLRdKofO">
                   <p:NodeReference LastCategoryFullName="Main.Model.ApplicationModel" LastDependency="GammaLauncher.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="RecordType" Name="ApplicationModel" NeedsToBeDirectParent="true" />
@@ -10621,6 +10632,7 @@
                   <Pin Id="Jhww7YATprZPqy5izDgqc7" Name="Output" Kind="OutputPin" />
                 </Node>
                 <ControlPoint Id="NY0uiaakr1INM9gxWlFrQz" Bounds="452,979" />
+                <ControlPoint Id="HrKpVpc4SWIMKJabIRN3UM" Bounds="173,570" />
               </Canvas>
               <ProcessDefinition Id="Oft9ztxwtabLhbL9d9ieOW">
                 <Fragment Id="DPmnFp0XIMaP91dP1ytw3k" Patch="LTGkWj6C8n5P8gA2GPgD3g" Enabled="true" />
@@ -10637,20 +10649,6 @@
               <Link Id="Q28nMSacLVDON3Y6dhsfYn" Ids="PKJMNiBX2EePSwDHMNX0eh,MpKSIzKc7c4P75jyinQ1GG" />
               <Link Id="AJvTHL2azIWN83hyYN6pJw" Ids="AyXAqlP45uqMn0CqUH0XNc,MFWlUxXO2VBNmTcKcicJZu" />
               <Link Id="VGYZR3TwQGBMFjYBDdABZl" Ids="SJSHmVXOHwnOGFyJYXTYB9,Pf7KVPKFy0KPrZoC6Va0cJ" IsHidden="true" />
-              <Patch Id="LTGkWj6C8n5P8gA2GPgD3g" Name="Create">
-                <Pin Id="SJSHmVXOHwnOGFyJYXTYB9" Name="Input" Kind="InputPin">
-                  <p:TypeAnnotation LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="TypeFlag" Name="Channel" />
-                    <p:TypeArguments>
-                      <TypeReference>
-                        <Choice Kind="TypeFlag" Name="ApplicationModel" />
-                      </TypeReference>
-                    </p:TypeArguments>
-                  </p:TypeAnnotation>
-                </Pin>
-                <Pin Id="G5ND3430b9GMFFXBKm9DCY" Name="Output" Kind="OutputPin" />
-                <Pin Id="MxinC7h4zrgOFddql2yBLa" Name="Initial Window Bounds" Kind="OutputPin" Bounds="452,979" />
-              </Patch>
               <Link Id="OhhFL9SQA98P1GEgsrXGEu" Ids="N4B7kBDybsyQXxelrGso04,JG2a7uPtWBiMvxcTs9CugQ" />
               <Link Id="TI9FkBCxuGjP2zZlcY09TA" Ids="OAfMjpwYJBCL1iItmIwRSL,USvtnLLBEXXNlMw790FzWW" />
               <Link Id="SV5PMDUFV0eLNDyJQzXv1Q" Ids="MU4do87kXmsOy0LlpFS3YF,ChbOCewaOVGNnXgqWpk3ex" />
@@ -10676,6 +10674,23 @@
               <Link Id="TJhFVxHXDDrNdewaOyqilQ" Ids="NY0uiaakr1INM9gxWlFrQz,MxinC7h4zrgOFddql2yBLa" IsHidden="true" />
               <Link Id="MMi5Q3e6XmAN8iawUjoi3E" Ids="Fnio9jR9XHyOdBURosaejY,Ere3NObzqvhO7kxxsZUeaF" />
               <Link Id="FeotpKhlb3iLnjMfLF7Ox5" Ids="F0OGlfIbKM2Mlko2m7GDyK,GO5poXW75ZoOEqBHPgouod" />
+              <Link Id="RX6qcWrXiGUOXfRgIJ4AMN" Ids="HrKpVpc4SWIMKJabIRN3UM,QdiSts2plUKL5JyY6lZ5kO" />
+              <Link Id="LhVUHcT3fMwMOjiKAMfXNi" Ids="O1Ue60RMCGaP7bLN7J5YaK,HrKpVpc4SWIMKJabIRN3UM" IsHidden="true" />
+              <Patch Id="LTGkWj6C8n5P8gA2GPgD3g" Name="Create">
+                <Pin Id="O1Ue60RMCGaP7bLN7J5YaK" Name="Version" Kind="InputPin" Bounds="173,570" />
+                <Pin Id="SJSHmVXOHwnOGFyJYXTYB9" Name="Input" Kind="InputPin">
+                  <p:TypeAnnotation LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="Channel" />
+                    <p:TypeArguments>
+                      <TypeReference>
+                        <Choice Kind="TypeFlag" Name="ApplicationModel" />
+                      </TypeReference>
+                    </p:TypeArguments>
+                  </p:TypeAnnotation>
+                </Pin>
+                <Pin Id="G5ND3430b9GMFFXBKm9DCY" Name="Output" Kind="OutputPin" />
+                <Pin Id="MxinC7h4zrgOFddql2yBLa" Name="Initial Window Bounds" Kind="OutputPin" Bounds="452,979" />
+              </Patch>
             </Patch>
           </Node>
         </Canvas>
@@ -11325,7 +11340,7 @@
           </p:NodeReference>
           <Patch Id="GMUZPoBxXAeMa1dkg8SZSm">
             <Canvas Id="FjdV0gNw3XMPHVtQ4eeuBo" CanvasType="Group">
-              <Node Bounds="157,150,78,26" Id="Pvv83m8n8oZMgaA4yuHIvT">
+              <Node Bounds="267,155,78,26" Id="Pvv83m8n8oZMgaA4yuHIvT">
                 <p:NodeReference LastCategoryFullName="Main.Model.ApplicationModel" LastDependency="GammaLauncher.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="ApplicationModel" />
@@ -11333,6 +11348,7 @@
                 </p:NodeReference>
                 <Pin Id="FR7CGMagKjGMHKAAEbjd7b" Name="Launch Tab Model" Kind="InputPin" />
                 <Pin Id="UqI77rDETtgM3MuS6yY7Sj" Name="Settings Model" Kind="InputPin" />
+                <Pin Id="GImjjh5nEPYLzWfi0nG5jb" Name="Version" Kind="InputPin" />
                 <Pin Id="EUs8MVnrUrOLyI63nQImXU" Name="Window Bounds" Kind="InputPin" />
                 <Pin Id="GyKJ2EFxovEOgeNghRvZoA" Name="Output" Kind="StateOutputPin" />
               </Node>
@@ -11354,11 +11370,12 @@
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="UserSettingsInitializer" />
                 </p:NodeReference>
+                <Pin Id="HJys8iIZ5k0Ntm92aPKKUS" Name="Version" Kind="InputPin" />
                 <Pin Id="EtOW1NYxf6vQUKBRoypON6" Name="Input" Kind="InputPin" />
                 <Pin Id="PA5XgeAGjuCPqnqUmxZLhu" Name="Output" Kind="OutputPin" />
                 <Pin Id="TWs1LtTucvYOShPAH8Jx9E" Name="Initial Window Bounds" Kind="OutputPin" />
               </Node>
-              <Node Bounds="157,199,53,19" Id="Mwb3jS25auiMFe2qXPiJak">
+              <Node Bounds="267,204,53,19" Id="Mwb3jS25auiMFe2qXPiJak">
                 <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
@@ -11399,6 +11416,7 @@
               <ControlPoint Id="O2etrIjDazwPfvhd0GAmm6" Bounds="404,271" />
               <ControlPoint Id="AFG6b8SDu2wMBnPFue9zJA" Bounds="481,370" />
               <ControlPoint Id="VXlDD65OEZMQFDI4YyRPpX" Bounds="269,293" />
+              <ControlPoint Id="URMuYkat84PLV96BD7EdUl" Bounds="159,210" />
             </Canvas>
             <Patch Id="A4S3mA8Mrd5PYO1muVgVWH" Name="Create" ParticipatingElements="Pvv83m8n8oZMgaA4yuHIvT,UBJeC1l4PfbPFwlpjVYn0x">
               <Pin Id="MY9udmQ3tPwOpuRNi9cjxF" Name="Version" Kind="InputPin" Bounds="439,159" />
@@ -11445,6 +11463,8 @@
             <Link Id="FoCJTScU76wLCF5IAi8lIE" Ids="O2etrIjDazwPfvhd0GAmm6,AVNR7YKkblqNU9Cu3wcK0q" />
             <Link Id="LEEay6hGNUaPMA2gPHlSsb" Ids="TWs1LtTucvYOShPAH8Jx9E,VXlDD65OEZMQFDI4YyRPpX" />
             <Link Id="OQuQKAsQH3TLVMGgt8gN8H" Ids="VXlDD65OEZMQFDI4YyRPpX,F2VAE8YpUJPLCIKwj6SCYs" IsHidden="true" />
+            <Link Id="Lmla94TcZWGOaZH3DAgFpU" Ids="MY9udmQ3tPwOpuRNi9cjxF,URMuYkat84PLV96BD7EdUl" IsHidden="true" />
+            <Link Id="SSDbFitji3yMsTpB46qniS" Ids="URMuYkat84PLV96BD7EdUl,HJys8iIZ5k0Ntm92aPKKUS" />
           </Patch>
         </Node>
       </Canvas>

--- a/GammaLauncher.vl
+++ b/GammaLauncher.vl
@@ -4089,7 +4089,7 @@
     ************************ Editor ************************
 
 -->
-          <Node Name="Editor" Bounds="127,108" Id="MCERlxns3b3O4vat28nymV">
+          <Node Name="Editor" Bounds="117,127" Id="MCERlxns3b3O4vat28nymV">
             <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
               <Choice Kind="ContainerDefinition" Name="Process" />
             </p:NodeReference>
@@ -9796,7 +9796,7 @@
                   <Pin Id="E82a96Bf0N6MUYwBJw9rhF" Name="Value" Kind="InputPin" />
                   <Pin Id="SIZL3cTLaRtOEYsgzyEALu" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="896,571,63,26" Id="N8ly9ye4e8iM2DfRzsDzhD">
+                <Node Bounds="895,574,63,26" Id="N8ly9ye4e8iM2DfRzsDzhD">
                   <p:NodeReference LastCategoryFullName="System.Windows.Forms.Form" LastDependency="System.Windows.Forms.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="AssemblyCategory" Name="Form" />
@@ -9805,7 +9805,7 @@
                   <Pin Id="FfGhhGtcxS1N87E08mSgPl" Name="Input" Kind="StateInputPin" />
                   <Pin Id="Ms4aINmUbb1Pwm5lduhlCO" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="896,647,94,96" Id="BJoI02x4AHLPFSvBklITYI">
+                <Node Bounds="896,647,94,103" Id="BJoI02x4AHLPFSvBklITYI">
                   <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="ProcessAppFlag" Name="ForEach" />
                     <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
@@ -9816,7 +9816,7 @@
                   <Pin Id="AchN78EBxCQLGzwswHzXh2" Name="Result" Kind="OutputPin" />
                   <Patch Id="HGsEp5bazzhLl71yTzdjRH" ManuallySortedPins="true">
                     <ControlPoint Id="HSiaMJN6kkiL4wYQJqDXoW" Bounds="900,655" />
-                    <ControlPoint Id="UDSSvBRhu1KOObtQ8t8a1j" Bounds="919,736" />
+                    <ControlPoint Id="UDSSvBRhu1KOObtQ8t8a1j" Bounds="930,743" />
                     <Node Bounds="927,694,51,26" Id="NYsvRsUPRxhQRd7g1IAtar">
                       <p:NodeReference LastCategoryFullName="Primitive.Reference" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -9847,7 +9847,7 @@
                   <Pin Id="QRnruOdnPRTLqlSGUVZo7c" Name="Input" Kind="StateInputPin" />
                   <Pin Id="ElyyVa8D1TyP49zUjbGA2g" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="750,654,89,96" Id="Hu0lXzGzmYxM9lHvyzRa0O">
+                <Node Bounds="750,654,89,97" Id="Hu0lXzGzmYxM9lHvyzRa0O">
                   <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="ProcessAppFlag" Name="ForEach" />
                     <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
@@ -9858,7 +9858,7 @@
                   <Pin Id="G1r9z5Pr6jxOwsMrGAMMpq" Name="Result" Kind="OutputPin" />
                   <Patch Id="RPFaQV7g6y2Pt3NpQ2skfT" ManuallySortedPins="true">
                     <ControlPoint Id="Lgrh9RzqtplNLcjVwlgGw3" Bounds="754,662" />
-                    <ControlPoint Id="VJSanpwLNb6LQOgK9Ms58J" Bounds="758,743" />
+                    <ControlPoint Id="VJSanpwLNb6LQOgK9Ms58J" Bounds="780,744" />
                     <Node Bounds="776,701,51,26" Id="HmUiSVxn6XcQaYnJXawCdW">
                       <p:NodeReference LastCategoryFullName="Primitive.Reference" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -9902,8 +9902,8 @@
                     <p:buttonmode p:Assembly="VL.UI.Forms" p:Type="VL.HDE.PatchEditor.Editors.ButtonModeEnum">Toggle</p:buttonmode>
                   </p:ValueBoxSettings>
                 </Pad>
-                <Pad Id="IJpPllIPYsUO7RN44o9LPJ" SlotId="MYAsvnuKGDCPymxDIzraML" Bounds="1074,551" />
-                <Node Bounds="1072,570,51,26" Id="BFlSaUu0pWTNwJ8T2q4onz">
+                <Pad Id="IJpPllIPYsUO7RN44o9LPJ" SlotId="MYAsvnuKGDCPymxDIzraML" Bounds="1054,563" />
+                <Node Bounds="1052,586,51,26" Id="BFlSaUu0pWTNwJ8T2q4onz">
                   <p:NodeReference LastCategoryFullName="Primitive.Reference" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Data" />
@@ -9913,7 +9913,7 @@
                   <Pin Id="KaKrWYPgmgDLv9HupkelRC" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="BJa5qpOIhiLODbazCmqRGa" Name="Data" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1118,716,61,19" Id="K16ypFKYvZENOKJFztlg8c">
+                <Node Bounds="1098,732,61,19" Id="K16ypFKYvZENOKJFztlg8c">
                   <p:NodeReference LastCategoryFullName="System.Application" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="MainLoop" />
@@ -9925,7 +9925,7 @@
                   <Pin Id="N3fySe4qew6PshG6RKyBOz" Name="Is Incremental" Kind="OutputPin" />
                   <Pin Id="KrLXwzvAhbvOoVQOeK6k1c" Name="Incremental FPS" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1118,680,45,19" Id="NxWp3eDi4X5MHO47kx4GHi">
+                <Node Bounds="1098,696,45,19" Id="NxWp3eDi4X5MHO47kx4GHi">
                   <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Switch" />
@@ -9944,14 +9944,14 @@
                   </Pin>
                   <Pin Id="ONYHqcfdvY2PcAt5isPqq4" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1143,576,65,19" Id="ORpiqigjoziM3Ojs8al3YB">
+                <Node Bounds="1123,592,65,19" Id="ORpiqigjoziM3Ojs8al3YB">
                   <p:NodeReference LastCategoryFullName="System.Application" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="IsExported" />
                   </p:NodeReference>
                   <Pin Id="CvFdHcUlCekN0PzHH2iGoM" Name="Is Exported" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1143,611,37,19" Id="PovDEBvJYw6Pfuxrc7bzxg">
+                <Node Bounds="1123,627,37,19" Id="PovDEBvJYw6Pfuxrc7bzxg">
                   <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="NOT" />
@@ -9960,7 +9960,7 @@
                   <Pin Id="K3poVUFQzD0PNrf47yMgPU" Name="Input" Kind="StateInputPin" />
                   <Pin Id="KoHSbQnq5W0MtxWiFHDnNL" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="1118,642,30,19" Id="SFZBdGRHmcMLdoTLV2G0Xp">
+                <Node Bounds="1098,658,30,19" Id="SFZBdGRHmcMLdoTLV2G0Xp">
                   <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="OR" />
@@ -9970,7 +9970,7 @@
                   <Pin Id="S3z72qJNyS9Lt6IpuPRCOY" Name="Input 2" Kind="InputPin" />
                   <Pin Id="Q4rbf9WtYuyOzfgaAl28Cb" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Pad Id="L57xm9rttpDQWvDND49JcK" Bounds="1216,593,98,135" ShowValueBox="true" isIOBox="true" Value="If the app is not exported, it's likely that we'll want to edit the patch, so let's stay at 60FPS">
+                <Pad Id="L57xm9rttpDQWvDND49JcK" Bounds="1196,609,98,135" ShowValueBox="true" isIOBox="true" Value="If the app is not exported, it's likely that we'll want to edit the patch, so let's stay at 60FPS">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="String" />
                   </p:TypeAnnotation>
@@ -9979,6 +9979,15 @@
                     <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
                   </p:ValueBoxSettings>
                 </Pad>
+                <Node Bounds="253,732,63,19" Id="DxM7ONovqJCPm6DwOCRg6M">
+                  <p:NodeReference LastCategoryFullName="Main.Editor.UI" LastDependency="GammaLauncher.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="Category" Name="UI" NeedsToBeDirectParent="true" />
+                    <Choice Kind="ProcessAppFlag" Name="NotifyIcon" />
+                  </p:NodeReference>
+                  <Pin Id="LU5xQKnjsEBO2OyJLkTTs0" Name="Form" Kind="InputPin" />
+                  <Pin Id="KD13BXIYKjGN3Iqi7kFFRv" Name="Update" Kind="ApplyPin" />
+                </Node>
               </Canvas>
               <ProcessDefinition Id="GJ1MuldFPStOxgWQnx9ZN6">
                 <Fragment Id="E0AYloWrji9NeKyn663gCn" Patch="Bm4kKQT1Qc0OcozdFGTBMM" Enabled="true" />
@@ -10061,6 +10070,713 @@
               <Link Id="TAS2Wu760ojLShcU6HPQka" Ids="S8WhG6uZEWQOsWJWrhxbBw,BK014BV8pwzPePlSdL3x6P" />
               <Link Id="U0qcq3MEZTLLMXv0I0QQm2" Ids="Q4rbf9WtYuyOzfgaAl28Cb,IyDt3cglaqdMTWckBKuVBF" />
               <Link Id="OOsvwwEngmFOlj0inEmruc" Ids="U5yE42cAVxUQeAR87IEKNe,LuMJe9jJvmOMwPwuNQVaLH" />
+              <Patch Id="L32wjuOxxZjNvzhZksDzvM" Name="Dispose" />
+              <Link Id="SmsYxNSDSFnLgaAFFrfbyI" Ids="CD91iVPoTUVLgaywPozHgI,LU5xQKnjsEBO2OyJLkTTs0" />
+            </Patch>
+          </Node>
+          <!--
+
+    ************************ NotifyIcon ************************
+
+-->
+          <Node Name="NotifyIcon" Bounds="115,229" Id="FG5NeLL761MP05zoif8U1L">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+              <Choice Kind="ContainerDefinition" Name="Process" />
+            </p:NodeReference>
+            <Patch Id="QH1fESzHCYwOdFKVwGxX05">
+              <Canvas Id="I1Hne7xGuUyNwoXYkyJTJt" CanvasType="Group">
+                <Node Bounds="170,-367,53,26" Id="QV7K6hYAtPZP9XvXXjkD5G">
+                  <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastDependency="System.Windows.Forms.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="System" />
+                    <CategoryReference Kind="AssemblyCategory" Name="Windows" />
+                    <CategoryReference Kind="AssemblyCategory" Name="Forms" />
+                    <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" />
+                    <Choice Kind="OperationCallFlag" Name="Create" />
+                  </p:NodeReference>
+                  <Pin Id="NNBGBwmjZy9QdjbXIt8wo9" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Pad Id="HfgD7xb2mnZMmybapFXfac" SlotId="OE2MJsQELrQQY9Dli1mX5w" Bounds="173,18" />
+                <Node Bounds="170,-224,53,26" Id="S3S5sJzRkC0PPPFFYoIX0f">
+                  <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastDependency="System.Windows.Forms.dll" OverloadStrategy="AllPinsThatAreNotCommon">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="System" />
+                    <CategoryReference Kind="AssemblyCategory" Name="Windows" />
+                    <CategoryReference Kind="AssemblyCategory" Name="Forms" />
+                    <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" />
+                    <Choice Kind="OperationCallFlag" Name="SetIcon" />
+                    <PinReference Kind="InputPin" Name="Container" />
+                  </p:NodeReference>
+                  <Pin Id="NEN8zGVBnaRPSSBzwGo8R1" Name="Input" Kind="InputPin" />
+                  <Pin Id="KWGvAvQ4uPGPunsgfZ63jP" Name="Value" Kind="InputPin" />
+                  <Pin Id="Htaher9IojCOmLgHklQABo" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Node Bounds="170,-44,60,26" Id="UgxJit6lpsqM0REJKQ6SZz">
+                  <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastDependency="System.Windows.Forms.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" NeedsToBeDirectParent="true">
+                      <p:OuterCategoryReference Kind="AssemblyCategory" Name="Forms" NeedsToBeDirectParent="true" />
+                    </CategoryReference>
+                    <Choice Kind="OperationCallFlag" Name="SetVisible" />
+                  </p:NodeReference>
+                  <Pin Id="M6Nf6KyaMQtM86mzYZQCsz" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="AJ8iRcXx4X1McMBLjBnssA" Name="Value" Kind="InputPin" DefaultValue="False" />
+                  <Pin Id="GYnyN4cHAGIQcHV9cEBwY5" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Pad Id="UBUCd29xlMJM25ovKFLYuN" Comment="" Bounds="227,-92,35,30" ShowValueBox="true" isIOBox="true" Value="False">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="ImmutableTypeFlag" Name="Boolean" />
+                    <CategoryReference Kind="Category" Name="Primitive" />
+                  </p:TypeAnnotation>
+                  <p:ValueBoxSettings>
+                    <p:buttonmode p:Assembly="VL.UI.Forms" p:Type="VL.HDE.PatchEditor.Editors.ButtonModeEnum">Toggle</p:buttonmode>
+                  </p:ValueBoxSettings>
+                </Pad>
+                <Node Bounds="170,-177,60,26" Id="BQmyYFnVgjnOD7FWvIXf8v">
+                  <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastDependency="System.Windows.Forms.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" NeedsToBeDirectParent="true">
+                      <p:OuterCategoryReference Kind="AssemblyCategory" Name="Forms" NeedsToBeDirectParent="true" />
+                    </CategoryReference>
+                    <Choice Kind="OperationCallFlag" Name="SetText" />
+                  </p:NodeReference>
+                  <Pin Id="CyoRy258HReMdNDKE9w2ek" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="AWMAzkTgeWGMij2dsUHPwI" Name="Value" Kind="InputPin" DefaultValue="False" />
+                  <Pin Id="IPttcxlBlMoPSNe6crb07m" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Node Bounds="604,245,63,26" Id="VujyYSbh4EAOgpFZT5FG7a">
+                  <p:NodeReference LastCategoryFullName="System.Windows.Forms.Form" LastDependency="System.Windows.Forms.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="Form" />
+                    <Choice Kind="OperationCallFlag" Name="Deactivate" />
+                  </p:NodeReference>
+                  <Pin Id="RdEDYSaHix3OtCf2WYp9Rb" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="HpkBcN8n1dFORyD35MOzRU" Name="Result" Kind="OutputPin" />
+                </Node>
+                <ControlPoint Id="AQq2BCoPmfsQIJn1mlFtDQ" Bounds="714,205" />
+                <Node Bounds="604,293,308,315" Id="TkCPsMqUEuQO5herPOBvMe">
+                  <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="ProcessAppFlag" Name="ForEach" />
+                    <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
+                    <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                  </p:NodeReference>
+                  <Pin Id="Pilkv6bClCTN5wXjQXNMQs" Name="Messages" Kind="InputPin" />
+                  <Pin Id="IscXSlJDJJlQdOkUsrHUXe" Name="Reset" Kind="InputPin" />
+                  <Pin Id="NILKy5L3ApIMqoHUfFS7j5" Name="Result" Kind="OutputPin" />
+                  <Patch Id="HjyBdyugUrvMjKi6TGJ0WM" ManuallySortedPins="true">
+                    <ControlPoint Id="Cz1ITRumM85L2WmAYduuQU" Bounds="608,304" />
+                    <ControlPoint Id="LBTWyra5d1FMI9BhuzPMXL" Bounds="622,587" />
+                    <Patch Id="DSfltlbBe53LelfAgw5CNp" Name="Create" ManuallySortedPins="true" />
+                    <Patch Id="VpNm4k0uxVYOTcxHTIEF9h" Name="Update" ManuallySortedPins="true">
+                      <Pin Id="R6zyXkT8POfLDiRhkLm1yj" Name="Input 1" Kind="InputPin" />
+                      <Pin Id="R71KHyB3wwPQGrjiQE0uck" Name="Output" Kind="OutputPin">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                          <Choice Kind="TypeFlag" Name="Integer32" />
+                        </p:TypeAnnotation>
+                      </Pin>
+                    </Patch>
+                    <Node Bounds="712,316,74,26" Id="KOwTsDchcpONhtGCW1WEZ4">
+                      <p:NodeReference LastCategoryFullName="System.Windows.Forms.Form" LastDependency="System.Windows.Forms.dll">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <CategoryReference Kind="AssemblyCategory" Name="Form" NeedsToBeDirectParent="true" />
+                        <Choice Kind="OperationCallFlag" Name="WindowState" />
+                      </p:NodeReference>
+                      <Pin Id="LxbfpZVGjg2LtxWYPxz5nF" Name="Input" Kind="StateInputPin" />
+                      <Pin Id="TOhTyTbjqWUO2gpKE94reT" Name="Output" Kind="StateOutputPin" />
+                      <Pin Id="N95LGyU7mnZM6CInIhXDOW" Name="Window State" Kind="OutputPin" />
+                    </Node>
+                    <Node Bounds="781,397,25,19" Id="VVzC0ulLPHoO454Snl3Wmd">
+                      <p:NodeReference LastCategoryFullName="System.Windows.Forms.FormWindowState" LastDependency="System.Windows.Forms.dll">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <CategoryReference Kind="AssemblyCategory" Name="FormWindowState" />
+                        <Choice Kind="OperationCallFlag" Name="=" />
+                      </p:NodeReference>
+                      <Pin Id="QViVWAMKxprMdFATCHH3dG" Name="Input" Kind="InputPin" />
+                      <Pin Id="EtqGDqZaSPkNJHh0MNHYZQ" Name="Input 2" Kind="InputPin" />
+                      <Pin Id="FTkJztdf8gfMMxF88ecQV1" Name="Result" Kind="OutputPin" />
+                    </Node>
+                    <Pad Id="FDHXsXORsjkMb53z8Vm5N1" Comment="" Bounds="803,332,78,15" ShowValueBox="true" isIOBox="true" Value="Minimized">
+                      <p:TypeAnnotation LastCategoryFullName="System.Windows.Forms" LastDependency="System.Windows.Forms.dll">
+                        <Choice Kind="TypeFlag" Name="FormWindowState" />
+                      </p:TypeAnnotation>
+                    </Pad>
+                    <Node Bounds="702,443,185,145" Id="BzznFNeTAQDOy8dosDRgke">
+                      <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                        <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                        <CategoryReference Kind="Category" Name="Primitive" />
+                        <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                      </p:NodeReference>
+                      <Pin Id="SdYRbI2RZ9NQZbHPa28cWw" Name="Condition" Kind="InputPin" />
+                      <Patch Id="IFbFm2CrG2SQGlwtuOtFj8" ManuallySortedPins="true">
+                        <Patch Id="Rmr9DngADHqNg4UZGdziGf" Name="Create" ManuallySortedPins="true" />
+                        <Patch Id="KIRDvtnxQWqPjqSrCC5MFa" Name="Then" ManuallySortedPins="true" />
+                        <Node Bounds="714,466,43,26" Id="Ul7U30vbhq4PBdiVNEsj72">
+                          <p:NodeReference LastCategoryFullName="System.Windows.Forms.Control" LastDependency="System.Windows.Forms.dll">
+                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                            <CategoryReference Kind="AssemblyCategory" Name="Control" NeedsToBeDirectParent="true" />
+                            <Choice Kind="OperationCallFlag" Name="Hide" />
+                          </p:NodeReference>
+                          <Pin Id="M9Nwo68YkMSM4yDEvaP2v3" Name="Input" Kind="StateInputPin" />
+                          <Pin Id="UoMl9rszlhsPRHRKQhgktW" Name="Output" Kind="StateOutputPin" />
+                        </Node>
+                        <Pad Id="EOScIignTGHOeFTbHyyPzp" Comment="" Bounds="821,517,35,15" ShowValueBox="true" isIOBox="true" Value="True">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                            <Choice Kind="ImmutableTypeFlag" Name="Boolean" />
+                            <CategoryReference Kind="Category" Name="Primitive" />
+                          </p:TypeAnnotation>
+                          <p:ValueBoxSettings>
+                            <p:buttonmode p:Assembly="VL.UI.Forms" p:Type="VL.HDE.PatchEditor.Editors.ButtonModeEnum">Toggle</p:buttonmode>
+                          </p:ValueBoxSettings>
+                        </Pad>
+                        <Node Bounds="764,542,60,26" Id="NOWFWuJxB90Obn5dM5wVCb">
+                          <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastDependency="System.Windows.Forms.dll">
+                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                            <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" NeedsToBeDirectParent="true">
+                              <p:OuterCategoryReference Kind="AssemblyCategory" Name="Forms" NeedsToBeDirectParent="true" />
+                            </CategoryReference>
+                            <Choice Kind="OperationCallFlag" Name="SetVisible" />
+                          </p:NodeReference>
+                          <Pin Id="Q85L0kfzQ8lQcy0R1gCOE8" Name="Input" Kind="StateInputPin" />
+                          <Pin Id="OOCBWhDiJ6UMNgAt3J9yCV" Name="Value" Kind="InputPin" DefaultValue="True" />
+                          <Pin Id="BZUjDlmpUFELs2ytteN6iW" Name="Output" Kind="StateOutputPin" />
+                        </Node>
+                      </Patch>
+                    </Node>
+                  </Patch>
+                </Node>
+                <Node Bounds="171,224,68,26" Id="Hfdl21Ix7IZMMeBlgBFxNZ">
+                  <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastDependency="System.Windows.Forms.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" />
+                    <Choice Kind="OperationCallFlag" Name="MouseClick" />
+                  </p:NodeReference>
+                  <Pin Id="Elvr8ZqLbNVMEvGNexiwvf" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="SVN3lN6KRv2NXQQIrtWB6I" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="171,292,288,294" Id="Uskf5kVxUcqNILU7jT2PIR">
+                  <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="ProcessAppFlag" Name="ForEach" />
+                    <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
+                    <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                  </p:NodeReference>
+                  <Pin Id="RwnceLxxjMxPcMlofvGwzx" Name="Messages" Kind="InputPin" />
+                  <Pin Id="EDRgADZeyujMyBqgBp9Oqz" Name="Reset" Kind="InputPin" />
+                  <Pin Id="HbufhULcT5cMC1toFnJYHt" Name="Result" Kind="OutputPin" />
+                  <Patch Id="GBxFIC0xkoTPDywNxiBKEJ" ManuallySortedPins="true">
+                    <ControlPoint Id="RYHgxPQ7gJLN0vJC5a5v8F" Bounds="185,300" />
+                    <Patch Id="QdyaDsuqwf8LNrgg4jpCOc" Name="Create" ManuallySortedPins="true" />
+                    <Patch Id="CoFNwHtAXWuMeX40nPbfXm" Name="Update" ManuallySortedPins="true">
+                      <Pin Id="J8BjmqAY1WdQaUPzczivmL" Name="Input 1" Kind="InputPin" />
+                      <Pin Id="VebZ1dFxUY6NdiajFhzkfZ" Name="Output" Kind="OutputPin">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                          <Choice Kind="TypeFlag" Name="Integer32" />
+                        </p:TypeAnnotation>
+                      </Pin>
+                    </Patch>
+                    <Node Bounds="183,330,62,26" Id="NwOVaBnGzR2MF9WBlKqBuV">
+                      <p:NodeReference LastCategoryFullName="Reactive.EventPattern" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <CategoryReference Kind="ClassType" Name="EventPattern" />
+                        <Choice Kind="OperationCallFlag" Name="EventArgs" />
+                      </p:NodeReference>
+                      <Pin Id="LcbbtPOWh4rNuypNikrmZr" Name="Input" Kind="StateInputPin" />
+                      <Pin Id="VFbuPgWvkMlLeGYZ6CkKOD" Name="Event Args" Kind="OutputPin" />
+                    </Node>
+                    <Node Bounds="183,379,75,26" Id="BRAydFqP3GtMWYWf1jSJbf">
+                      <p:NodeReference LastCategoryFullName="System.Windows.Forms.MouseEventArgs" LastDependency="System.Windows.Forms.dll">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <CategoryReference Kind="AssemblyCategory" Name="MouseEventArgs" />
+                        <Choice Kind="OperationCallFlag" Name="Button" />
+                      </p:NodeReference>
+                      <Pin Id="KxG40PmKB14NXBoE90zKn8" Name="Input" Kind="StateInputPin" />
+                      <Pin Id="L0ut0hafDydNuj6qEmHNKb" Name="Output" Kind="StateOutputPin" />
+                      <Pin Id="M4r2YMUqSGgN9NjXLGPBtT" Name="Button" Kind="OutputPin" />
+                    </Node>
+                    <Node Bounds="253,431,25,19" Id="CUNOIjy5DNcMgBUuADesZK">
+                      <p:NodeReference LastCategoryFullName="System.Windows.Forms.MouseButtons" LastDependency="System.Windows.Forms.dll">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <CategoryReference Kind="AssemblyCategory" Name="MouseButtons" />
+                        <Choice Kind="OperationCallFlag" Name="=" />
+                      </p:NodeReference>
+                      <Pin Id="HepFSUaz7PsNlbWj7FA3gN" Name="Input" Kind="InputPin" />
+                      <Pin Id="FcXPO1tZaOMOeYqvovQVoa" Name="Input 2" Kind="InputPin" />
+                      <Pin Id="UKbnXyyByN8NQtNKWkc2aT" Name="Result" Kind="OutputPin" />
+                    </Node>
+                    <Pad Id="FcD2g88iFQqQAqsxJGN3f3" Comment="" Bounds="275,401,70,15" ShowValueBox="true" isIOBox="true" Value="Left">
+                      <p:TypeAnnotation LastCategoryFullName="System.Windows.Forms" LastDependency="System.Windows.Forms.dll">
+                        <Choice Kind="TypeFlag" Name="MouseButtons" />
+                      </p:TypeAnnotation>
+                    </Pad>
+                    <Node Bounds="252,489,195,72" Id="HcZ482U5SBCNezZVEXzwS9">
+                      <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                        <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                        <CategoryReference Kind="Category" Name="Primitive" />
+                        <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                      </p:NodeReference>
+                      <Pin Id="A61DlKk6x37MyyFHM5INOb" Name="Condition" Kind="InputPin" />
+                      <Patch Id="OytsjBWrkMsMPl7gULkAyb" ManuallySortedPins="true">
+                        <Patch Id="EWahsEAJb6aLH8qDIBakYp" Name="Create" ManuallySortedPins="true" />
+                        <Patch Id="FIWFBM5YiXdNEBxBIoQUFw" Name="Then" ManuallySortedPins="true" />
+                        <Node Bounds="359,522,76,19" Id="LqVs4lam4bVNuVbJ7eIOUS">
+                          <p:NodeReference LastCategoryFullName="Main.Editor.UI.NotifyIcon" LastDependency="GammaLauncher.vl">
+                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                            <Choice Kind="OperationCallFlag" Name="ShowWindow" />
+                          </p:NodeReference>
+                          <Pin Id="ITG9pMpmQWSL0jMHSeRRHB" Name="Form" Kind="InputPin" />
+                          <Pin Id="PFY5GtoCAnBMXc0g2Uf74N" Name="NotificationIcon" Kind="InputPin" />
+                        </Node>
+                      </Patch>
+                      <ControlPoint Id="ELRGSVtSOtCMSfjJP2Raad" Bounds="361,495" Alignment="Top" />
+                      <ControlPoint Id="PLnjTKxYi3iPkUfMwlkxAl" Bounds="266,555" Alignment="Bottom" />
+                    </Node>
+                    <ControlPoint Id="CE8rPjGI2emPwMTWrly1xM" Bounds="188,579" />
+                  </Patch>
+                </Node>
+                <Node Bounds="-167,89,60,26" Id="AtiLOcOJgLNMfjwb22tIwA">
+                  <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastDependency="System.Windows.Forms.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" NeedsToBeDirectParent="true">
+                      <p:OuterCategoryReference Kind="AssemblyCategory" Name="Forms" NeedsToBeDirectParent="true" />
+                    </CategoryReference>
+                    <Choice Kind="OperationCallFlag" Name="SetVisible" />
+                  </p:NodeReference>
+                  <Pin Id="TMtWD4hSFcnLQnFrduNl0k" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="Cof7J2NpoQ7McP68lEYsDO" Name="Value" Kind="InputPin" DefaultValue="True" />
+                  <Pin Id="Ch5rLHCbEvpPMaAgoTrtZ3" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Pad Id="QLhsnXdmoI7Ph8X5dJKeWz" Comment="" Bounds="-110,57,35,35" ShowValueBox="true" isIOBox="true" Value="False">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="ImmutableTypeFlag" Name="Boolean" />
+                    <CategoryReference Kind="Category" Name="Primitive" />
+                  </p:TypeAnnotation>
+                  <p:ValueBoxSettings>
+                    <p:buttonmode p:Assembly="VL.UI.Forms" p:Type="VL.HDE.PatchEditor.Editors.ButtonModeEnum">Toggle</p:buttonmode>
+                  </p:ValueBoxSettings>
+                </Pad>
+                <Node Bounds="-168,139,58,26" Id="T4V0wPTrunsMyZDuw3i0O3">
+                  <p:NodeReference LastCategoryFullName="Primitive.IDisposable" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="Dispose" />
+                    <CategoryReference Kind="MutableInterfaceType" Name="IDisposable" NeedsToBeDirectParent="true" />
+                  </p:NodeReference>
+                  <Pin Id="RZuknA7deyuP7mrzK6NEah" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="IF2bT6ptAIvPwGdC0GVFTC" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Node Bounds="188,-273,35,26" Id="M9RuC49NbYgQP4uo0HEkN5">
+                  <p:NodeReference LastCategoryFullName="System.Windows.Forms.Form" LastDependency="System.Windows.Forms.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="Form" />
+                    <Choice Kind="OperationCallFlag" Name="Icon" />
+                  </p:NodeReference>
+                  <Pin Id="QwTlwVeD6PXPSSYFe3nF0F" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="ONVeXlVrlCiNCUxAEiIljv" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="PyDO6n0CqonMJEpyG3GCRh" Name="Icon" Kind="OutputPin" />
+                </Node>
+                <ControlPoint Id="A71w2CVr3ZmN8fjV6ZZD3P" Bounds="190,-295" />
+                <ControlPoint Id="MNhRX7eboDINspNUtgHPNh" Bounds="361,256" />
+                <Pad Id="CWNyuxbS79SLzB9P0gWbMX" SlotId="OE2MJsQELrQQY9Dli1mX5w" Bounds="-166,58" />
+                <ControlPoint Id="QqcExocLOaeMBj93epi5xE" Bounds="765,86" />
+                <Pad Id="TupUx0rCcWfOtrscXJvNbi" Comment="" Bounds="227,-192,83,15" ShowValueBox="true" isIOBox="true" Value="GammaLauncher">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="String" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Node Bounds="170,-129,112,26" Id="C75GgDNbf2ZQRhCdkbpPQy">
+                  <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastDependency="System.Windows.Forms.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" NeedsToBeDirectParent="true">
+                      <p:OuterCategoryReference Kind="AssemblyCategory" Name="Forms" NeedsToBeDirectParent="true" />
+                    </CategoryReference>
+                    <Choice Kind="OperationCallFlag" Name="SetContextMenuStrip" />
+                  </p:NodeReference>
+                  <Pin Id="R6CrEFFmNZKLAXOB4tDhG1" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="G91JUVH3aeHQLmmCZzOq2l" Name="Value" Kind="InputPin" DefaultValue="False" />
+                  <Pin Id="NESwfuqhsMSMoumnDQIhr0" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Node Bounds="1028,-155,77,19" Id="L6cS4ylX99yQcj0ak7eawE">
+                  <p:NodeReference LastCategoryFullName="Main.Editor.UI" LastDependency="GammaLauncher.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="ProcessAppFlag" Name="ContextMenu" />
+                  </p:NodeReference>
+                  <Pin Id="LKAiMm4AWZbLH1I1zhPR0f" Name="Update" Kind="InputPin" />
+                  <Pin Id="AhGvgn6bEcHN50N44b2wuW" Name="Output" Kind="OutputPin" />
+                  <Pin Id="EmW6DXW33YQLZ8QMNtD4o1" Name="Show" Kind="OutputPin" />
+                  <Pin Id="R2LgSumi5qrLawWetnLbno" Name="Quit" Kind="OutputPin" />
+                </Node>
+                <!--
+
+    ************************ ShowWindow (Internal) ************************
+
+-->
+                <Node Name="ShowWindow (Internal)" Bounds="-342,292,292,338" Id="AWRucj3ti2BPOuYbSX6VkT">
+                  <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                    <Choice Kind="OperationDefinition" Name="Operation" />
+                  </p:NodeReference>
+                  <Patch Id="L2DN2HYIhmtNL2NZE1nUbT">
+                    <Node Bounds="-319,347,91,78" Id="B2SQJu7fXHJLG8eB3z1B45">
+                      <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                        <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                        <CategoryReference Kind="Category" Name="Primitive" />
+                        <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                      </p:NodeReference>
+                      <Pin Id="CQ2QgynAIUaMMhdHshTcJj" Name="Condition" Kind="InputPin" DefaultValue="True" />
+                      <Patch Id="QT4ha4xpHN3LoyAWpaYQir" ManuallySortedPins="true">
+                        <Node Bounds="-307,379,43,26" Id="OM2ey5eOZAMLQWqO15jMZV">
+                          <p:NodeReference LastCategoryFullName="System.Windows.Forms.Control" LastDependency="System.Windows.Forms.dll">
+                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                            <CategoryReference Kind="AssemblyCategory" Name="Control" NeedsToBeDirectParent="true" />
+                            <Choice Kind="OperationCallFlag" Name="Show" />
+                          </p:NodeReference>
+                          <Pin Id="Me30iJopL8DOwTb4jfDNKk" Name="Input" Kind="StateInputPin" />
+                          <Pin Id="SBbhZID3U0qLSjeoJ225U1" Name="Output" Kind="StateOutputPin" />
+                        </Node>
+                        <Patch Id="KVNVjTGwSuUP4zAvjTrS13" Name="Create" ManuallySortedPins="true" />
+                        <Patch Id="O2hpSmLy5EFLHOfMqwCTL5" Name="Then" />
+                      </Patch>
+                      <ControlPoint Id="IBVCxE2ACIwMwIdXDJC6U4" Bounds="-245,353" Alignment="Top" />
+                      <ControlPoint Id="QO5ilTskY7XLB0ufCAyriT" Bounds="-246,419" Alignment="Bottom" />
+                    </Node>
+                    <Node Bounds="-248,451,88,26" Id="H4GjBtAE9R7OBa3L801lrN">
+                      <p:NodeReference LastCategoryFullName="System.Windows.Forms.Form" LastDependency="System.Windows.Forms.dll">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <CategoryReference Kind="AssemblyCategory" Name="Form" NeedsToBeDirectParent="true" />
+                        <Choice Kind="OperationCallFlag" Name="SetWindowState" />
+                      </p:NodeReference>
+                      <Pin Id="S9pMLmaB6DKMStCmxBMLkx" Name="Input" Kind="StateInputPin" />
+                      <Pin Id="Eb9JRZEvZzeQYboBVbsQoQ" Name="Value" Kind="InputPin" />
+                      <Pin Id="KTOfH9pLkgeOjClYObS91f" Name="Output" Kind="StateOutputPin" />
+                    </Node>
+                    <Pad Id="UlRYooykYHzNBvUzE1Yev4" Comment="" Bounds="-163,443,78,15" ShowValueBox="true" isIOBox="true" Value="Normal">
+                      <p:TypeAnnotation LastCategoryFullName="System.Windows.Forms" LastDependency="System.Windows.Forms.dll">
+                        <Choice Kind="TypeFlag" Name="FormWindowState" />
+                      </p:TypeAnnotation>
+                    </Pad>
+                    <Node Bounds="-248,498,53,26" Id="OeGY5uGLgmLMdBFDpaXn0s">
+                      <p:NodeReference LastCategoryFullName="System.Windows.Forms.Form" LastDependency="System.Windows.Forms.dll">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <CategoryReference Kind="AssemblyCategory" Name="Form" />
+                        <Choice Kind="OperationCallFlag" Name="Activate" />
+                      </p:NodeReference>
+                      <Pin Id="I4U508c9XU5LMqnX3oQin1" Name="Input" Kind="StateInputPin" />
+                      <Pin Id="E0o5sa1d8n6Pn523ZIGrL5" Name="Output" Kind="StateOutputPin" />
+                    </Node>
+                    <Node Bounds="-173,584,60,26" Id="JBxpJnyKdAdOVy2woHbgBt">
+                      <p:NodeReference LastCategoryFullName="System.Windows.Forms.NotifyIcon" LastDependency="System.Windows.Forms.dll">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <CategoryReference Kind="AssemblyCategory" Name="NotifyIcon" NeedsToBeDirectParent="true">
+                          <p:OuterCategoryReference Kind="AssemblyCategory" Name="Forms" NeedsToBeDirectParent="true" />
+                        </CategoryReference>
+                        <Choice Kind="OperationCallFlag" Name="SetVisible" />
+                      </p:NodeReference>
+                      <Pin Id="KZLWwAJuaLYOuOP46pvC12" Name="Input" Kind="StateInputPin" />
+                      <Pin Id="Uxd2iHDoL76NHQYMes5muG" Name="Value" Kind="InputPin" DefaultValue="True" />
+                      <Pin Id="ToYCrNCgqN3MD4azwFUkcQ" Name="Output" Kind="StateOutputPin" />
+                    </Node>
+                    <Pad Id="BWITJFj97D0MFAZ2eUhTqy" Comment="" Bounds="-116,543,35,15" ShowValueBox="true" isIOBox="true" Value="False">
+                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="ImmutableTypeFlag" Name="Boolean" />
+                        <CategoryReference Kind="Category" Name="Primitive" />
+                      </p:TypeAnnotation>
+                      <p:ValueBoxSettings>
+                        <p:buttonmode p:Assembly="VL.UI.Forms" p:Type="VL.HDE.PatchEditor.Editors.ButtonModeEnum">Toggle</p:buttonmode>
+                      </p:ValueBoxSettings>
+                    </Pad>
+                    <Link Id="RNHQSZcSvtUQS8mHW6fNxw" Ids="UlRYooykYHzNBvUzE1Yev4,Eb9JRZEvZzeQYboBVbsQoQ" />
+                    <Link Id="GdyX2n84OMMQFoidWRZMCF" Ids="KTOfH9pLkgeOjClYObS91f,I4U508c9XU5LMqnX3oQin1" />
+                    <Link Id="NAx68JwLWWRNyGFCJ7uE4F" Ids="BWITJFj97D0MFAZ2eUhTqy,Uxd2iHDoL76NHQYMes5muG" />
+                    <Link Id="CIwT6JXMg9TLFc3wjhDjTZ" Ids="IBVCxE2ACIwMwIdXDJC6U4,QO5ilTskY7XLB0ufCAyriT" IsFeedback="true" />
+                    <Link Id="GBszoENnp1yLhRuguDr0Pi" Ids="IBVCxE2ACIwMwIdXDJC6U4,Me30iJopL8DOwTb4jfDNKk" />
+                    <Link Id="QsNjNfKn9tjLEECukY0frq" Ids="Hu08V5eYUf8Nuq5udXwB35,IBVCxE2ACIwMwIdXDJC6U4" />
+                    <ControlPoint Id="Hu08V5eYUf8Nuq5udXwB35" Bounds="-245,310" />
+                    <Pin Id="VdvrUYsyFrhNpVVnAMVjmU" Name="Form" Kind="InputPin" Bounds="-210,287" />
+                    <Link Id="VV915K05cDgOmGuNPDZj0I" Ids="VdvrUYsyFrhNpVVnAMVjmU,Hu08V5eYUf8Nuq5udXwB35" IsHidden="true" />
+                    <Link Id="BpzcKPv3vHCPcC3LXgG9fu" Ids="IBVCxE2ACIwMwIdXDJC6U4,QO5ilTskY7XLB0ufCAyriT" />
+                    <Link Id="MGdl8nnkGZ1MqGMiQuPh5e" Ids="QO5ilTskY7XLB0ufCAyriT,S9pMLmaB6DKMStCmxBMLkx" />
+                    <ControlPoint Id="BiIxOBDhy7pLocihAbKcy6" Bounds="-171,508" />
+                    <Link Id="B9GmHmnWVuKNkqkCenzLH8" Ids="BiIxOBDhy7pLocihAbKcy6,KZLWwAJuaLYOuOP46pvC12" />
+                    <Pin Id="DvSInqAvFZaMsEnI9E5Sfl" Name="NotificationIcon" Kind="InputPin" Bounds="-90,336" />
+                    <Link Id="TwQVJsn9XRDQaGJOrPan6c" Ids="DvSInqAvFZaMsEnI9E5Sfl,BiIxOBDhy7pLocihAbKcy6" IsHidden="true" />
+                  </Patch>
+                </Node>
+                <ControlPoint Id="SKcPh0vr1fVMjV5VNAX50Q" Bounds="433,54" />
+                <Node Bounds="1067,281,118,132" Id="JiDbvWRkTfEPq0mJYqVv3C">
+                  <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="ProcessAppFlag" Name="ForEach" />
+                    <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
+                    <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                  </p:NodeReference>
+                  <Pin Id="EGCzPmX2L5LQPlVryf7JMj" Name="Messages" Kind="InputPin" />
+                  <Pin Id="VZWlSkViqkmLsO4Z44rD4O" Name="Reset" Kind="InputPin" />
+                  <Pin Id="TYzah1WwQ72Pi4JUHTS1Fn" Name="Result" Kind="OutputPin" />
+                  <Patch Id="JaAdLGdCY0TN37GZzMD1kW" ManuallySortedPins="true">
+                    <ControlPoint Id="IEYpZAIk0eaNY2VcD5Vqn5" Bounds="1071,289" />
+                    <ControlPoint Id="P5NBHx4yFIuQZ6zSqeL2Mv" Bounds="1085,406" />
+                    <Patch Id="PrXTEHBrbWpM3ghMWBhQnN" Name="Create" ManuallySortedPins="true" />
+                    <Patch Id="RCtT946xadANo91lxbxT29" Name="Update" ManuallySortedPins="true">
+                      <Pin Id="Bv0kbQ5zoxMQbiefD0hDm6" Name="Input 1" Kind="InputPin" />
+                      <Pin Id="Ijv5jPEETnLLiqzk0B8yzU" Name="Output" Kind="OutputPin">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                          <Choice Kind="TypeFlag" Name="Integer32" />
+                        </p:TypeAnnotation>
+                      </Pin>
+                    </Patch>
+                    <Node Bounds="1097,338,76,19" Id="V6Mt6LArgOePdzICMbTX4N">
+                      <p:NodeReference LastCategoryFullName="Main.Editor.UI.NotifyIcon" LastDependency="GammaLauncher.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <Choice Kind="OperationCallFlag" Name="ShowWindow" />
+                      </p:NodeReference>
+                      <Pin Id="MADOSabgYQYQDW5gJKTxht" Name="Form" Kind="InputPin" />
+                      <Pin Id="JaH9aq3vWyYPDkyob0OrrJ" Name="NotificationIcon" Kind="InputPin" />
+                    </Node>
+                  </Patch>
+                </Node>
+                <ControlPoint Id="NCOmkF7KDB3MzK14xNsvaG" Bounds="1100,208" />
+                <ControlPoint Id="ODauPDV5W1wQSlZqvQR9kd" Bounds="1172,126" />
+                <Node Bounds="1265,277,74,138" Id="R3ao1vmULIKMlfaqsgvr7X">
+                  <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="ProcessAppFlag" Name="ForEach" />
+                    <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
+                    <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                  </p:NodeReference>
+                  <Pin Id="QrQJgQc2ug6LxVug3hKsrW" Name="Messages" Kind="InputPin" />
+                  <Pin Id="UyJnSCbkKPyQPOTbEAmZ81" Name="Reset" Kind="InputPin" />
+                  <Pin Id="MxWlKq1BLx8MZKK9c8WRMp" Name="Result" Kind="OutputPin" />
+                  <Patch Id="PUimhiwGJFlNSoVRiZMRe1" ManuallySortedPins="true">
+                    <ControlPoint Id="GtnEpYQvn9dMlyJc34mEkp" Bounds="1269,287" />
+                    <ControlPoint Id="LOTaSX5FTDyL4z5AoXwNsm" Bounds="1284,408" />
+                    <Patch Id="OQuN28Knc5jNnBJVypgYtW" Name="Create" ManuallySortedPins="true" />
+                    <Patch Id="MJhPojWqH1gMN9s6q0Yda3" Name="Update" ManuallySortedPins="true">
+                      <Pin Id="CUpkYLBUunSLwbzcFfDVpP" Name="Input 1" Kind="InputPin" />
+                      <Pin Id="VSh52v42UYxPtANlm91Gbu" Name="Output" Kind="OutputPin">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                          <Choice Kind="TypeFlag" Name="Integer32" />
+                        </p:TypeAnnotation>
+                      </Pin>
+                    </Patch>
+                    <Node Bounds="1293,300,31,19" Id="B7x95h9wMpzQVUsVv3MhLB">
+                      <p:NodeReference LastCategoryFullName="System.Application" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <CategoryReference Kind="Category" Name="Application" />
+                        <Choice Kind="ProcessAppFlag" Name="PID" />
+                      </p:NodeReference>
+                      <Pin Id="CtB9zmXuFPOL8m5c1Kxap4" Name="Id" Kind="OutputPin" />
+                    </Node>
+                    <Node Bounds="1293,363,31,19" Id="KpSEuGDMp2BNsrApkkjIdd">
+                      <p:NodeReference LastCategoryFullName="System" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <Choice Kind="OperationCallFlag" Name="Kill" />
+                      </p:NodeReference>
+                      <Pin Id="Gb3h2IxBXHxLi1NceLUE99" Name="Process Id" Kind="InputPin" />
+                      <Pin Id="FM3uiRJxf7ZPofPoyxYnrv" Name="Execute" Kind="InputPin" DefaultValue="True" />
+                    </Node>
+                  </Patch>
+                </Node>
+                <Node Bounds="1372,335,65,19" Id="TKTMfoKxMyjPvF2cjEs3f9">
+                  <p:NodeReference LastCategoryFullName="System.Application" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="IsExported" />
+                  </p:NodeReference>
+                  <Pin Id="FSVGaGyZd8sNzMqlWjKM0I" Name="Is Exported" Kind="OutputPin" />
+                </Node>
+                <ControlPoint Id="O3PSYDiQUbvOpn00qvu6E2" Bounds="1266,-43" />
+              </Canvas>
+              <ProcessDefinition Id="HXr9hcMT06CLDX4WqwHVJX">
+                <Fragment Id="TgG0gZMbJ3GNX3PqEJRn08" Patch="KJiBd7mIoI4QDhuF8HxLy6" Enabled="true" />
+                <Fragment Id="L8JA4pTmW6CLcwpBTrn6js" Patch="PTGInIM7cNPQDOK2kDDoR9" Enabled="true" />
+                <Fragment Id="DCAgxCUjCptME6oi3iZnIn" Patch="AWRucj3ti2BPOuYbSX6VkT" />
+              </ProcessDefinition>
+              <Slot Id="OE2MJsQELrQQY9Dli1mX5w" Name="NotifyIcon" />
+              <Link Id="P1lranIdtgaLZWKgw3y3Fb" Ids="UBUCd29xlMJM25ovKFLYuN,AJ8iRcXx4X1McMBLjBnssA" />
+              <Link Id="VZ4ONbprHZBOqtxYV3cZ7x" Ids="NNBGBwmjZy9QdjbXIt8wo9,NEN8zGVBnaRPSSBzwGo8R1" />
+              <Link Id="GJq86XfKB95LUBEJO4Qid3" Ids="GYnyN4cHAGIQcHV9cEBwY5,HfgD7xb2mnZMmybapFXfac" />
+              <Link Id="SmahoLqB3kBNrkV1FBrFXx" Ids="Htaher9IojCOmLgHklQABo,CyoRy258HReMdNDKE9w2ek" />
+              <Patch Id="KJiBd7mIoI4QDhuF8HxLy6" Name="Create" ParticipatingElements="FjhqDU9Yaz8LVckNdL4jKb">
+                <Pin Id="Jb2tIXBW9aELXWvKoVs8sM" Name="Form" Kind="InputPin" />
+              </Patch>
+              <Patch Id="PTGInIM7cNPQDOK2kDDoR9" Name="Update" ParticipatingElements="VujyYSbh4EAOgpFZT5FG7a" />
+              <Link Id="PbIAAqZqgofMKFGdpUJLT7" Ids="R6zyXkT8POfLDiRhkLm1yj,Cz1ITRumM85L2WmAYduuQU" IsHidden="true" />
+              <Link Id="CQztqhvjkMaPgYdmjlvOSl" Ids="LBTWyra5d1FMI9BhuzPMXL,R71KHyB3wwPQGrjiQE0uck" IsHidden="true" />
+              <Link Id="GgsUReF7DJdLlFuqJam6Ax" Ids="HpkBcN8n1dFORyD35MOzRU,Pilkv6bClCTN5wXjQXNMQs" />
+              <Link Id="NurYhe9cyY8QbHzPagCs0z" Ids="AQq2BCoPmfsQIJn1mlFtDQ,LxbfpZVGjg2LtxWYPxz5nF" />
+              <Link Id="OvU9ZQJKS98M7ZCIchBEPF" Ids="N95LGyU7mnZM6CInIhXDOW,QViVWAMKxprMdFATCHH3dG" />
+              <Link Id="FzK5OiITn5yLXuGJm7vmsj" Ids="FDHXsXORsjkMb53z8Vm5N1,EtqGDqZaSPkNJHh0MNHYZQ" />
+              <Link Id="JA4ZkIAHkanN0eQ7spQCrM" Ids="FTkJztdf8gfMMxF88ecQV1,SdYRbI2RZ9NQZbHPa28cWw" />
+              <Link Id="OoqxJ11Vq5DP96wNPA5XHG" Ids="TOhTyTbjqWUO2gpKE94reT,M9Nwo68YkMSM4yDEvaP2v3" />
+              <Link Id="A5GLZKnp9XVNVDYoGplyWG" Ids="EOScIignTGHOeFTbHyyPzp,OOCBWhDiJ6UMNgAt3J9yCV" />
+              <Link Id="O9iMvSMHRUcM8iZlxGAXqq" Ids="J8BjmqAY1WdQaUPzczivmL,RYHgxPQ7gJLN0vJC5a5v8F" IsHidden="true" />
+              <Link Id="DeIiIWTTWlmLr5Ql3QK3l9" Ids="QLhsnXdmoI7Ph8X5dJKeWz,Cof7J2NpoQ7McP68lEYsDO" />
+              <Patch Id="McXLM5odShNNwELf5DHEgk" Name="Dispose" ParticipatingElements="AtiLOcOJgLNMfjwb22tIwA,T4V0wPTrunsMyZDuw3i0O3,DeIiIWTTWlmLr5Ql3QK3l9,J8N0tSqAt9mOwrPoEwkK6Q,BBmu81TtawZOmVi2w8yu5O" />
+              <Link Id="J8N0tSqAt9mOwrPoEwkK6Q" Ids="Ch5rLHCbEvpPMaAgoTrtZ3,RZuknA7deyuP7mrzK6NEah" />
+              <Link Id="R6ef2VESxKPOx9xMwOroOm" Ids="Jb2tIXBW9aELXWvKoVs8sM,AQq2BCoPmfsQIJn1mlFtDQ" IsHidden="true" />
+              <Link Id="TmufOEMZP8TOAFiahGBHso" Ids="Jb2tIXBW9aELXWvKoVs8sM,A71w2CVr3ZmN8fjV6ZZD3P" IsHidden="true" />
+              <Link Id="HgG1vUKQz8XLcUnPPAL55b" Ids="A71w2CVr3ZmN8fjV6ZZD3P,QwTlwVeD6PXPSSYFe3nF0F" />
+              <Link Id="GLkmuNlodkyPw5JTomel3O" Ids="Jb2tIXBW9aELXWvKoVs8sM,MNhRX7eboDINspNUtgHPNh" IsHidden="true" />
+              <Link Id="BBmu81TtawZOmVi2w8yu5O" Ids="CWNyuxbS79SLzB9P0gWbMX,TMtWD4hSFcnLQnFrduNl0k" />
+              <Link Id="VMbsuLCSCCZMU569vveuFE" Ids="AQq2BCoPmfsQIJn1mlFtDQ,RdEDYSaHix3OtCf2WYp9Rb" />
+              <Link Id="FjhqDU9Yaz8LVckNdL4jKb" Ids="HfgD7xb2mnZMmybapFXfac,Elvr8ZqLbNVMEvGNexiwvf" />
+              <Link Id="E07UydektIBN2IKZEYKwoH" Ids="RYHgxPQ7gJLN0vJC5a5v8F,LcbbtPOWh4rNuypNikrmZr" />
+              <Link Id="UbrlgcBAlK7MSeImdaZmWQ" Ids="VFbuPgWvkMlLeGYZ6CkKOD,KxG40PmKB14NXBoE90zKn8" />
+              <Link Id="QcIAP1a0ERAL5RjbPF62kD" Ids="M4r2YMUqSGgN9NjXLGPBtT,HepFSUaz7PsNlbWj7FA3gN" />
+              <Link Id="CMwb60oqyonMMXV986iCCg" Ids="FcD2g88iFQqQAqsxJGN3f3,FcXPO1tZaOMOeYqvovQVoa" />
+              <Link Id="RrrwKO5HljnOgasMg7AQmj" Ids="UKbnXyyByN8NQtNKWkc2aT,A61DlKk6x37MyyFHM5INOb" />
+              <Link Id="R06BZ9WDuZbQd0Z8LvFmph" Ids="ELRGSVtSOtCMSfjJP2Raad,PLnjTKxYi3iPkUfMwlkxAl" IsFeedback="true" />
+              <Link Id="A989LeRS6ijNyyy7JoOMeP" Ids="MNhRX7eboDINspNUtgHPNh,ELRGSVtSOtCMSfjJP2Raad" />
+              <Link Id="OX5PgS8qeIyN3Hje2eoXS0" Ids="CE8rPjGI2emPwMTWrly1xM,VebZ1dFxUY6NdiajFhzkfZ" IsHidden="true" />
+              <Link Id="C2SQ7rjVQEqP1iPHfm0IOi" Ids="HfgD7xb2mnZMmybapFXfac,QqcExocLOaeMBj93epi5xE,Q85L0kfzQ8lQcy0R1gCOE8" />
+              <Link Id="P1PLYefJgWQQGJvt5xTUTm" Ids="SVN3lN6KRv2NXQQIrtWB6I,RwnceLxxjMxPcMlofvGwzx" />
+              <Link Id="MOUenCnFhg9ORsPwRNzd83" Ids="PyDO6n0CqonMJEpyG3GCRh,KWGvAvQ4uPGPunsgfZ63jP" />
+              <Link Id="MDLbfi4tQ9rOeR1hcDHnPD" Ids="TupUx0rCcWfOtrscXJvNbi,AWMAzkTgeWGMij2dsUHPwI" />
+              <Link Id="EP2y1fTeaqbP4OFsexqJFG" Ids="IPttcxlBlMoPSNe6crb07m,R6CrEFFmNZKLAXOB4tDhG1" />
+              <Link Id="Avx8NgBicGoOv3eVvZMTDJ" Ids="NESwfuqhsMSMoumnDQIhr0,M6Nf6KyaMQtM86mzYZQCsz" />
+              <Link Id="Ik7coiKL4u2OfBuy94MLH4" Ids="AhGvgn6bEcHN50N44b2wuW,G91JUVH3aeHQLmmCZzOq2l" />
+              <Link Id="Gu60XISh3GnLTrGHF7UEcv" Ids="ELRGSVtSOtCMSfjJP2Raad,ITG9pMpmQWSL0jMHSeRRHB" />
+              <Link Id="AW8ft4F3oV4NvzIRzRdupQ" Ids="HfgD7xb2mnZMmybapFXfac,SKcPh0vr1fVMjV5VNAX50Q,PFY5GtoCAnBMXc0g2Uf74N" />
+              <Link Id="ORFd5lP7HxRNGwauo7ksSZ" Ids="Bv0kbQ5zoxMQbiefD0hDm6,IEYpZAIk0eaNY2VcD5Vqn5" IsHidden="true" />
+              <Link Id="By3weqDs8BFP6jxHllOLUF" Ids="P5NBHx4yFIuQZ6zSqeL2Mv,Ijv5jPEETnLLiqzk0B8yzU" IsHidden="true" />
+              <Link Id="BSIVjwBUL7kL0yjJaIJ8Jp" Ids="EmW6DXW33YQLZ8QMNtD4o1,EGCzPmX2L5LQPlVryf7JMj" />
+              <Link Id="V2TA7mxE3CDO6BXKfxgOMb" Ids="Jb2tIXBW9aELXWvKoVs8sM,NCOmkF7KDB3MzK14xNsvaG" IsHidden="true" />
+              <Link Id="Kg04hbXzXyUN5Kt6gBWvLL" Ids="NCOmkF7KDB3MzK14xNsvaG,MADOSabgYQYQDW5gJKTxht" />
+              <Link Id="Qd5Xn1FADJfPamsaZytH90" Ids="HfgD7xb2mnZMmybapFXfac,ODauPDV5W1wQSlZqvQR9kd,JaH9aq3vWyYPDkyob0OrrJ" />
+              <Link Id="PykzeGIYeDVLlUPG6c8CXE" Ids="CUpkYLBUunSLwbzcFfDVpP,GtnEpYQvn9dMlyJc34mEkp" IsHidden="true" />
+              <Link Id="NXoMPkJd5B8NtpmPREYHvH" Ids="LOTaSX5FTDyL4z5AoXwNsm,VSh52v42UYxPtANlm91Gbu" IsHidden="true" />
+              <Link Id="F68V3UFjM2ELTaL7jb2knm" Ids="CtB9zmXuFPOL8m5c1Kxap4,Gb3h2IxBXHxLi1NceLUE99" />
+              <Link Id="VmbBSWeBv3iQUg8tUaLXA2" Ids="R2LgSumi5qrLawWetnLbno,O3PSYDiQUbvOpn00qvu6E2,QrQJgQc2ug6LxVug3hKsrW" />
+              <Link Id="LozGxIhIgTjQcuasVjqDcK" Ids="FSVGaGyZd8sNzMqlWjKM0I,FM3uiRJxf7ZPofPoyxYnrv" />
+            </Patch>
+          </Node>
+          <!--
+
+    ************************ ContextMenu ************************
+
+-->
+          <Node Name="ContextMenu" Bounds="135,281" Id="L0YZabEg9KKLmumeZdF8We">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+              <Choice Kind="ContainerDefinition" Name="Process" />
+            </p:NodeReference>
+            <Patch Id="KYzsnTiAFsGLvfI1KXr9GX">
+              <Canvas Id="NQYa602OOt4MFTVUvGWmWO" CanvasType="Group">
+                <Node Bounds="201,-122,81,26" Id="N1O4Q6YDpasNLxpqlrM19X">
+                  <p:NodeReference LastCategoryFullName="System.Windows.Forms.ContextMenuStrip" LastDependency="System.Windows.Forms.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="ContextMenuStrip" />
+                    <Choice Kind="OperationCallFlag" Name="Create" />
+                  </p:NodeReference>
+                  <Pin Id="PpDXIguSZEbLmtaZEAy6ue" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Pad Id="SHC7bcGXtp6NV4PMKony5W" SlotId="Eex5kssGbqaLeL8WwskRXh" Bounds="202,-30" />
+                <ControlPoint Id="Rmo3RQT1lzNQEPRSxEPHeE" Bounds="202,80" />
+                <Node Bounds="296,94,49,26" Id="R4ffzpFB0U2MEqgY2ManAE">
+                  <p:NodeReference LastCategoryFullName="System.Windows.Forms.ToolStrip" LastDependency="System.Windows.Forms.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="ToolStrip" NeedsToBeDirectParent="true" />
+                    <Choice Kind="OperationCallFlag" Name="Items" />
+                  </p:NodeReference>
+                  <Pin Id="UXfMteFfiQLPVHmEpXUkxL" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="Lnafx5T1eK9L4KvfIggsSv" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="GRFuvpruDzEPIo88j0LRUG" Name="Items" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="340,185,100,26" Id="KagA3FSP0LGOg7HP3miikb">
+                  <p:NodeReference LastCategoryFullName="System.Windows.Forms.ToolStripItemCollection" LastDependency="System.Windows.Forms.dll" OverloadStrategy="AllPinsThatAreNotCommon">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="ToolStripItemCollection" />
+                    <Choice Kind="OperationCallFlag" Name="Add" />
+                    <PinReference Kind="InputPin" Name="Text" />
+                    <PinReference Kind="OutputPin" Name="Result">
+                      <p:DataTypeReference p:Type="TypeReference" LastCategoryFullName="System.Windows.Forms" LastDependency="System.Windows.Forms.dll">
+                        <Choice Kind="TypeFlag" Name="ToolStripItem" />
+                      </p:DataTypeReference>
+                    </PinReference>
+                  </p:NodeReference>
+                  <Pin Id="S7Qo4vicHLiOQE5uFI2KcJ" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="N8wn7oUH4AfOru8aubavDb" Name="Text" Kind="InputPin" />
+                  <Pin Id="DxyPiYrJW33Pog8oDZdJyB" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="SxBkG8HngroO1XyQ1D42Zy" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Pad Id="Qk9ys8I1tVrOolVfZADFZe" Comment="" Bounds="437,115,35,15" ShowValueBox="true" isIOBox="true" Value="Show">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="String" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Node Bounds="340,360,100,26" Id="U1zksFooEGfM3iDBGFcoo2">
+                  <p:NodeReference LastCategoryFullName="System.Windows.Forms.ToolStripItemCollection" LastDependency="System.Windows.Forms.dll" OverloadStrategy="AllPinsThatAreNotCommon">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="ToolStripItemCollection" />
+                    <Choice Kind="OperationCallFlag" Name="Add" />
+                    <PinReference Kind="InputPin" Name="Text" />
+                    <PinReference Kind="OutputPin" Name="Result">
+                      <p:DataTypeReference p:Type="TypeReference" LastCategoryFullName="System.Windows.Forms" LastDependency="System.Windows.Forms.dll">
+                        <Choice Kind="TypeFlag" Name="ToolStripItem" />
+                      </p:DataTypeReference>
+                    </PinReference>
+                  </p:NodeReference>
+                  <Pin Id="LXIC1zp8704OwRJE4DxH9k" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="HJb0W7SOoLrMlQPwVtkEvR" Name="Text" Kind="InputPin" />
+                  <Pin Id="VBnqjk9PqQtPb9vhB6WJQe" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="Ri6lUo6yguNPWy1QzXZYhl" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Pad Id="VJyV180Xs47MPC0GrXeZ3W" Comment="" Bounds="437,338,35,15" ShowValueBox="true" isIOBox="true" Value="Quit">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="String" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Node Bounds="435,407,64,26" Id="Lw9Ozed4SQSN4EVMTFkc3Z">
+                  <p:NodeReference LastCategoryFullName="System.Windows.Forms.ToolStripItem" LastDependency="System.Windows.Forms.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="ToolStripItem" />
+                    <Choice Kind="OperationCallFlag" Name="Click" />
+                  </p:NodeReference>
+                  <Pin Id="RKu4qPz4x3kOhV6LMrR5Y8" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="HSUjws3fzMWN2aeWd1JlFr" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="435,230,64,26" Id="KQs05VL1zP4NeMWeBHP2Un">
+                  <p:NodeReference LastCategoryFullName="System.Windows.Forms.ToolStripItem" LastDependency="System.Windows.Forms.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="ToolStripItem" />
+                    <Choice Kind="OperationCallFlag" Name="Click" />
+                  </p:NodeReference>
+                  <Pin Id="JksR1FK5dsvNkenrft1mmU" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="So8rhqj1PxmPlx2sJYE2BT" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="80,57,58,26" Id="JkVFAMnRoThLaRbgmPMatS">
+                  <p:NodeReference LastCategoryFullName="Primitive.IDisposable" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="MutableInterfaceType" Name="IDisposable" NeedsToBeDirectParent="true" />
+                    <Choice Kind="OperationCallFlag" Name="Dispose" />
+                  </p:NodeReference>
+                  <Pin Id="CarFzfGINOuNuzLpIRbX9r" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="FnXz0uzh1OoMqoAowZq3pI" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <ControlPoint Id="F369c8q23SdMzJGTjUQFLC" Bounds="437,285" />
+                <ControlPoint Id="UrWtEWiMMTAOauzc9qS0IP" Bounds="437,474" />
+              </Canvas>
+              <ProcessDefinition Id="OxfYkDGNdmDPbQGzapm0YB">
+                <Fragment Id="ByZRoLOqU21PFoQin7QsHO" Patch="Ss8HJJ6py3yMASfc3HltE6" Enabled="true" />
+                <Fragment Id="CCira3Bo87fLSyyqW8nl5K" Patch="HwSpmfMCwPVMi1hpqFinb8" Enabled="true" />
+              </ProcessDefinition>
+              <Slot Id="Eex5kssGbqaLeL8WwskRXh" Name="CMS" />
+              <Link Id="TaLpHoRfILiNjXqeRZ7VAn" Ids="PpDXIguSZEbLmtaZEAy6ue,SHC7bcGXtp6NV4PMKony5W" />
+              <Slot Id="M2oksLvLr3KMYHgp4MsezW" Name="TS" />
+              <Link Id="FHlWilqP5y7OEekloEqVx3" Ids="Rmo3RQT1lzNQEPRSxEPHeE,FWwXE9gs61GNQJ1ojMbGSb" IsHidden="true" />
+              <Link Id="UCv3gptxK3qPPYSvDGclhT" Ids="GRFuvpruDzEPIo88j0LRUG,S7Qo4vicHLiOQE5uFI2KcJ" />
+              <Link Id="PMZs3qTe34ePO6M73bwgFe" Ids="Qk9ys8I1tVrOolVfZADFZe,N8wn7oUH4AfOru8aubavDb" />
+              <Link Id="IZqxoIwzAmwOL9I4vHqgWP" Ids="VJyV180Xs47MPC0GrXeZ3W,HJb0W7SOoLrMlQPwVtkEvR" />
+              <Link Id="I6vye65iaRGPOam8qyI733" Ids="DxyPiYrJW33Pog8oDZdJyB,LXIC1zp8704OwRJE4DxH9k" />
+              <Link Id="GWTUs3EltJxLkbFsg58g67" Ids="Ri6lUo6yguNPWy1QzXZYhl,RKu4qPz4x3kOhV6LMrR5Y8" />
+              <Link Id="UNOb00Bk5WcOHPKxIkZFTP" Ids="SxBkG8HngroO1XyQ1D42Zy,JksR1FK5dsvNkenrft1mmU" />
+              <Link Id="MBvOrgfKaB9NIuJlAUkxnd" Ids="SHC7bcGXtp6NV4PMKony5W,Rmo3RQT1lzNQEPRSxEPHeE" />
+              <Link Id="GoBcmytZsy0N4wEgvqz5r9" Ids="SHC7bcGXtp6NV4PMKony5W,UXfMteFfiQLPVHmEpXUkxL" />
+              <Link Id="MoPYvVSUK3uMB6aekJXrrb" Ids="SHC7bcGXtp6NV4PMKony5W,CarFzfGINOuNuzLpIRbX9r" />
+              <Link Id="EB4geM4LeLDPtgJTxdiMCw" Ids="So8rhqj1PxmPlx2sJYE2BT,F369c8q23SdMzJGTjUQFLC" />
+              <Link Id="Vr0IHRt9RKMLCm1m04UUC6" Ids="F369c8q23SdMzJGTjUQFLC,GfT8LeMpCPiLIKHBBPz3YM" IsHidden="true" />
+              <Link Id="FjBxY3FMPCHQZe8jgBUNcw" Ids="UrWtEWiMMTAOauzc9qS0IP,MM9VbMjVeKeQUX5UyrznMy" IsHidden="true" />
+              <Link Id="PMzoQlY94nEQcmKqLVe51q" Ids="HSUjws3fzMWN2aeWd1JlFr,UrWtEWiMMTAOauzc9qS0IP" />
+              <Patch Id="Ss8HJJ6py3yMASfc3HltE6" Name="Create" ParticipatingElements="TaLpHoRfILiNjXqeRZ7VAn,GoBcmytZsy0N4wEgvqz5r9" ManuallySortedPins="true">
+                <Pin Id="FWwXE9gs61GNQJ1ojMbGSb" Name="Output" Kind="OutputPin" />
+                <Pin Id="GfT8LeMpCPiLIKHBBPz3YM" Name="Show" Kind="OutputPin" Bounds="476,375" />
+                <Pin Id="MM9VbMjVeKeQUX5UyrznMy" Name="Quit" Kind="OutputPin" />
+              </Patch>
+              <Patch Id="HwSpmfMCwPVMi1hpqFinb8" Name="Update" />
+              <Patch Id="JcoaLfnPEN7Pm6nnEo2WLi" Name="Dispose" ParticipatingElements="MoPYvVSUK3uMB6aekJXrrb" />
             </Patch>
           </Node>
         </Canvas>
@@ -12865,7 +13581,7 @@
             <Choice Kind="OperationDefinition" Name="Operation" />
           </p:NodeReference>
           <Patch Id="MgH8AWMshuHNUkb0184Cjj" ManuallySortedPins="true">
-            <Node Bounds="1557,974,24,26" Id="InPAXPv0sBlNcS9pd63Cwq">
+            <Node Bounds="1557,974,104,26" Id="InPAXPv0sBlNcS9pd63Cwq">
               <p:NodeReference LastCategoryFullName="Main.Model.LaunchTabModel" LastDependency="GammaLauncher.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="GetSelectedVersion" />
@@ -12879,7 +13595,7 @@
             <Link Id="Rhh2RChvciINdQpCvgMc5O" Ids="RZysq5UCp6GMw2cNelIgWf,MSVKmKuVFDAPCAFDZcG7Il" IsHidden="true" />
             <ControlPoint Id="OWpyLTpgAN4MPe7eATeu06" Bounds="1637,1272" />
             <Link Id="C8TaQs5UWauNtnGbCXhQ2S" Ids="OWpyLTpgAN4MPe7eATeu06,Ofc1VH5SR2ILctTtvilq3a" IsHidden="true" />
-            <Node Bounds="1521,944,41,19" Id="NHWcAx6OmO9NXAtbjC7Msx">
+            <Node Bounds="1521,944,45,26" Id="NHWcAx6OmO9NXAtbjC7Msx">
               <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -12965,7 +13681,7 @@
               <Pin Id="Jb0s0rXExjgQYGdLRkFvNv" Name="Path" Kind="OutputPin" />
             </Node>
             <Link Id="R3nFGlsM7TINiDnuMoqUeu" Ids="LroFHzLv4WBOYhCRvXAKJb,JxWqoLzC50MOqfFyRK64gl" />
-            <Node Bounds="1635,1233,55,19" Id="NyWVhSU6SxuP4MsY9vUDfo">
+            <Node Bounds="1635,1233,55,26" Id="NyWVhSU6SxuP4MsY9vUDfo">
               <p:NodeReference LastCategoryFullName="IO.Path" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="Category" Name="Path" />
@@ -15843,8 +16559,8 @@
                       <Pin Id="T9fZekIAze6Nr1bQGMHnvZ" Name="Force" Kind="InputPin" />
                       <Pin Id="KJjW0DIl2vPNsWldQfLadJ" Name="Dispose Cached Outputs" Kind="InputPin" />
                       <Pin Id="AyZhokf65FIMShsVhXH125" Name="Has Changed" Kind="OutputPin" />
-                      <ControlPoint Id="ToJuz7L7FlHNp4B6WjDiEI" Bounds="76,161" Alignment="Top" />
-                      <ControlPoint Id="EAw7RneRXsFPO0PzINWPxb" Bounds="507,953" Alignment="Bottom" />
+                      <ControlPoint Id="ToJuz7L7FlHNp4B6WjDiEI" Bounds="76,160" Alignment="Top" />
+                      <ControlPoint Id="EAw7RneRXsFPO0PzINWPxb" Bounds="507,954" Alignment="Bottom" />
                       <Patch Id="J6dAo0bTgmAO07iARzREeT" ManuallySortedPins="true">
                         <Patch Id="JleSUEg8BChP7hU2QUKMCl" Name="Create" ManuallySortedPins="true" />
                         <Patch Id="FsJGllUgzS7QERv8M0Ryfx" Name="Then" ManuallySortedPins="true" />
@@ -16364,6 +17080,173 @@
             </Patch>
           </Node>
         </Canvas>
+        <!--
+
+    ************************ LoadIcon ************************
+
+-->
+        <Node Name="LoadIcon" Bounds="311,328" Id="TrMdJfJotFqPq8P2vx52qf">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+            <Choice Kind="ContainerDefinition" Name="Process" />
+          </p:NodeReference>
+          <Patch Id="LYLNkum3wZVQDwdS6DXaxT">
+            <Canvas Id="QnTKKHjTorLP9ArOwUQUXB" CanvasType="Group">
+              <Node Bounds="145,142,199,366" Id="Qp9N5LQMrfdO7StvMQNwi4">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                  <Choice Kind="ProcessStatefulRegion" Name="Cache" />
+                  <FullNameCategoryReference ID="Primitive" />
+                </p:NodeReference>
+                <Pin Id="CrEZN4A4VgtMWRWvY8FagN" Name="Force" Kind="InputPin" />
+                <Pin Id="JgvLmOeQLvaLns27hDpZdb" Name="Dispose Cached Outputs" Kind="InputPin" />
+                <Pin Id="ISVFJwcZa2NMOgD8NCUjtt" Name="Has Changed" Kind="OutputPin" />
+                <ControlPoint Id="UuSDKNumtObPw7oEsDY9Fz" Bounds="205,148" Alignment="Top" />
+                <Patch Id="Ic9mKhYg7e5OFGf83kUETi" ManuallySortedPins="true">
+                  <Patch Id="HFrd732gnxIMaPaTMKst38" Name="Create" ManuallySortedPins="true" />
+                  <Patch Id="FZGE37IbVpDQITEri2JAbM" Name="Then" ManuallySortedPins="true" />
+                  <Node Bounds="204,205,55,19" Id="UAus0atvZ0yQD3wyje1peV">
+                    <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="ToString" />
+                    </p:NodeReference>
+                    <Pin Id="KodAsDurk8LMPca2kjsiYs" Name="Input" Kind="InputPin" />
+                    <Pin Id="JvzzcpkaWhiLuNdRne8vbp" Name="Result" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="237,167,57,19" Id="AHgCxFbViEcOytouAI5M6L">
+                    <p:NodeReference LastCategoryFullName="IO.Path" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="Filename (Split)" />
+                    </p:NodeReference>
+                    <Pin Id="Gh1AscdxaliPA4TVpOmZ9U" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="F6GNpRDnLe4QOf4d0qdHJ0" Name="Directory" Kind="OutputPin" />
+                    <Pin Id="BtTKwRKzsjuQA9YqVZR23w" Name="Filename" Kind="OutputPin" />
+                    <Pin Id="J6HobVyX1H1LRq0XsouOfo" Name="Extension" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="289,215,25,19" Id="Q9CtAAkoNz4NoJdQalLvK8">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="=" />
+                    </p:NodeReference>
+                    <Pin Id="HkW2jPUvb6oOwsGy6fDYJ3" Name="Input" Kind="InputPin" />
+                    <Pin Id="QZ8LOicIcKuLunQ8OLNzLH" Name="Input 2" Kind="InputPin" DefaultValue="ico">
+                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="TypeFlag" Name="String" />
+                      </p:TypeAnnotation>
+                    </Pin>
+                    <Pin Id="ONS4NccVtPaO9foHhWOU3Q" Name="Result" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="168,256,70,80" Id="RLHiZC2zqP8LUAvZ4KYWfb">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                      <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                      <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                      <FullNameCategoryReference ID="Primitive" />
+                    </p:NodeReference>
+                    <Pin Id="Nw9mSpKojxeOdiUuQeRup1" Name="Condition" Kind="InputPin" />
+                    <Patch Id="Qxm8FXZ2yycMs2kEMpa7Sf" ManuallySortedPins="true">
+                      <Patch Id="A2BjHvyNMQfQAlu8maRZVU" Name="Create" ManuallySortedPins="true" />
+                      <Patch Id="VpnNYvoECJRPxQPu7EBHxX" Name="Then" ManuallySortedPins="true" />
+                      <Node Bounds="180,283,46,26" Id="UsLifZDbuO3LrSJYkxKrb7">
+                        <p:NodeReference LastCategoryFullName="System.Drawing.Icon" LastDependency="System.Drawing.dll">
+                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                          <CategoryReference Kind="AssemblyCategory" Name="Icon" />
+                          <Choice Kind="OperationCallFlag" Name="Create" />
+                          <PinReference Kind="InputPin" Name="File Name" />
+                        </p:NodeReference>
+                        <Pin Id="AvrX04bLxsIQbt3Ss0WI3D" Name="File Name" Kind="InputPin" />
+                        <Pin Id="A1UcGq8XKDaMTOVIHG6933" Name="Output" Kind="StateOutputPin" />
+                      </Node>
+                    </Patch>
+                    <ControlPoint Id="FdsSWvKoZgqNjmUoE5yAgY" Bounds="182,330" Alignment="Bottom" />
+                    <ControlPoint Id="LP85bhg0muFNRqal8R8Nr0" Bounds="183,262" Alignment="Top" />
+                  </Node>
+                  <Node Bounds="288,284,37,19" Id="KtQbttkr3WLPnroLTnFWDw">
+                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="NOT" />
+                    </p:NodeReference>
+                    <Pin Id="EXgkSMdUsSSQFWPGRcIpVo" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="Gn0spJX1571LZlIvhqcIAF" Name="Output" Kind="StateOutputPin" />
+                  </Node>
+                  <Node Bounds="168,359,164,127" Id="PD5oQevTaFZPlLVInKFNCH">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                      <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                      <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                      <CategoryReference Kind="Category" Name="Primitive" />
+                    </p:NodeReference>
+                    <Pin Id="G7wpeKEAREKLc6CMNLsuY1" Name="Condition" Kind="InputPin" />
+                    <Patch Id="McbyhYUHC1lM3iOagnEWn4" ManuallySortedPins="true">
+                      <Patch Id="Ozmkb6L2UnIOfo1Yj0RvgC" Name="Create" ManuallySortedPins="true" />
+                      <Patch Id="RnQoDfQ1G5sLOhhOmtzZJ4" Name="Then" ManuallySortedPins="true" />
+                      <Node Bounds="197,382,46,26" Id="VFwi2wjFWFwNTQ0LGh1m42">
+                        <p:NodeReference LastCategoryFullName="System.Drawing.Bitmap" LastDependency="System.Drawing.dll">
+                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                          <CategoryReference Kind="AssemblyCategory" Name="Bitmap" />
+                          <Choice Kind="OperationCallFlag" Name="Create" />
+                          <PinReference Kind="InputPin" Name="Filename" />
+                        </p:NodeReference>
+                        <Pin Id="A5fcpLZato8PMgZpBCETJJ" Name="Filename" Kind="InputPin" />
+                        <Pin Id="HJcVyNWAGSaLn5sg3MXuUj" Name="Output" Kind="StateOutputPin" />
+                      </Node>
+                      <Node Bounds="196,413,58,26" Id="DmIzPuxmUS8PXMT8k7B42j">
+                        <p:NodeReference LastCategoryFullName="System.Drawing.Bitmap" LastDependency="System.Drawing.dll">
+                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                          <Choice Kind="OperationCallFlag" Name="GetHicon" />
+                          <CategoryReference Kind="AssemblyCategory" Name="Bitmap" NeedsToBeDirectParent="true" />
+                        </p:NodeReference>
+                        <Pin Id="LXv0gZT9S5ILsfzkzMt1ZE" Name="Input" Kind="StateInputPin" />
+                        <Pin Id="VZFz8MaS6V4LhFQSqNZspc" Name="Output" Kind="StateOutputPin" />
+                        <Pin Id="MQtvvBcnB0BL2l6zwswKNh" Name="Result" Kind="OutputPin" />
+                      </Node>
+                      <Node Bounds="249,447,71,19" Id="Ref8cCmEl8lQP8Rm9TsrYE">
+                        <p:NodeReference LastCategoryFullName="System.Drawing.Icon" LastDependency="System.Drawing.dll">
+                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                          <Choice Kind="OperationCallFlag" Name="FromHandle" />
+                          <CategoryReference Kind="AssemblyCategory" Name="Icon" NeedsToBeDirectParent="true" />
+                        </p:NodeReference>
+                        <Pin Id="FQDSaovJ8uEOSXXh07Cph7" Name="Handle" Kind="InputPin" />
+                        <Pin Id="Htwz8yBk6JENo9VoEFf6ZQ" Name="Result" Kind="OutputPin" />
+                      </Node>
+                    </Patch>
+                    <ControlPoint Id="N0T7KcezT6vLnW3lGu2Mut" Bounds="182,365" Alignment="Top" />
+                    <ControlPoint Id="OXQrUzt1XK6LLvUNF2XjEh" Bounds="252,480" Alignment="Bottom" />
+                  </Node>
+                </Patch>
+                <ControlPoint Id="D9qAXFm2LRrOpBsR3Vv0mp" Bounds="252,502" Alignment="Bottom" />
+              </Node>
+              <ControlPoint Id="Hwbl746wYrYOlCSpNplKmU" Bounds="205,101" />
+              <ControlPoint Id="Dfraco54gc3M2nGAkCd0Gs" Bounds="252,560" />
+            </Canvas>
+            <Patch Id="QgwGYkPWwPnLDvX5PRWiRa" Name="Create" />
+            <Patch Id="QF13xDzvu7yLS10oW2tIwB" Name="Update">
+              <Pin Id="BLxaDK0MBxNLI3k6Pdu2iN" Name="Icon Path" Kind="InputPin" Bounds="639,258" />
+              <Pin Id="L0Cl9E9qxsXOIHAFenGtEc" Name="Output" Kind="OutputPin" Bounds="278,651" />
+            </Patch>
+            <ProcessDefinition Id="VfWs4FZcGyLP8YtfzYFQIp">
+              <Fragment Id="B2zCPvpx177Mf1wXrBYJZt" Patch="QgwGYkPWwPnLDvX5PRWiRa" Enabled="true" />
+              <Fragment Id="E5DRwnARLlRMxQUguhnzzf" Patch="QF13xDzvu7yLS10oW2tIwB" Enabled="true" />
+            </ProcessDefinition>
+            <Link Id="IX4TCZT3CpBLsiZq5iBlad" Ids="JvzzcpkaWhiLuNdRne8vbp,AvrX04bLxsIQbt3Ss0WI3D" />
+            <Link Id="BHN70XB2cT3PfAYjKMwoWe" Ids="UuSDKNumtObPw7oEsDY9Fz,KodAsDurk8LMPca2kjsiYs" />
+            <Link Id="Tj3BTOMJZ5lN7MdxLPDKHP" Ids="BLxaDK0MBxNLI3k6Pdu2iN,Hwbl746wYrYOlCSpNplKmU" IsHidden="true" />
+            <Link Id="Jp2E6tMTMhONAoY1n4Carr" Ids="JvzzcpkaWhiLuNdRne8vbp,A5fcpLZato8PMgZpBCETJJ" />
+            <Link Id="D5l3QliguvnMMOVBgYAhpz" Ids="UuSDKNumtObPw7oEsDY9Fz,Gh1AscdxaliPA4TVpOmZ9U" />
+            <Link Id="UagR6znZnN6O94tfDJwnA5" Ids="J6HobVyX1H1LRq0XsouOfo,HkW2jPUvb6oOwsGy6fDYJ3" />
+            <Link Id="Df2whAw5eBhONigFJ1Z7lo" Ids="ONS4NccVtPaO9foHhWOU3Q,Nw9mSpKojxeOdiUuQeRup1" />
+            <Link Id="Akcz01UmImGNj2U6a8XH2c" Ids="ONS4NccVtPaO9foHhWOU3Q,EXgkSMdUsSSQFWPGRcIpVo" />
+            <Link Id="Tj7KmaMD3GQOxEB7HeSRuN" Ids="LP85bhg0muFNRqal8R8Nr0,FdsSWvKoZgqNjmUoE5yAgY" IsFeedback="true" />
+            <Link Id="Mmr20bOOl0RLSTBUptx9kb" Ids="A1UcGq8XKDaMTOVIHG6933,FdsSWvKoZgqNjmUoE5yAgY" />
+            <Link Id="VNOKUO9nEvBQRXCaYNeBTx" Ids="N0T7KcezT6vLnW3lGu2Mut,OXQrUzt1XK6LLvUNF2XjEh" IsFeedback="true" />
+            <Link Id="GCYRJriqAEZMBFwzGBqwE6" Ids="FdsSWvKoZgqNjmUoE5yAgY,N0T7KcezT6vLnW3lGu2Mut" />
+            <Link Id="THbVTyWHNDxLf4QegPhLAW" Ids="HJcVyNWAGSaLn5sg3MXuUj,LXv0gZT9S5ILsfzkzMt1ZE" />
+            <Link Id="EMkuOnDowlJPl1j5nlPgBe" Ids="MQtvvBcnB0BL2l6zwswKNh,FQDSaovJ8uEOSXXh07Cph7" />
+            <Link Id="KtojsrJ0YstNlVovFoefKU" Ids="Htwz8yBk6JENo9VoEFf6ZQ,OXQrUzt1XK6LLvUNF2XjEh" />
+            <Link Id="Cy93KNTt7NIPTJ791oh56q" Ids="Gn0spJX1571LZlIvhqcIAF,G7wpeKEAREKLc6CMNLsuY1" />
+            <Link Id="VgsDIBhAADjM8kENdYOdUs" Ids="OXQrUzt1XK6LLvUNF2XjEh,D9qAXFm2LRrOpBsR3Vv0mp" />
+            <Link Id="QPBXaoJADPONICVJ3gVGQy" Ids="Hwbl746wYrYOlCSpNplKmU,UuSDKNumtObPw7oEsDY9Fz" />
+            <Link Id="L64TwML5F7APx7Q1X04VTS" Ids="D9qAXFm2LRrOpBsR3Vv0mp,Dfraco54gc3M2nGAkCd0Gs" />
+            <Link Id="OkoQCwLyYVqOiqfvMvK0RZ" Ids="Dfraco54gc3M2nGAkCd0Gs,L0Cl9E9qxsXOIHAFenGtEc" IsHidden="true" />
+          </Patch>
+        </Node>
       </Canvas>
     </Canvas>
     <!--
@@ -16378,7 +17261,7 @@
       </p:NodeReference>
       <Patch Id="F8UlxYFfbPnMePYinfRrYh">
         <Canvas Id="RCLbd3ePcrmLiAS4XEaOOm" CanvasType="Group">
-          <Node Bounds="56,213,35,19" Id="D9GJ8H74AwdOkmcKjPYJrF">
+          <Node Bounds="101,124,35,19" Id="D9GJ8H74AwdOkmcKjPYJrF">
             <p:NodeReference LastCategoryFullName="Main.App" LastDependency="GammaLauncher.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="App" />
@@ -16388,7 +17271,7 @@
             <Pin Id="VUqK419WdeSL73H3YcC0hP" Name="Output" Kind="StateOutputPin" />
             <Pin Id="PXt4MhFPF7sM49glNMIYkB" Name="Initial Window Bounds" Kind="OutputPin" />
           </Node>
-          <Node Bounds="86,296,45,19" Id="KsPBahmoFh9NNY9cQdjWYM">
+          <Node Bounds="131,207,45,19" Id="KsPBahmoFh9NNY9cQdjWYM">
             <p:NodeReference LastCategoryFullName="Main.Editor.UI" LastDependency="GammaLauncher.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Editor" />
@@ -16397,12 +17280,12 @@
             <Pin Id="TIdAF5p3lkJPu2CcXmBGuH" Name="Application" Kind="InputPin" />
             <Pin Id="C66dxMfii8eLTpXdFi2Z0a" Name="Console" Kind="InputPin" />
           </Node>
-          <Pad Id="VUCcbzHMmBDOhUMfMo8Axu" Comment="" Bounds="58,190,91,15" ShowValueBox="true" isIOBox="true" Value="5.1.0">
+          <Pad Id="VUCcbzHMmBDOhUMfMo8Axu" Comment="" Bounds="103,101,91,15" ShowValueBox="true" isIOBox="true" Value="5.1.0">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
           </Pad>
-          <Node Bounds="126,260,86,19" Id="LVjAnI0SvlpPeyJdNtNIi4">
+          <Node Bounds="171,171,86,19" Id="LVjAnI0SvlpPeyJdNtNIi4">
             <p:NodeReference LastCategoryFullName="Main.Editor.Keyboard" LastDependency="GammaLauncher.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="KeyboardEditor" />


### PR DESCRIPTION
Hey, I added a NotifyIcon.

App is minimized to system tray (notification area).
Left click on the notification icon maximizes the window again.
Right click brings up a context menu which has two entries:
* _Show_ -> maximizes the window
* _Quit_ -> quits the launcher

I prefer it that way but don't know if it should be the default behaviour.
Maybe It can be added as setting: either minimize to tray or to taskbar.

I branched off `feature/mute-arguments` since it already fixed the issues when updating to 5.0 stable.