### PR TITLE
Adds Show vvvv package cache to Edit Menu

### DIFF
--- a/GammaLauncher.vl
+++ b/GammaLauncher.vl
@@ -22935,42 +22935,6 @@
             <Pin Id="Lw9O5JbB4XJMsdoNmBfAfU" Name="Application" Kind="InputPin" />
             <Pin Id="Q7BOO0RprLrLpZ96F1OLnv" Name="Output" Kind="OutputPin" />
           </Node>
-          <Node Bounds="480,480,77,19" Id="BZpL4xTNIISPzj4yP77phg">
-            <p:NodeReference LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
-              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-              <Choice Kind="OperationCallFlag" Name="SystemFolder" />
-            </p:NodeReference>
-            <Pin Id="IzRypZLAQRXLoR5yey2G7C" Name="Special Folder" Kind="InputPin" DefaultValue="LocalApplicationData" />
-            <Pin Id="RgtwjabOL7SOWhRmsLktA9" Name="Result" Kind="OutputPin" />
-          </Node>
-          <Node Bounds="480,580,60,19" Id="FvzqGbOcSxDMi1ddUZEpkl">
-            <p:NodeReference LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
-              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-              <Choice Kind="OperationCallFlag" Name="MakePath" />
-            </p:NodeReference>
-            <Pin Id="BD0ng4cIl4hPHTPq6XeBiC" Name="Path" Kind="InputPin" IsHidden="true" />
-            <Pin Id="TgUyGOgFed0LPeOXN7gYTr" Name="Input" Kind="InputPin" />
-            <Pin Id="L31RJgD4lCMNmWM7SGuWXy" Name="Input 2" Kind="InputPin" />
-            <Pin Id="Cc9aQNZy5AHNfq4tQkRg7q" Name="Output" Kind="OutputPin" />
-          </Node>
-          <Node Bounds="480,520,55,19" Id="Pc0cjGl4v1iOiDebRpUyJ1">
-            <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
-              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-              <Choice Kind="OperationCallFlag" Name="ToString" />
-            </p:NodeReference>
-            <Pin Id="DhDI6XEoHa8P17Ljrjm0W2" Name="Input" Kind="InputPin" />
-            <Pin Id="IzM5EYJ72ZtLlt9jiOW8su" Name="Result" Kind="OutputPin" />
-          </Node>
-          <Pad Id="MUH5XFhwcn2N3s2aTA6YU7" Comment="" Bounds="537,550,152,15" ShowValueBox="true" isIOBox="true" Value="Temp\vvvv-package-cache">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-              <Choice Kind="TypeFlag" Name="String" />
-            </p:TypeAnnotation>
-          </Pad>
-          <Pad Id="F8gm8lhXMWQPDhnP7Olg6O" Comment="" Bounds="482,450,144,15" ShowValueBox="true" isIOBox="true" Value="LocalApplicationData">
-            <p:TypeAnnotation LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
-              <Choice Kind="TypeFlag" Name="SpecialFolder" />
-            </p:TypeAnnotation>
-          </Pad>
         </Canvas>
         <Patch Id="KKnejguk59iOlItt5SMhF8" Name="Create" />
         <Patch Id="CKL6bDvGpbBMcPbl7oUMJl" Name="Update" />
@@ -22983,10 +22947,6 @@
         <Link Id="JyL7QuGqd5wLTQNjMNlILH" Ids="Q7BOO0RprLrLpZ96F1OLnv,C66dxMfii8eLTpXdFi2Z0a" />
         <Link Id="EDFh0Zc82h2PBIILqosifZ" Ids="VUqK419WdeSL73H3YcC0hP,Lw9O5JbB4XJMsdoNmBfAfU" />
         <Link Id="BdFXnNBECfsLvMOOc34cW6" Ids="PXt4MhFPF7sM49glNMIYkB,FOtvu5ptxnCMfy4a61eBXT" />
-        <Link Id="RnBepg1V8OEOACCxBDTnaq" Ids="RgtwjabOL7SOWhRmsLktA9,DhDI6XEoHa8P17Ljrjm0W2" />
-        <Link Id="L1Ig9IWgdE1O4iW4QaKgNI" Ids="IzM5EYJ72ZtLlt9jiOW8su,TgUyGOgFed0LPeOXN7gYTr" />
-        <Link Id="T0pPz4Pj5qZOiZ5kh2zAnx" Ids="MUH5XFhwcn2N3s2aTA6YU7,L31RJgD4lCMNmWM7SGuWXy" />
-        <Link Id="QccODdhlPpOO3Fh6jEP3Sz" Ids="F8gm8lhXMWQPDhnP7Olg6O,IzRypZLAQRXLoR5yey2G7C" />
       </Patch>
     </Node>
   </Patch>

--- a/GammaLauncher.vl
+++ b/GammaLauncher.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="PJSrtxvah1rPaRdkPeoySD" LanguageVersion="2024.6.7-0145-g7866bdf1e8" Version="0.128">
-  <NugetDependency Id="S7VWZeBsvN1PjJuK8xKPoa" Location="VL.CoreLib" Version="2024.6.7-0145-g7866bdf1e8" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="PJSrtxvah1rPaRdkPeoySD" LanguageVersion="2025.7.0-0200-g4a7221ecd9" Version="0.128">
+  <NugetDependency Id="S7VWZeBsvN1PjJuK8xKPoa" Location="VL.CoreLib" Version="2025.7.0-0200-g4a7221ecd9" />
   <Patch Id="VwtUUR3K9mbPm4q6fszgF3">
     <Canvas Id="Cn8FrGu71DtOiQColm6Utc" DefaultCategory="Main" CanvasType="FullCategory">
       <Canvas Id="A8kMw5cSAh9N9pwyyLzDKt" Name="Model" Position="92,129">
@@ -1151,6 +1151,7 @@
                 <Pin Id="FKsX5vj722dPztBQS8pMn3" Name="File Name" Kind="InputPin" />
                 <Pin Id="TZlCnF12UFFNq0DS3FCP7x" Name="Arguments" Kind="InputPin" />
                 <Pin Id="R2wYeN1HicEOeLzzJb7I3e" Name="Working Directory" Kind="InputPin" />
+                <Pin Id="PMADdn5euU8NxfRDN9lCiW" Name="Environment Path Variable" Kind="InputPin" IsHidden="true" />
                 <Pin Id="H94AFwyP4SjMt7RcemCoFw" Name="Execute" Kind="InputPin" DefaultValue="True" />
                 <Pin Id="H0ByfdMB2XINsdG3bw62WS" Name="State Output" Kind="StateOutputPin" />
                 <Pin Id="IptvDh9mAGQL9IB2sSjU2I" Name="Output" Kind="OutputPin" />
@@ -1188,6 +1189,7 @@
                   </p:TypeAnnotation>
                 </Pin>
                 <Pin Id="RLR1AnSB7bWPy9KQVIaOPv" Name="Working Directory" Kind="InputPin" />
+                <Pin Id="LWpT1ZwY5jKLHypy6HGd1d" Name="Environment Path Variable" Kind="InputPin" IsHidden="true" />
                 <Pin Id="IzwMS7h3tdQPhwWjuSA1aq" Name="Execute" Kind="InputPin" DefaultValue="True" />
                 <Pin Id="PqcA7agmQ8rPHX4O5rKkJI" Name="State Output" Kind="OutputPin" />
                 <Pin Id="DIlX6U6qUI7MICEfrWURBQ" Name="Output" Kind="OutputPin" />
@@ -1294,6 +1296,7 @@
                         </Pin>
                         <Pin Id="FzBZBPhsvELO5tUbi3be6o" Name="Arguments" Kind="InputPin" />
                         <Pin Id="LwWcvTNtZIzNkGXZXwXviD" Name="Working Directory" Kind="InputPin" />
+                        <Pin Id="EOMw4hYupTWLbS1kySTEao" Name="Environment Path Variable" Kind="InputPin" IsHidden="true" />
                         <Pin Id="BNCfUPHR8T6N4TvMJGfiJM" Name="Execute" Kind="InputPin" DefaultValue="True">
                           <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Boolean" />
@@ -1510,6 +1513,7 @@
                 </Pin>
                 <Pin Id="Aqf16USG0teNibJ6dLvfqH" Name="Arguments" Kind="InputPin" />
                 <Pin Id="JYWcLQNVrjzOErn8cutCAy" Name="Working Directory" Kind="InputPin" />
+                <Pin Id="DntxlKSBllkMeS4Wm01MV4" Name="Environment Path Variable" Kind="InputPin" IsHidden="true" />
                 <Pin Id="KyiIgClgRD7N5H3jiOhGd3" Name="Execute" Kind="InputPin" />
                 <Pin Id="PZB7RigfCLPPZDdXsLMycQ" Name="State Output" Kind="OutputPin" />
                 <Pin Id="Ahm4CB7D9zHN2aVnOgvm5F" Name="Output" Kind="OutputPin" />
@@ -1541,6 +1545,7 @@
                 <Pin Id="S93GulhWf79NIeY7tQurN3" Name="File Name" Kind="InputPin" />
                 <Pin Id="Gz1pNMyREaXLfZthUHEnMf" Name="Arguments" Kind="InputPin" />
                 <Pin Id="Qno5s34HgUELsfwaoG6bS9" Name="Working Directory" Kind="InputPin" />
+                <Pin Id="LG0sPw4ANskNBdrH5N5jG0" Name="Environment Path Variable" Kind="InputPin" IsHidden="true" />
                 <Pin Id="MlunhpoQ4wuOtRTyZ9Q13D" Name="Execute" Kind="InputPin" DefaultValue="True" />
                 <Pin Id="S25m7yLpd5WLiqbZZoVrP1" Name="State Output" Kind="StateOutputPin" />
                 <Pin Id="CiY2tTUHSMwOb6004YeuRx" Name="Output" Kind="OutputPin" />
@@ -1599,6 +1604,7 @@
                 <Pin Id="AU8zOGQ58L7O0akrn3vcGm" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="DrTNFdlUQd5N7BhUBW3GEK" Name="Messages" Kind="InputPin" />
                 <Pin Id="F4ymQD3zpRUNUWdh42w6xP" Name="Reset" Kind="InputPin" />
+                <Pin Id="SQlxgWrRkwsORlBrAYMvmJ" Name="Output" Kind="OutputPin" />
                 <Pin Id="N2zMTFjekeML8T8QqJvWO9" Name="Result" Kind="OutputPin" />
               </Node>
               <Node Bounds="392,1247,36,19" Id="G8mWdBw7LcJOq92eivnKsU">
@@ -1658,6 +1664,7 @@
                 </Pin>
                 <Pin Id="S8lSst8RH4COFT82PdqI6J" Name="Arguments" Kind="InputPin" />
                 <Pin Id="AACHyv8U1dyNQoo6L9Hsw4" Name="Working Directory" Kind="InputPin" />
+                <Pin Id="RCCbmo44iYzNpDedEPPUlB" Name="Environment Path Variable" Kind="InputPin" IsHidden="true" />
                 <Pin Id="QmS76pYzWZVN38uuKpVyg4" Name="Execute" Kind="InputPin" DefaultValue="True" />
                 <Pin Id="GyxHhBsGne3OAq4K3YNZ5s" Name="State Output" Kind="OutputPin" />
                 <Pin Id="KcUb8FqTXpOORtCnz3I0wY" Name="Output" Kind="OutputPin" />
@@ -1718,6 +1725,7 @@
                 <Pin Id="OmzCIxeM8hAMCZ5lkPKP10" Name="File Name" Kind="InputPin" />
                 <Pin Id="N8Ak0zEbsGhNASKsU2Kp77" Name="Arguments" Kind="InputPin" />
                 <Pin Id="Oq0CuW2ReVkMyoBNHwJN0A" Name="Working Directory" Kind="InputPin" />
+                <Pin Id="S0gtFKygnMhLQkqNaoT2Ik" Name="Environment Path Variable" Kind="InputPin" IsHidden="true" />
                 <Pin Id="EK2rgLunEm8ME2ggmh5ElL" Name="Execute" Kind="InputPin" DefaultValue="True" />
                 <Pin Id="B4v5TM5qDuaPJKkfF9bNu8" Name="State Output" Kind="StateOutputPin" />
                 <Pin Id="IduYWOXX9gXNCPbdkx63Kb" Name="Output" Kind="OutputPin" />
@@ -1910,6 +1918,7 @@
                     </Pin>
                     <Pin Id="Prn0IgzEChwLnr0hWKeGuD" Name="Arguments" Kind="InputPin" />
                     <Pin Id="IYCC0K3H3zgOl0SsOCidbv" Name="Working Directory" Kind="InputPin" />
+                    <Pin Id="GAHUKW7QfonMjUZvVo2Guy" Name="Environment Path Variable" Kind="InputPin" IsHidden="true" />
                     <Pin Id="QMj3KDjIBj4M9eCdh5VOhn" Name="Execute" Kind="InputPin" DefaultValue="True" />
                     <Pin Id="TsuBcdABU6ZPEpTDH2tTWn" Name="State Output" Kind="OutputPin" />
                     <Pin Id="JrWLN1PLCjOPKCarNouAhz" Name="Output" Kind="OutputPin" />
@@ -2102,6 +2111,76 @@
               <Overlay Id="ONTU9FOD9o7LCa2QMsPwlM" Name="Stuff vvvversion in clipboard" Bounds="1754,416,308,277">
                 <p:ColorIndex p:Type="Int32">11</p:ColorIndex>
               </Overlay>
+              <Node Bounds="176,1830,125,19" Id="U6l1TpNS0ZRMkXITS9ifst">
+                <p:NodeReference LastCategoryFullName="System" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="Executor" />
+                </p:NodeReference>
+                <Pin Id="O5viHCBTdDdMcDCDXnHFQD" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                <Pin Id="RndGUrdv8eUMSV4vONf1EY" Name="File Name" Kind="InputPin" DefaultValue="explorer.exe">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="String" />
+                  </p:TypeAnnotation>
+                </Pin>
+                <Pin Id="BP4mIvbdZcxQFaz29ZYC75" Name="Arguments" Kind="InputPin" />
+                <Pin Id="U95l7tNS2bIMxjOKDDTp8y" Name="Working Directory" Kind="InputPin" DefaultValue="" />
+                <Pin Id="OuDaBOxDXKIPHh7jqXOuxP" Name="Environment Path Variable" Kind="InputPin" IsHidden="true" />
+                <Pin Id="CrnsjRUPtAuP4X4kP0boNd" Name="Execute" Kind="InputPin" DefaultValue="True" />
+                <Pin Id="RjMDLnwTQVjM50HZJyZiel" Name="State Output" Kind="OutputPin" />
+                <Pin Id="UXkFkwrd16YMo0dBC1znls" Name="Output" Kind="OutputPin" />
+                <Pin Id="OhP9pwwnEwOQIABlHiojrH" Name="Error" Kind="OutputPin" />
+                <Pin Id="BRiyMfTy1j4LwpgRdUbHmL" Name="Exited" Kind="OutputPin" />
+                <Pin Id="N4kAYeUEvVSPYEps3rXqk1" Name="Id" Kind="OutputPin" />
+                <Pin Id="RkqKNhhfkvePYre93M3VWo" Name="IsRunning" Kind="OutputPin" />
+                <Pin Id="GAeiqDbQ81yNxt15NxYD0q" Name="Exit Code" Kind="OutputPin" />
+              </Node>
+              <Overlay Id="DZ8fSxBuYOALqE5coymyGj" Name="Show vvvv package cache" Bounds="126,1552,330,327">
+                <p:ColorIndex p:Type="Int32">11</p:ColorIndex>
+              </Overlay>
+              <Node Bounds="216,1650,77,19" Id="KCtSlu6qtTiOS8YNHXiJUV">
+                <p:NodeReference LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="SystemFolder" />
+                </p:NodeReference>
+                <Pin Id="MhXOrs5wba6MPmynuoVbr7" Name="Special Folder" Kind="InputPin" DefaultValue="LocalApplicationData" />
+                <Pin Id="CjM1QuGfyuzQJJRdhmC9Vl" Name="Result" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="216,1750,60,19" Id="MkOhoJCVC3dN3aDgOeePqb">
+                <p:NodeReference LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="MakePath" />
+                </p:NodeReference>
+                <Pin Id="Lcqgmx5J2LbQNNFTdjM5tL" Name="Path" Kind="InputPin" IsHidden="true" />
+                <Pin Id="D1plQ05hlZiPVpdB4KK3S7" Name="Input" Kind="InputPin" />
+                <Pin Id="KOYHmnQczJSN467OVTNeHl" Name="Input 2" Kind="InputPin" />
+                <Pin Id="Ljt9xcbhWhELPrVNQ60CXX" Name="Output" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="216,1690,55,19" Id="Q8w9OKg6ufXPds7YX459RL">
+                <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="ToString" />
+                </p:NodeReference>
+                <Pin Id="Ughbc3cHpKQMnRIlhvCypt" Name="Input" Kind="InputPin" />
+                <Pin Id="QiE6TOJK5uHL5eeeBTCAE8" Name="Result" Kind="OutputPin" />
+              </Node>
+              <Pad Id="DkL2lVQRzivO79qnafJkaE" Comment="" Bounds="273,1721,152,15" ShowValueBox="true" isIOBox="true" Value="Temp\vvvv-package-cache">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="String" />
+                </p:TypeAnnotation>
+              </Pad>
+              <Pad Id="KUjhOjtHxFXL8x0stbeAXZ" Comment="" Bounds="218,1620,144,15" ShowValueBox="true" isIOBox="true" Value="LocalApplicationData">
+                <p:TypeAnnotation LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="SpecialFolder" />
+                </p:TypeAnnotation>
+              </Pad>
+              <Node Bounds="216,1780,55,19" Id="KMVi6NrdTmhLgtvMpj2x59">
+                <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="ToString" />
+                </p:NodeReference>
+                <Pin Id="CuRWVNZGMM1MyPrseeoCFM" Name="Input" Kind="InputPin" />
+                <Pin Id="DGCmwH4OnarP4QGeFxbVBU" Name="Result" Kind="OutputPin" />
+              </Node>
             </Canvas>
             <ProcessDefinition Id="ULKeWrzkUTzP9EFyg4tUY2" IsHidden="true">
               <Fragment Id="B7QLnKwc4NfLqzD7GB4anr" Patch="EOlZvqEmzODMJyl8LwURTP" Enabled="true" />
@@ -2119,6 +2198,7 @@
               <Fragment Id="J7jHULDT34gLx09PCj7DyS" Patch="UZOWb3sekQoLHiCN9qhgPa" />
               <Fragment Id="SyCBYEQvtQrLltqxyGcE5P" Patch="IzXwv77O7wiNFgqGHJRCiJ" />
               <Fragment Id="L4Nz7Syr9vrMCHizsFPRaz" Patch="BgrrnYgoLdaLC5wLhT93kb" />
+              <Fragment Id="C9svtjaxX3oN8ek48504by" Patch="Tblxyy51tL8PQMG69JgH8h" />
             </ProcessDefinition>
             <Link Id="HRNsXmlCZCrMOgrvSMXCSS" Ids="S9iTlewGHNyMQ9KGPuxOZk,F3NLnoFJ2NDPf6qrmkX2ED" IsHidden="true" />
             <Slot Id="TpJHFOeYXgNONR6mOhl4uR" Name="Launch Tab Model Channel">
@@ -2296,6 +2376,13 @@
             <Link Id="JVAzZLz9B8PPYxZkR2j682" Ids="T4Ex5cNVbanPM9ok6pAz09,DBfmn7AtG2lMhuix8zNMTq" />
             <Link Id="Lx2bM3k2QszOV9pfMlLYiS" Ids="Lu4E6Pu3JuwQbFUAbCZTqN,Qno5s34HgUELsfwaoG6bS9" />
             <Link Id="GLDzCzozpx8L3QsD0TMWB2" Ids="HeoXs7z25DNMjtUZ99DwEo,Oq0CuW2ReVkMyoBNHwJN0A" />
+            <Patch Id="Tblxyy51tL8PQMG69JgH8h" Name="ShowVVVVPackageCache" ParticipatingElements="KWLMq62yF6dNGoCTG4cWxA" />
+            <Link Id="PKeH31d73T0PVKwUH47quj" Ids="CjM1QuGfyuzQJJRdhmC9Vl,Ughbc3cHpKQMnRIlhvCypt" />
+            <Link Id="FnHCW0txLHoMzjnKWtS4xP" Ids="QiE6TOJK5uHL5eeeBTCAE8,D1plQ05hlZiPVpdB4KK3S7" />
+            <Link Id="MajnCOjpqanOerYkiifRAL" Ids="DkL2lVQRzivO79qnafJkaE,KOYHmnQczJSN467OVTNeHl" />
+            <Link Id="LHW5rcH6SK0OMJngqxRorZ" Ids="KUjhOjtHxFXL8x0stbeAXZ,MhXOrs5wba6MPmynuoVbr7" />
+            <Link Id="M2nKTwOYGeGLwezBgZIcnW" Ids="Ljt9xcbhWhELPrVNQ60CXX,CuRWVNZGMM1MyPrseeoCFM" />
+            <Link Id="KWLMq62yF6dNGoCTG4cWxA" Ids="DGCmwH4OnarP4QGeFxbVBU,BP4mIvbdZcxQFaz29ZYC75" />
           </Patch>
         </Node>
         <!--
@@ -2377,6 +2464,7 @@
                 <Pin Id="RWsaPoRzj3sPt1loYINriR" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="EGoZmdMIHeIO9HVHcFclve" Name="Messages" Kind="InputPin" />
                 <Pin Id="JQVJGeDCCL3Pzm5ojHvCwG" Name="Reset" Kind="InputPin" />
+                <Pin Id="KsGKPc8EdpMQU5th7feGLj" Name="Output" Kind="OutputPin" />
                 <Pin Id="Uli1WQ3xUtmOsoMtBTB7Ye" Name="Result" Kind="OutputPin" />
                 <Patch Id="GCv8inajwejLlUXJhlJX6k" ManuallySortedPins="true">
                   <ControlPoint Id="PuIixxpQExqNJz9utOdBC5" Bounds="515,1519" />
@@ -2544,6 +2632,7 @@
                 <Pin Id="DRyK9ULof4GQVVc726Qfb9" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="ECndSOjUbpjPZM62mkH5YK" Name="Messages" Kind="InputPin" />
                 <Pin Id="AbENbm51whiQSPonewJjZz" Name="Reset" Kind="InputPin" />
+                <Pin Id="NBfdWUyuXkLPDnwVseQfqI" Name="Output" Kind="OutputPin" />
                 <Pin Id="AyrO0P8KaiZQFHglhoWMdq" Name="Result" Kind="OutputPin" />
                 <Patch Id="PP1cJ6vykiXMAvZoUxDV7W" ManuallySortedPins="true">
                   <Patch Id="Fd6eJ5Tng8qO0kUB9RMWBt" Name="Create" ManuallySortedPins="true" />
@@ -2628,6 +2717,7 @@
                 <Pin Id="TBPpB73U9NDOv5Bej6W9TY" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="DZ9cQ7nnV2JQBVEqmD8jDG" Name="Messages" Kind="InputPin" />
                 <Pin Id="VrYoNNSbYUoP2KMak7VAcK" Name="Reset" Kind="InputPin" />
+                <Pin Id="UKKJLfTYmYVOCtPVmTcjLO" Name="Output" Kind="OutputPin" />
                 <Pin Id="OrJjXEQh4sLNoe0qrw5vZc" Name="Result" Kind="OutputPin" />
                 <Patch Id="PCA49t9xdD4Pui0W75U8pK" ManuallySortedPins="true">
                   <ControlPoint Id="ECHhMBSfl2eLVgmDEXgwFY" Bounds="1627,665" />
@@ -2758,6 +2848,7 @@
                 <Pin Id="OJpAmY6XYGFOuCy1q9sCaz" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="FXYMsQVtblDPKKUVhICVCK" Name="Messages" Kind="InputPin" />
                 <Pin Id="Ia6Teg1YsQsLdOKxkhfGtW" Name="Reset" Kind="InputPin" />
+                <Pin Id="AOyGYzQemc9LlNhDkOy4Ty" Name="Output" Kind="OutputPin" />
                 <Pin Id="Cny2EitEEscNw9aYxxKs1Y" Name="Result" Kind="OutputPin" />
               </Node>
               <Pad Id="IEVGyBVZgkgQK1IDNN0UGO" Bounds="1520,426">
@@ -2834,6 +2925,7 @@
                 <Pin Id="NRpP3jBgqC2QLDeJghsmG4" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="Gl5JasdhuNbNeY9uGyjl8D" Name="Messages" Kind="InputPin" />
                 <Pin Id="Lr18T8dQyxVLNqqIawvhvB" Name="Reset" Kind="InputPin" />
+                <Pin Id="UYaOhQWA5woLQGOzfGd9Zs" Name="Output" Kind="OutputPin" />
                 <Pin Id="KcKP8Z0VyrYO3dHSZaWhuR" Name="Result" Kind="OutputPin" />
               </Node>
               <ControlPoint Id="TkrUL4u83sLMPsD8q4xgpw" Bounds="285,2082" />
@@ -2869,6 +2961,7 @@
                 <Pin Id="TtnCOryhCQqPRONc0CANJy" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="OuKKbb04uPOMoIMip3LtTX" Name="Messages" Kind="InputPin" />
                 <Pin Id="EGUiqaivASKLZ7ygKkjrlW" Name="Reset" Kind="InputPin" />
+                <Pin Id="EeSK2ZmIttyLZxnKnokTXN" Name="Output" Kind="OutputPin" />
                 <Pin Id="HPjMy2uXw8aNqJ2q94qUzI" Name="Result" Kind="OutputPin" />
                 <Patch Id="AsQvUaMwZrAP93GDy4QiE3" ManuallySortedPins="true">
                   <Patch Id="K2gnfW3lDvXPgjWjVYN4ie" Name="Create" ManuallySortedPins="true" />
@@ -2918,6 +3011,7 @@
                 <Pin Id="Fa5XPYczanJMV45ZxR2ZTU" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="AbhrNUH67OZO7h3BLam4Lx" Name="Messages" Kind="InputPin" />
                 <Pin Id="Uts5i76rmLZO58CwwPTIWZ" Name="Reset" Kind="InputPin" />
+                <Pin Id="Jdyo9a3VV2ROuUPuI6uDe4" Name="Output" Kind="OutputPin" />
                 <Pin Id="GTwKFvfev6mQNWgCm6vHQy" Name="Result" Kind="OutputPin" />
                 <Patch Id="B20n7hMZgTPQM8Ff198hSv" ManuallySortedPins="true">
                   <Patch Id="T5YC3vkYCUOMA3lZk615iL" Name="Create" ManuallySortedPins="true" />
@@ -3003,6 +3097,7 @@
                 <Pin Id="Q61ZFTgqf4xPNashmRM2z8" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="EKKPC4c5d1NMopzGSSfLiP" Name="Messages" Kind="InputPin" />
                 <Pin Id="EMsTABbzsp1PmphwrcHO4j" Name="Reset" Kind="InputPin" />
+                <Pin Id="MNBSsBmjB2GMTTBLfyPPb4" Name="Output" Kind="OutputPin" />
                 <Pin Id="Kb11lq3fHl4PxEgRK35bkq" Name="Result" Kind="OutputPin" />
                 <Patch Id="N9u1yONh5qrPXZIpj9pUHu" ManuallySortedPins="true">
                   <ControlPoint Id="UcJMR7OiMFsL4s234rOuG7" Bounds="1337,1563" />
@@ -3052,6 +3147,7 @@
                 <Pin Id="HLQjPE19Ex4MW7XeNI9LL4" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="MfQjQvEb5eQMRxZd5OK1ns" Name="Messages" Kind="InputPin" />
                 <Pin Id="Bf1aJZpkt59PH9orl9tVu8" Name="Reset" Kind="InputPin" />
+                <Pin Id="I4I4A5UhnGdQL5YaHIxuuB" Name="Output" Kind="OutputPin" />
                 <Pin Id="ET3eIQHhJ0hQMbzrziOHzF" Name="Result" Kind="OutputPin" />
                 <Patch Id="JoVS642uA1DQCqaujwfnCN" ManuallySortedPins="true">
                   <ControlPoint Id="KEJRo7klyqWQGIGACNvJi3" Bounds="1605,1555" />
@@ -3128,6 +3224,7 @@
                 <Pin Id="Eu3SLwKRUp0OL0SbN16Eqz" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="FkVQKFwymR9NhclN756GsB" Name="Messages" Kind="InputPin" />
                 <Pin Id="F2hBDy29QS3OgMWLQatY3X" Name="Reset" Kind="InputPin" />
+                <Pin Id="LLpv1Vhd3M3PihJ1ZrWAEO" Name="Output" Kind="OutputPin" />
                 <Pin Id="BuSPFyWZQ1aL1KzzFz3Iuo" Name="Result" Kind="OutputPin" />
                 <Patch Id="I935WHOdQgtNoGVMhbUZjL" ManuallySortedPins="true">
                   <ControlPoint Id="J8O6lRfKHvCLFH07YbBtSI" Bounds="1904,1551" />
@@ -3269,6 +3366,7 @@
                 <Pin Id="J4PFViO24sIP0WTacDofwC" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="OTb5SUSESCGOveLeMROtmO" Name="Messages" Kind="InputPin" />
                 <Pin Id="DGmlSaaHMk3QDgVZb8vzia" Name="Reset" Kind="InputPin" />
+                <Pin Id="VXVCTwJtnLWOQxgxanPtT0" Name="Output" Kind="OutputPin" />
                 <Pin Id="RnX6X7ns1dDNfZUvP2lI7y" Name="Result" Kind="OutputPin" />
               </Node>
               <Node Bounds="1469,1164,247,266" Id="UMcAzCYC0WxQJwLppwzKSp">
@@ -3280,6 +3378,7 @@
                 <Pin Id="MoXeg6A6IVhOF15izWkbfh" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="DrGXTtri9hOOtkjSqKvkxV" Name="Messages" Kind="InputPin" />
                 <Pin Id="A6gZdnooZHZMcyR4noX7Sx" Name="Reset" Kind="InputPin" />
+                <Pin Id="K8j7mzeJ7htK9rkcEBCLbp" Name="Output" Kind="OutputPin" />
                 <Pin Id="MFpgXkG02iwQWBzV5vVeg7" Name="Result" Kind="OutputPin" />
                 <Patch Id="AoKokANyBY0MLkoS1bBlNK" ManuallySortedPins="true">
                   <ControlPoint Id="RJNnAJSoqijNEPARO9H8Si" Bounds="1522,1172" />
@@ -3452,6 +3551,7 @@
                 <Pin Id="DwOLZAneDQZNYTlm62GXgd" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="Qu39sfZV7HkNKImmYV4jVF" Name="Messages" Kind="InputPin" />
                 <Pin Id="KEPXnxB7cSjQVF91eRj38z" Name="Reset" Kind="InputPin" />
+                <Pin Id="I2F1n94gBt3QSmReypzBZt" Name="Output" Kind="OutputPin" />
                 <Pin Id="UBzpXd7vQ6iLA9dqGdw70v" Name="Result" Kind="OutputPin" />
               </Node>
               <Node Bounds="1775,2381,214,100" Id="I3lCgu4h9TANcyAwZmbMKu">
@@ -3519,6 +3619,7 @@
                 <Pin Id="S86clbplxNUObtdpl67EyH" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="Ql4k2jnekyCMHJMvVqFPld" Name="Messages" Kind="InputPin" />
                 <Pin Id="Ko6VsVj9DEULfKoADsEIUL" Name="Reset" Kind="InputPin" />
+                <Pin Id="Ohf27M7VNLeO09CTXH5Nzt" Name="Output" Kind="OutputPin" />
                 <Pin Id="NR8zI1gYhwBO0Niy9m4rZz" Name="Result" Kind="OutputPin" />
                 <Patch Id="SobhDsYwh5xPQUN6QKIzP5" ManuallySortedPins="true">
                   <Patch Id="KQZ1O4jl7iVL7Ov6NPXNKn" Name="Create" ManuallySortedPins="true" />
@@ -3591,6 +3692,7 @@
                 <Pin Id="L1w5pHawOdCLsAeRtSud3G" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="VlovE3DPzEnOBE5t6DVmCP" Name="Messages" Kind="InputPin" />
                 <Pin Id="TFxRFK9c7cnOEiUPsYmLIO" Name="Reset" Kind="InputPin" />
+                <Pin Id="QXz34C12jUFLLRaRuf9TDr" Name="Output" Kind="OutputPin" />
                 <Pin Id="PIqLv6GWwcOP9KNGMtVRla" Name="Result" Kind="OutputPin" />
                 <Patch Id="UeDfO2c6inWLrTKFj64csO" ManuallySortedPins="true">
                   <Patch Id="NGCNBRMFsaOO637usyZePp" Name="Create" ManuallySortedPins="true" />
@@ -3641,6 +3743,7 @@
                 <Pin Id="GrEJbmn1xFBLS0MyQiLiin" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="CwACqppPIsENPDci7ecnkb" Name="Messages" Kind="InputPin" />
                 <Pin Id="F7tHidYx46HNebH2mHLlnK" Name="Reset" Kind="InputPin" />
+                <Pin Id="OmqtjxQWlFNPz2C5Nx5iTY" Name="Output" Kind="OutputPin" />
                 <Pin Id="RuKweqJMs2RQZjWWu5vbUP" Name="Result" Kind="OutputPin" />
               </Node>
               <ControlPoint Id="VPognoe9ltWOwqczOLIbzb" Bounds="1798,2705" />
@@ -3701,6 +3804,7 @@
                 <Pin Id="UuqEtCz86U5QHp8oV8Jg7y" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="Fa9cPU6KFXXLRnTkFjx0rR" Name="Messages" Kind="InputPin" />
                 <Pin Id="U9PWGoq4C5PL4rwMmb4yiU" Name="Reset" Kind="InputPin" />
+                <Pin Id="RrgipAxa81JPmxxKOJkZCW" Name="Output" Kind="OutputPin" />
                 <Pin Id="VzhylmNDKxNNAmqgnEGJh7" Name="Result" Kind="OutputPin" />
               </Node>
               <ControlPoint Id="ILowSvjSIcbNvL4bXDfJmf" Bounds="329,4255" />
@@ -3724,6 +3828,7 @@
                 <Pin Id="RWohQWvmw99NqVanB56orz" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="GCGXdaj2TIFNHcWlMCHAzY" Name="Messages" Kind="InputPin" />
                 <Pin Id="An4mxngnnvjQNQTNMBoMVH" Name="Reset" Kind="InputPin" />
+                <Pin Id="E78eX4XKGmcNIwn4sKlNJP" Name="Output" Kind="OutputPin" />
                 <Pin Id="DDl6YjOo3RHMzgr6mKFhm6" Name="Result" Kind="OutputPin" />
                 <Patch Id="PwRk4vtsylAL6qku2ZbGkF" ManuallySortedPins="true">
                   <Patch Id="GGdT8ovXzgILTib45A8qTe" Name="Create" ManuallySortedPins="true" />
@@ -3842,6 +3947,7 @@
                 <Pin Id="G9jbMQzg10pQGYotSDZTTB" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="UCyuB5B95MsLQbhNznxTvK" Name="Messages" Kind="InputPin" />
                 <Pin Id="AOprb3iUXc9PR9zjzbmIsX" Name="Reset" Kind="InputPin" />
+                <Pin Id="Ns1sE4TaXOqP3o2L5vxvfN" Name="Output" Kind="OutputPin" />
                 <Pin Id="IneAYx8A6f2N2XMPRfKGNI" Name="Result" Kind="OutputPin" />
                 <Patch Id="BHDOSLzlz3DOpuTLH0PjUl" ManuallySortedPins="true">
                   <Patch Id="B9PS5lR3pXSM1cfVYWibnI" Name="Create" ManuallySortedPins="true" />
@@ -3891,6 +3997,7 @@
                 <Pin Id="Ci4IoKiMPrbPgQQEl3bwey" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="HtIyWBIBrTjQJw5HgVrAg0" Name="Messages" Kind="InputPin" />
                 <Pin Id="Nz9ZVkSreTyObG8m9gM5Xv" Name="Reset" Kind="InputPin" />
+                <Pin Id="R7c9pqsYqRGPi5AHRP81iN" Name="Output" Kind="OutputPin" />
                 <Pin Id="TuW7ckSOhlaL10gIskfYPs" Name="Result" Kind="OutputPin" />
                 <Patch Id="I1zuxqGaXqqP2Kyjc4Fewp" ManuallySortedPins="true">
                   <Patch Id="ShDZCIbQyFZMfHufEacC5L" Name="Create" ManuallySortedPins="true" />
@@ -3987,6 +4094,7 @@
                 <Pin Id="ESRtfW4mVdWNXbrRA7oteK" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="JUib5CqilTPNy7MWpQjjZw" Name="Messages" Kind="InputPin" />
                 <Pin Id="Tlbc6kFBT8lOfEc0NfUo8Q" Name="Reset" Kind="InputPin" />
+                <Pin Id="JMXVQnwdD3wPaL3YnHkWj7" Name="Output" Kind="OutputPin" />
                 <Pin Id="Npo12pOKrl6QaVdV0lSxTG" Name="Result" Kind="OutputPin" />
                 <Patch Id="FVqLLyFByReNxhxGDzUKno" ManuallySortedPins="true">
                   <Patch Id="FB7P1kWldieLEGWCaz8heG" Name="Create" ManuallySortedPins="true" />
@@ -4037,6 +4145,7 @@
                 <Pin Id="InA62sq1x8CNDVReINsf8z" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="FrtEgZDScJlOOnGXStNkHS" Name="Messages" Kind="InputPin" />
                 <Pin Id="T4OOFi1asQ6Njye8sSg9j1" Name="Reset" Kind="InputPin" />
+                <Pin Id="NiYmKxIms9eP01vBWm9BBH" Name="Output" Kind="OutputPin" />
                 <Pin Id="BFb8OmeVqr4MsGGZ38IY9J" Name="Result" Kind="OutputPin" />
                 <Patch Id="JY2xPEbLDyLLxmPLpOaRLd" ManuallySortedPins="true">
                   <Patch Id="H0Sq4aBlu1MQZ8eezeap2R" Name="Create" ManuallySortedPins="true" />
@@ -4131,6 +4240,7 @@
                 <Pin Id="PRDSTqrGtW9PuYkXcHLHwQ" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="Acam8XRMSh4PIXsMUnzl7d" Name="Messages" Kind="InputPin" />
                 <Pin Id="HeksDQBwFYaM2MhYh26MPb" Name="Reset" Kind="InputPin" />
+                <Pin Id="JOgpyckxKkqMJy0wLX5Qvx" Name="Output" Kind="OutputPin" />
                 <Pin Id="LTXFThbRAINPqEyGfkKHmf" Name="Result" Kind="OutputPin" />
                 <Patch Id="DRXralFzAlyPhvypLih6bY" ManuallySortedPins="true">
                   <Patch Id="N6IxriX3usuO9Q7P03ZdXY" Name="Create" ManuallySortedPins="true" />
@@ -4290,6 +4400,7 @@
                 <Pin Id="K4wzWYVogf1LRNBw1wPQQo" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="ItpDiiocKkPNoEOSmXQgHc" Name="Messages" Kind="InputPin" />
                 <Pin Id="EO4JZRWfSMNMk4E1eknuVm" Name="Reset" Kind="InputPin" />
+                <Pin Id="I0RWg2cryP3LaYmSCLJW9j" Name="Output" Kind="OutputPin" />
                 <Pin Id="HX5AgzmOBj4OHc7JRzlXs8" Name="Result" Kind="OutputPin" />
                 <Patch Id="PfGGrEgFtnQNmEcQ41OF4y" ManuallySortedPins="true">
                   <Patch Id="QOnxrOUSIpNPtL6mQu6P1o" Name="Create" ManuallySortedPins="true" />
@@ -4339,6 +4450,7 @@
                 <Pin Id="M1HNBI6TvLXLLV0bRsJE66" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="ICCZ6ddM9KWODht1WzEovx" Name="Messages" Kind="InputPin" />
                 <Pin Id="AjcVDx5jTFuK9pNaLzAF1I" Name="Reset" Kind="InputPin" />
+                <Pin Id="HcPjjlJ4qRNPv3KPvPjyIC" Name="Output" Kind="OutputPin" />
                 <Pin Id="Sgj7ag60ThDPkjpVu7lyJE" Name="Result" Kind="OutputPin" />
                 <Patch Id="B7L7U9quLlSQYsTLi62EfG" ManuallySortedPins="true">
                   <Patch Id="RHUVXYxxQd3PUeRkqaGvc7" Name="Create" ManuallySortedPins="true" />
@@ -4376,6 +4488,7 @@
                 <Pin Id="GP8TzTeuizdPrI0gpgH01B" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="Fkri62995HJPXsrcv53MxW" Name="Messages" Kind="InputPin" />
                 <Pin Id="GlbDsoQ4uT0M8UKnDF2EmM" Name="Reset" Kind="InputPin" />
+                <Pin Id="KMM0VTQOC06OXo9cZcRUtZ" Name="Output" Kind="OutputPin" />
                 <Pin Id="UjvtpQlTLTKLF1f8Bo3wNW" Name="Result" Kind="OutputPin" />
                 <Patch Id="UIiF3TPMLG2LscgSk2yNvj" ManuallySortedPins="true">
                   <ControlPoint Id="LAfTosewwNFP5eluKveXOQ" Bounds="618,2885" />
@@ -4536,6 +4649,7 @@
                 <Pin Id="TM3TnZbqBLeNcRj14T2doz" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="LW4QIqkcgTOPMyxF5wdfxX" Name="Messages" Kind="InputPin" />
                 <Pin Id="DKamqgHybOTMjFdBQ9wcBA" Name="Reset" Kind="InputPin" />
+                <Pin Id="L3ULLUv9ONoMfRYUOGszLi" Name="Output" Kind="OutputPin" />
                 <Pin Id="HZhxsYCNTHMMo0cdL2qlpE" Name="Result" Kind="OutputPin" />
               </Node>
               <ControlPoint Id="QnjJiQRisTANS1qr3fz7NC" Bounds="288,3518" />
@@ -5238,6 +5352,7 @@
                   <Pin Id="DAZstZxKXdCO1sDGLml6W7" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="L7J3ka66wWcLH9oVEDFarm" Name="Dialog If Document Changed" Kind="InputPin" IsHidden="true" />
                   <Pin Id="VrJBu6PnEsRPhe8HFb2vrf" Name="Input" Kind="InputPin" />
+                  <Pin Id="BC6c3OljvaMMvlqCa4mRYW" Name="Title" Kind="InputPin" />
                   <Pin Id="Q1U2B2DxwN6OyuWphQYIg8" Name="Color" Kind="InputPin" DefaultValue="0.08627451, 0.08627451, 0.08627451, 1" />
                   <Pin Id="Po83XcpfoeOPPhalBGjY9c" Name="Clear" Kind="InputPin" />
                   <Pin Id="HjLbMKlDHTaNEu2sluMvEh" Name="Space" Kind="InputPin" />
@@ -10516,7 +10631,7 @@
                   </p:NodeReference>
                   <Patch Id="Mq8n8Q39dogLgfWFoOgFjN">
                     <Canvas Id="J0ei1Nwm1MYL8Ty3Fh69VA" CanvasType="Group">
-                      <Node Bounds="399,178,622,2573" Id="LQpdBsrfsv3L9oUO99SiM6">
+                      <Node Bounds="402,178,622,2573" Id="LQpdBsrfsv3L9oUO99SiM6">
                         <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                           <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="MainMenuBar" />
@@ -10573,6 +10688,7 @@
                                 <Pin Id="PEC9hpG1eByPCdlb7w9rKJ" Name="File Name" Kind="InputPin" DefaultValue="explorer.exe" />
                                 <Pin Id="VjBWLHmtCabPmLu99X9HzM" Name="Arguments" Kind="InputPin" />
                                 <Pin Id="KcEvrtFyOsBL09x0Kv3DBB" Name="Working Directory" Kind="InputPin" />
+                                <Pin Id="L2jl9SfDvyTLHBQeMZJRcP" Name="Environment Path Variable" Kind="InputPin" IsHidden="true" />
                                 <Pin Id="VwPyVj7TeT8Nv8ZypShOTd" Name="Execute" Kind="InputPin" />
                                 <Pin Id="VrDnYknwDNoNTc381pI00S" Name="State Output" Kind="StateOutputPin" />
                                 <Pin Id="FaWGt8xpNSqNZtz6qHeOz3" Name="Output" Kind="OutputPin" />
@@ -10666,7 +10782,7 @@
                               <Choice Kind="TypeFlag" Name="String" />
                             </p:TypeAnnotation>
                           </Pad>
-                          <Node Bounds="442,656,354,902" Id="PqbVO8yjoAbOaFXv1O8W1l">
+                          <Node Bounds="445,656,354,1007" Id="PqbVO8yjoAbOaFXv1O8W1l">
                             <p:NodeReference LastCategoryFullName="ImGui.Widgets.Immediate" LastDependency="VL.ImGui.vl">
                               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                               <Choice Kind="ProcessAppFlag" Name="Menu" />
@@ -10680,7 +10796,7 @@
                             <Pin Id="GaY3CjCJADXLlEzckSDd6i" Name="Context" Kind="OutputPin" />
                             <Patch Id="ItutXmlUqvONh2UHZwRIi9" ManuallySortedPins="true">
                               <Patch Id="UkldBGFHcLTOQ4lSQUN3ZJ" Name="Create" ManuallySortedPins="true" />
-                              <Patch Id="N6i4b14HZKOMKPCbLuWs1X" Name="Update" ParticipatingElements="VQ4yysmdrAnMypUoqtzoYE,V3qcyQ7Y5pKLaopZL5oxBT,JKQD01ULpPyN83aED5rN74,JF7o5iYZMzFMPQcHmX5F0t,C0Np9VbNsh2LfA7cj402wa,Pmp9kSZXZwxOxi7G66i690,Ccun4dqU1W8OvOXRcdOKEp,GYZaAh655K9L4TIb43IKvX,C7ihyZ0CxzWOHaJXYFuOvC,UmHvdS3DIeGMnBPROHL9H4" ManuallySortedPins="true" />
+                              <Patch Id="N6i4b14HZKOMKPCbLuWs1X" Name="Update" ParticipatingElements="VQ4yysmdrAnMypUoqtzoYE,V3qcyQ7Y5pKLaopZL5oxBT,JKQD01ULpPyN83aED5rN74,C0Np9VbNsh2LfA7cj402wa,Pmp9kSZXZwxOxi7G66i690,Ccun4dqU1W8OvOXRcdOKEp,GYZaAh655K9L4TIb43IKvX,C7ihyZ0CxzWOHaJXYFuOvC,UmHvdS3DIeGMnBPROHL9H4,JRnpOWTOvfKPXsI7MeceEd" ManuallySortedPins="true" />
                               <Node Bounds="492,702,145,19" Id="PgkAupvIzKAQHB1GCEjaWG">
                                 <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -10747,7 +10863,7 @@
                                   <Choice Kind="TypeFlag" Name="String" />
                                 </p:TypeAnnotation>
                               </Pad>
-                              <Node Bounds="492,1043,145,19" Id="FxYwkTRR5d0PABCliih4CU">
+                              <Node Bounds="492,1148,145,19" Id="FxYwkTRR5d0PABCliih4CU">
                                 <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="ProcessNode" Name="MenuItem" />
@@ -10764,12 +10880,12 @@
                                 <Pin Id="MeMynhhXHmCMGzc2WB2xh0" Name="Bang" Kind="OutputPin" />
                                 <Pin Id="BVaJgEolCpBMMeJM8kkZBG" Name="Is Selected" Kind="OutputPin" />
                               </Node>
-                              <Pad Id="CiLwaFqcl2FPusQWoOFlCL" Comment="Label" Bounds="534,1028,152,15" ShowValueBox="true" isIOBox="true" Value="Kill all vvvv instances">
+                              <Pad Id="CiLwaFqcl2FPusQWoOFlCL" Comment="Label" Bounds="534,1133,152,15" ShowValueBox="true" isIOBox="true" Value="Kill all vvvv instances">
                                 <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                                   <Choice Kind="TypeFlag" Name="String" />
                                 </p:TypeAnnotation>
                               </Pad>
-                              <Node Bounds="492,1136,145,19" Id="MQxKgJzaGcoPUWSl9pgB44">
+                              <Node Bounds="492,1241,145,19" Id="MQxKgJzaGcoPUWSl9pgB44">
                                 <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="ProcessNode" Name="MenuItem" />
@@ -10786,12 +10902,12 @@
                                 <Pin Id="MH3PAZQKVxBMBTSnGWDPst" Name="Bang" Kind="OutputPin" />
                                 <Pin Id="UBbdBLXre3AQHjvnUhc5GU" Name="Is Selected" Kind="OutputPin" />
                               </Node>
-                              <Pad Id="AeAnkjYy2u7Oj2j3UXkGpD" Comment="Label" Bounds="534,1121,152,15" ShowValueBox="true" isIOBox="true" Value="Explore selected version">
+                              <Pad Id="AeAnkjYy2u7Oj2j3UXkGpD" Comment="Label" Bounds="534,1226,152,15" ShowValueBox="true" isIOBox="true" Value="Explore selected version">
                                 <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                                   <Choice Kind="TypeFlag" Name="String" />
                                 </p:TypeAnnotation>
                               </Pad>
-                              <Node Bounds="492,1359,145,19" Id="EW968D5z0H1MAtQTgBsgYy">
+                              <Node Bounds="495,1464,145,19" Id="EW968D5z0H1MAtQTgBsgYy">
                                 <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="ProcessNode" Name="MenuItem" />
@@ -10808,7 +10924,7 @@
                                 <Pin Id="VCXSpAlZLmZP4sh6OtQ8s5" Name="Bang" Kind="OutputPin" />
                                 <Pin Id="Fi1V4VlR7bsQcmt3Y6Z9BK" Name="Is Selected" Kind="OutputPin" />
                               </Node>
-                              <Pad Id="DJ1HY6triYzPlg4AMADpLz" Comment="Label" Bounds="534,1344,204,15" ShowValueBox="true" isIOBox="true" Value="Look for vvvv updates">
+                              <Pad Id="DJ1HY6triYzPlg4AMADpLz" Comment="Label" Bounds="537,1449,204,15" ShowValueBox="true" isIOBox="true" Value="Look for vvvv updates">
                                 <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                                   <Choice Kind="TypeFlag" Name="String" />
                                 </p:TypeAnnotation>
@@ -10841,7 +10957,7 @@
                                 <Pin Id="TEFkUF1xPL9LhcvtPVRtyX" Name="Output" Kind="StateOutputPin" />
                                 <Pin Id="LDUqDPFtORrLaClCJi6tKj" Name="Apply" Kind="InputPin" />
                               </Node>
-                              <Node Bounds="475,1081,72,26" Id="KbrR0Et8bxON0jzoeRtcpU">
+                              <Node Bounds="475,1186,72,26" Id="KbrR0Et8bxON0jzoeRtcpU">
                                 <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -10854,7 +10970,7 @@
                                 <Pin Id="RSCRczRKME7N7tGpUM9aZy" Name="Apply" Kind="InputPin" />
                                 <Pin Id="StOgxhNEJNqLLzhn5bXo7s" Name="Output" Kind="OutputPin" />
                               </Node>
-                              <Node Bounds="458,1179,137,26" Id="RsJtmzyuq24NEqVZ2u8W7T">
+                              <Node Bounds="458,1284,137,26" Id="RsJtmzyuq24NEqVZ2u8W7T">
                                 <p:NodeReference LastCategoryFullName="Main.Runtime.LaunchTabRuntime" LastDependency="GammaLauncher.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="OperationCallFlag" Name="ShowFolderOfSelectedVvvv" />
@@ -10863,7 +10979,7 @@
                                 <Pin Id="BV0R5jODUP0PpIe65GOKuT" Name="Output" Kind="StateOutputPin" />
                                 <Pin Id="E6ZW4nNhz38PUV1lv0iNav" Name="Apply" Kind="InputPin" />
                               </Node>
-                              <Node Bounds="462,1415,126,26" Id="QMFla2AHa5ONDHRtjlMciw">
+                              <Node Bounds="465,1520,126,26" Id="QMFla2AHa5ONDHRtjlMciw">
                                 <p:NodeReference LastCategoryFullName="Main.Runtime.UpdatesTabRuntime" LastDependency="GammaLauncher.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <CategoryReference Kind="ClassType" Name="UpdatesTabRuntime" />
@@ -10873,7 +10989,7 @@
                                 <Pin Id="Nw0mnMbOxYyLdCeMGQDba5" Name="Output" Kind="StateOutputPin" />
                                 <Pin Id="S3rBQbAbVsHNWDZGQa6gjq" Name="Apply" Kind="InputPin" />
                               </Node>
-                              <Node Bounds="493,1257,145,19" Id="TwF8PpQNAMqPbMTm8s5ckQ">
+                              <Node Bounds="496,1362,145,19" Id="TwF8PpQNAMqPbMTm8s5ckQ">
                                 <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="ProcessNode" Name="MenuItem" />
@@ -10890,12 +11006,12 @@
                                 <Pin Id="EEpxv5IlYm7QDEOa7crtkn" Name="Bang" Kind="OutputPin" />
                                 <Pin Id="Sc36qnTgbEWMkyGuNb5Rwm" Name="Is Selected" Kind="OutputPin" />
                               </Node>
-                              <Pad Id="O4aGYbPkDobOxnMO4SEX5O" Comment="Label" Bounds="534,1235,35,15" ShowValueBox="true" isIOBox="true" Value="Uninstall selected version">
+                              <Pad Id="O4aGYbPkDobOxnMO4SEX5O" Comment="Label" Bounds="537,1340,35,15" ShowValueBox="true" isIOBox="true" Value="Uninstall selected version">
                                 <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                                   <Choice Kind="TypeFlag" Name="String" />
                                 </p:TypeAnnotation>
                               </Pad>
-                              <Node Bounds="455,1298,128,26" Id="JkHYYpGJANxLRCnimfF9Sh">
+                              <Node Bounds="458,1403,128,26" Id="JkHYYpGJANxLRCnimfF9Sh">
                                 <p:NodeReference LastCategoryFullName="Main.Runtime.LaunchTabRuntime" LastDependency="GammaLauncher.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="OperationCallFlag" Name="UninstallSelectedVersion" />
@@ -10904,7 +11020,7 @@
                                 <Pin Id="R5jy2kYRENUNJnbc0Hjk3Z" Name="Output" Kind="StateOutputPin" />
                                 <Pin Id="HW94xa2rAydL7nqIUG1eBx" Name="Apply" Kind="InputPin" />
                               </Node>
-                              <Node Bounds="491,1471,145,19" Id="Q9rqOruacnyN8dolaMT4dN">
+                              <Node Bounds="494,1576,145,19" Id="Q9rqOruacnyN8dolaMT4dN">
                                 <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="ProcessNode" Name="MenuItem" />
@@ -10921,12 +11037,12 @@
                                 <Pin Id="CAQMuna9BxVOz9lKY4dZI2" Name="Bang" Kind="OutputPin" />
                                 <Pin Id="SySHUeMeC0dN5EIfB9UlrJ" Name="Is Selected" Kind="OutputPin" />
                               </Node>
-                              <Pad Id="It6Mrl8I2gVO46TNSBbFuX" Comment="Label" Bounds="548,1445,35,15" ShowValueBox="true" isIOBox="true" Value="Rescan vvvv installations">
+                              <Pad Id="It6Mrl8I2gVO46TNSBbFuX" Comment="Label" Bounds="536,1565,139,15" ShowValueBox="true" isIOBox="true" Value="Rescan vvvv installations">
                                 <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                                   <Choice Kind="TypeFlag" Name="String" />
                                 </p:TypeAnnotation>
                               </Pad>
-                              <Node Bounds="454,1512,120,26" Id="PQm8gjQzEEwQcOxn5jYToi">
+                              <Node Bounds="457,1617,120,26" Id="PQm8gjQzEEwQcOxn5jYToi">
                                 <p:NodeReference LastCategoryFullName="Main.Runtime.LaunchTabRuntime" LastDependency="GammaLauncher.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="OperationCallFlag" Name="ScanLocalVvvvVersions" />
@@ -10936,6 +11052,37 @@
                                 <Pin Id="NWmqooYKt3WQNkmmok6n9K" Name="Apply" Kind="InputPin" />
                               </Node>
                               <Patch Id="FFlgeQB4hD0L5VFop0Z558" Name="Dispose" />
+                              <Node Bounds="492,1034,145,19" Id="VK7OFifhpsYLj5DsYDWmzn">
+                                <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
+                                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                  <Choice Kind="ProcessNode" Name="MenuItem" />
+                                </p:NodeReference>
+                                <Pin Id="E1zEwgryyiqQISpuJ3gkdM" Name="Context" Kind="InputPin" />
+                                <Pin Id="FUP5PFxiVuuN4G69xdTdtm" Name="Channel" Kind="InputPin" />
+                                <Pin Id="QC15GlMjyF6LcwU62KKGuj" Name="Label" Kind="InputPin" />
+                                <Pin Id="G5NcmzsmjU3LpWRE55MXfd" Name="Shortcut" Kind="InputPin" />
+                                <Pin Id="BB2iszXMsQMMHSE8Bxuuod" Name="Enabled" Kind="InputPin" />
+                                <Pin Id="Ql68xw6egs2NaTJl0KRRxI" Name="Selectable" Kind="InputPin" />
+                                <Pin Id="ABR2S7GKFQeLTu0rBRUIpv" Name="Selected Channel" Kind="InputPin" />
+                                <Pin Id="PF52pMUBZ9fOMTk2pSyOCm" Name="Style" Kind="InputPin" />
+                                <Pin Id="USefSlNMlccMzfsnaI5NbE" Name="Context" Kind="OutputPin" />
+                                <Pin Id="IYh5eWgcUCfLMy9JW8Gnus" Name="Bang" Kind="OutputPin" />
+                                <Pin Id="TmSYaKvZK0mLrsNMpb01nv" Name="Is Selected" Kind="OutputPin" />
+                              </Node>
+                              <Pad Id="D4amNPTEtp5QVab7KI6pzY" Comment="Label" Bounds="534,1019,152,15" ShowValueBox="true" isIOBox="true" Value="Show vvvv package cache">
+                                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                                  <Choice Kind="TypeFlag" Name="String" />
+                                </p:TypeAnnotation>
+                              </Pad>
+                              <Node Bounds="459,1070,134,26" Id="Q0kQGx8R4odO2M58OqDkhJ">
+                                <p:NodeReference LastCategoryFullName="Main.Runtime.LaunchTabRuntime" LastDependency="GammaLauncher.vl">
+                                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                  <Choice Kind="OperationCallFlag" Name="ShowVVVVPackageCache" />
+                                </p:NodeReference>
+                                <Pin Id="Oc4jlL47f9BLFImW61BBIX" Name="Input" Kind="StateInputPin" />
+                                <Pin Id="NGUbZ2FQ3bYQQIilm3Sgnx" Name="Output" Kind="StateOutputPin" />
+                                <Pin Id="NVC1WtLBPlPPa0usqqmCvM" Name="Apply" Kind="InputPin" />
+                              </Node>
                             </Patch>
                           </Node>
                           <Pad Id="L0c25gVlEwsQYxtOz7dQps" Comment="Label" Bounds="550,631,42,15" ShowValueBox="true" isIOBox="true" Value="Edit">
@@ -10943,7 +11090,7 @@
                               <Choice Kind="TypeFlag" Name="String" />
                             </p:TypeAnnotation>
                           </Pad>
-                          <Node Bounds="443,2217,169,514" Id="OlRhaMX9Vo2NaIgl58pABj">
+                          <Node Bounds="443,2217,194,514" Id="OlRhaMX9Vo2NaIgl58pABj">
                             <p:NodeReference LastCategoryFullName="ImGui.Widgets.Immediate" LastDependency="VL.ImGui.vl">
                               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                               <Choice Kind="ProcessAppFlag" Name="Menu" />
@@ -10997,7 +11144,7 @@
                                 <Pin Id="TzrSC1MJnBcM6g35HKQ4gG" Name="Bang" Kind="OutputPin" />
                                 <Pin Id="MVovfRdKUWHMY07sSLJSm5" Name="Is Selected" Kind="OutputPin" />
                               </Node>
-                              <Pad Id="SCYYUy06PLxPsArDtRvZjI" Comment="Label" Bounds="497,2245,39,15" ShowValueBox="true" isIOBox="true" Value="Changelog">
+                              <Pad Id="SCYYUy06PLxPsArDtRvZjI" Comment="Label" Bounds="497,2245,79,21" ShowValueBox="true" isIOBox="true" Value="Changelog">
                                 <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                                   <Choice Kind="TypeFlag" Name="String" />
                                 </p:TypeAnnotation>
@@ -11019,7 +11166,7 @@
                                 <Pin Id="Sy4SCnrbkuUQZr9tigeZHB" Name="Bang" Kind="OutputPin" />
                                 <Pin Id="ODCTdzQR8rQMZsdMs1thif" Name="Is Selected" Kind="OutputPin" />
                               </Node>
-                              <Pad Id="EjJOHjZNmySPwdriVZHZkQ" Comment="Label" Bounds="497,2360,39,15" ShowValueBox="true" isIOBox="true" Value="Source code">
+                              <Pad Id="EjJOHjZNmySPwdriVZHZkQ" Comment="Label" Bounds="497,2360,82,16" ShowValueBox="true" isIOBox="true" Value="Source code">
                                 <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                                   <Choice Kind="TypeFlag" Name="String" />
                                 </p:TypeAnnotation>
@@ -11058,7 +11205,7 @@
                               <Patch Id="Owt75142PVKLfWNcbE6Vtm" Name="Dispose" />
                             </Patch>
                           </Node>
-                          <Pad Id="GxFzDGEaa1WOeL6Yph7WHI" Comment="Label" Bounds="482,2194,36,15" ShowValueBox="true" isIOBox="true" Value="Help">
+                          <Pad Id="GxFzDGEaa1WOeL6Yph7WHI" Comment="Label" Bounds="507,2200,36,15" ShowValueBox="true" isIOBox="true" Value="Help">
                             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="TypeFlag" Name="String" />
                             </p:TypeAnnotation>
@@ -11207,7 +11354,7 @@
                             <Pin Id="N3DqgsU1WkiNPMAPlHsK51" Name="Output" Kind="OutputPin" />
                             <Pin Id="LytFLrI0dAPQJUqoZMulZr" Name="Value" Kind="OutputPin" />
                           </Node>
-                          <Node Bounds="440,1667,169,127" Id="JfBLsmmLM7IPq5Sjmv61PH">
+                          <Node Bounds="445,1763,169,173" Id="JfBLsmmLM7IPq5Sjmv61PH">
                             <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                               <CategoryReference Kind="Category" Name="Widgets" NeedsToBeDirectParent="true" />
@@ -11216,7 +11363,7 @@
                             <Patch Id="A5XM3CSa68DMsD77GGrvSc" ManuallySortedPins="true">
                               <Patch Id="Qtfnh4kLjZCNwWvNOtGipc" Name="Create" ManuallySortedPins="true" />
                               <Patch Id="EEinecaLrkeQaMLWcvFZw7" Name="Update" ManuallySortedPins="true" />
-                              <Node Bounds="452,1690,145,19" Id="Qmq1n33P2VBLFjxENp8KFA">
+                              <Node Bounds="457,1850,145,19" Id="Qmq1n33P2VBLFjxENp8KFA">
                                 <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="ProcessNode" Name="MenuItem" />
@@ -11233,7 +11380,7 @@
                                 <Pin Id="NMo9Zuwci4MObnyM6iGb7K" Name="Bang" Kind="OutputPin" />
                                 <Pin Id="UCA5k1oLtnTM4mKh9DzdBl" Name="Is Selected" Kind="OutputPin" />
                               </Node>
-                              <Node Bounds="494,1748,72,26" Id="AZNFRAqPKA9MXhuX18VWEV">
+                              <Node Bounds="460,1890,72,26" Id="AZNFRAqPKA9MXhuX18VWEV">
                                 <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <CategoryReference Kind="ClassType" Name="Channel" NeedsToBeDirectParent="true" />
@@ -11282,7 +11429,7 @@
                         <Pin Id="QCmUEtYgkcVOAlFUkT7D7O" Name="Output" Kind="StateOutputPin" />
                         <Pin Id="GILVqAAUt6nNSSJeEeG1h9" Name="Value" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="344,1370,123,26" Id="BqfARDxC0ngMWa3NobP2ts">
+                      <Node Bounds="344,1475,123,26" Id="BqfARDxC0ngMWa3NobP2ts">
                         <p:NodeReference LastCategoryFullName="Main.Runtime.ApplicationRuntime" LastDependency="GammaLauncher.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <CategoryReference Kind="ClassType" Name="ApplicationRuntime" />
@@ -11393,7 +11540,6 @@
                     <Link Id="I79s6eplE6KMvsdU2yBMtE" Ids="A003waohdQ7LOsGETc7tOG,G1AKL6Wp3DhQLHpyRnVTHS" />
                     <Link Id="JKQD01ULpPyN83aED5rN74" Ids="AHeXjyoitheLd7iHwuMKhg,DhKBjgFa9fLO1FTqPTDSX5" />
                     <Link Id="SoAVORWot8RMQsiwMFP9OP" Ids="CiLwaFqcl2FPusQWoOFlCL,Ahzd2jMwq4uMV2cGTVm9yW" />
-                    <Link Id="JF7o5iYZMzFMPQcHmX5F0t" Ids="K5VDk2mMN7ELPOHGhdjRYO,ThcWivz9XMjO0sBOmYQu8n" />
                     <Link Id="VXLvdkxrkbuNzLqwRmtjbN" Ids="L0c25gVlEwsQYxtOz7dQps,FL1GBRSpUEINyDeBtAf3XZ" />
                     <Link Id="UY2nVXVYZF6M0d7hBqulGz" Ids="L6iiVuMghrXM5TZeaITZum,GCRqms9exTNQGP1jVrwKyj" />
                     <Link Id="AlnHURZhPpxPuH1OFKYFWf" Ids="GxFzDGEaa1WOeL6Yph7WHI,NenndeZ1YMeOn8t3ZORgrp" />
@@ -11424,7 +11570,6 @@
                     <Link Id="I6CvHPxQrLCNCbeE9K0mIz" Ids="NyZ150Gv0R5Mr1N4zmkD3g,Bd8kPW19BonNl59Fdgc5IX" />
                     <Link Id="GK6leMZwdqcMueAMjNqRGl" Ids="RFVrt50ppEbPJy7WBCAd2V,NyZ150Gv0R5Mr1N4zmkD3g" IsHidden="true" />
                     <Link Id="NvFUgfGNta3PqwicZTgALb" Ids="MH3PAZQKVxBMBTSnGWDPst,E6ZW4nNhz38PUV1lv0iNav" />
-                    <Link Id="Ein2NfhJRotODO1u7zKiE1" Ids="TEFkUF1xPL9LhcvtPVRtyX,PpQrJN3pNgTMKtzb2mPm8v" />
                     <Link Id="H2549REbIfXOlAB1UdsQwo" Ids="VCXSpAlZLmZP4sh6OtQ8s5,S3rBQbAbVsHNWDZGQa6gjq" />
                     <Link Id="OH8mASrdOWyN4u7FbCJDoN" Ids="Ipd3ng3ea2MMc2v0BxKVTn,TtvYgwdfzbbOKvDHhuFZ7T" />
                     <Link Id="IHSuaxAh2VJMZSaRgbDorx" Ids="Bmc7Tw0lvl7O16EYUQjkrd,VFCmDi3MI8SLvt8hm4YgQk" IsHidden="true" />
@@ -11503,6 +11648,12 @@
                       </Pin>
                       <Pin Id="CT9X5YjFoYKPCw2OeyCIp4" Name="Context" Kind="OutputPin" Bounds="344,646" />
                     </Patch>
+                    <Link Id="Qz5eW9KfdJZMU7YzQgF3wO" Ids="D4amNPTEtp5QVab7KI6pzY,QC15GlMjyF6LcwU62KKGuj" />
+                    <Link Id="Tamv5ejeyFMNOmjKZnY9W7" Ids="AHeXjyoitheLd7iHwuMKhg,E1zEwgryyiqQISpuJ3gkdM" />
+                    <Link Id="EQyVBcVCRCGLJ3OK7QQBA9" Ids="IYh5eWgcUCfLMy9JW8Gnus,NVC1WtLBPlPPa0usqqmCvM" />
+                    <Link Id="UnkFme9562ANwvNkqdSXTq" Ids="GWRniMOwGRuLVXket9fxAb,Oc4jlL47f9BLFImW61BBIX" />
+                    <Link Id="JRnpOWTOvfKPXsI7MeceEd" Ids="USefSlNMlccMzfsnaI5NbE,ThcWivz9XMjO0sBOmYQu8n" />
+                    <Link Id="VR1HwKIXsW7OMeo0Tiqg59" Ids="NGUbZ2FQ3bYQQIilm3Sgnx,PpQrJN3pNgTMKtzb2mPm8v" />
                   </Patch>
                 </Node>
                 <Node Bounds="459,604,105,19" Id="D0CpyGCX0snPKt1QQ1WfUk">
@@ -11670,6 +11821,7 @@
                   <Pin Id="L92XPAfdPPoLK4vH2Q0HNv" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="ESCuDyKHZ50MuYY2OJjTs3" Name="Messages" Kind="InputPin" />
                   <Pin Id="MjzszFn7XqDOUFaxBSyEIp" Name="Reset" Kind="InputPin" />
+                  <Pin Id="SKqPr3sQsQfOFfUdLejwYS" Name="Output" Kind="OutputPin" />
                   <Pin Id="IO7rcuTLc63MnzUuV5Y8Ib" Name="Result" Kind="OutputPin" />
                 </Node>
                 <ControlPoint Id="GQKcuzWv7FgMt6H5AbwIL8" Bounds="148,1047" />
@@ -11784,6 +11936,7 @@
                   <Pin Id="MH0NVR3y3D4Mw18VadTTsj" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="QKlBRefSPLGNKgqhp9zoSS" Name="Messages" Kind="InputPin" />
                   <Pin Id="BWNH6O0ngayOuzjXDMHPuS" Name="Reset" Kind="InputPin" />
+                  <Pin Id="BgSzGQruNDgPK2VyrOTqO2" Name="Output" Kind="OutputPin" />
                   <Pin Id="AchN78EBxCQLGzwswHzXh2" Name="Result" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="750,579,63,26" Id="UNd8JTkdOw8QZ1tpAfK7OB">
@@ -11832,6 +11985,7 @@
                   <Pin Id="P7MlPxEXnYwNguArxSYBVf" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="LcuWtyIrrWmPCDfSmEJhJA" Name="Messages" Kind="InputPin" />
                   <Pin Id="BWDtytaLOacP5fuVxdxbUG" Name="Reset" Kind="InputPin" />
+                  <Pin Id="EWEIifGYGxVLjBcnBRNa17" Name="Output" Kind="OutputPin" />
                   <Pin Id="G1r9z5Pr6jxOwsMrGAMMpq" Name="Result" Kind="OutputPin" />
                 </Node>
                 <Pad Id="VfEqhMfyBAcLDrR1Vh3c8Z" SlotId="MYAsvnuKGDCPymxDIzraML" Bounds="864,500" />
@@ -12278,6 +12432,7 @@
                                 <Pin Id="Mc3b2czKxloLAZdl7TcreO" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                 <Pin Id="NVIcKM36lU8MwSqXckY7yy" Name="Trigger" Kind="InputPin" />
                                 <Pin Id="MqM8E7nEaUfMLs1rOhbAQG" Name="Abort" Kind="InputPin" />
+                                <Pin Id="LcM4fLD9pctObFhsT8GXpP" Name="Output" Kind="OutputPin" />
                                 <Pin Id="HMQ49KK8SJRODNOz1dcgke" Name="Result" Kind="OutputPin" />
                                 <Pin Id="QMCFAQ1cUUyL8y0efSEPdq" Name="In Progress" Kind="OutputPin" />
                                 <Patch Id="MMIf7HfOrsYOGKsNxYRCkQ" ManuallySortedPins="true">
@@ -12906,6 +13061,7 @@
                   <Pin Id="R8D2Vo3wfz8NVLCuEHZZAL" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="Pilkv6bClCTN5wXjQXNMQs" Name="Messages" Kind="InputPin" />
                   <Pin Id="IscXSlJDJJlQdOkUsrHUXe" Name="Reset" Kind="InputPin" />
+                  <Pin Id="QriLesfzwsMOA8HxVsuWlH" Name="Output" Kind="OutputPin" />
                   <Pin Id="NILKy5L3ApIMqoHUfFS7j5" Name="Result" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="131,690,68,26" Id="Hfdl21Ix7IZMMeBlgBFxNZ">
@@ -12996,6 +13152,7 @@
                   <Pin Id="CZKealBlUuSMdfQz88Em8U" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="RwnceLxxjMxPcMlofvGwzx" Name="Messages" Kind="InputPin" />
                   <Pin Id="EDRgADZeyujMyBqgBp9Oqz" Name="Reset" Kind="InputPin" />
+                  <Pin Id="DS0WLrlytKBLR4RPC7kbuR" Name="Output" Kind="OutputPin" />
                   <Pin Id="HbufhULcT5cMC1toFnJYHt" Name="Result" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="594,119,60,26" Id="AtiLOcOJgLNMfjwb22tIwA">
@@ -13196,6 +13353,7 @@
                   <Pin Id="Dry12DvUEiLQByMdNOjjPK" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="EGCzPmX2L5LQPlVryf7JMj" Name="Messages" Kind="InputPin" />
                   <Pin Id="VZWlSkViqkmLsO4Z44rD4O" Name="Reset" Kind="InputPin" />
+                  <Pin Id="SMDJEaF6IOCMmcor6FmXl6" Name="Output" Kind="OutputPin" />
                   <Pin Id="TYzah1WwQ72Pi4JUHTS1Fn" Name="Result" Kind="OutputPin" />
                 </Node>
                 <ControlPoint Id="NCOmkF7KDB3MzK14xNsvaG" Bounds="1060,674" />
@@ -13209,6 +13367,7 @@
                   <Pin Id="O5O9J5ieDq4LD9pYHFLhbZ" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="QrQJgQc2ug6LxVug3hKsrW" Name="Messages" Kind="InputPin" />
                   <Pin Id="UyJnSCbkKPyQPOTbEAmZ81" Name="Reset" Kind="InputPin" />
+                  <Pin Id="KUq4xvltVC0P5d1URvUccx" Name="Output" Kind="OutputPin" />
                   <Pin Id="MxWlKq1BLx8MZKK9c8WRMp" Name="Result" Kind="OutputPin" />
                   <Patch Id="PUimhiwGJFlNSoVRiZMRe1" ManuallySortedPins="true">
                     <ControlPoint Id="GtnEpYQvn9dMlyJc34mEkp" Bounds="1229,753" />
@@ -13478,7 +13637,6 @@
                     <Choice Kind="ProcessAppFlag" Name="DefaultDarkTheme" />
                   </p:NodeReference>
                   <Pin Id="N1OB2LAc8rqP1j33V3NJe6" Name="Node Context" Kind="InputPin" IsHidden="true" />
-                  <Pin Id="HXQcDQcCSncNzmoLpgLiCo" Name="Update" Kind="ApplyPin" />
                   <Pin Id="DVdZqogjf1TLP92mgjFse0" Name="Output" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="291,423,71,19" Id="LlNzZFXaFKNMKV2iAtuRrX">
@@ -13756,6 +13914,7 @@
                   <Pin Id="F634dYferJqMzb203ByO6l" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="NOkr93ZTskGLAptrHHgiMA" Name="Messages" Kind="InputPin" />
                   <Pin Id="T6KD2HFUctbPNhM79xsawm" Name="Reset" Kind="InputPin" />
+                  <Pin Id="E4WhwQ5kMNDLzkCuWCwUNX" Name="Output" Kind="OutputPin" />
                   <Pin Id="QODtz0Ai5oFP3TEc5LIMt8" Name="Result" Kind="OutputPin" />
                   <Patch Id="VIVYaq7ATlZNLJDrJnMhfN" ManuallySortedPins="true">
                     <Patch Id="JQZmv0KxXTALdzTJN8JfEq" Name="Create" ManuallySortedPins="true" />
@@ -14513,6 +14672,7 @@
                     <Choice Kind="ProcessAppFlag" Name="Console" />
                   </p:NodeReference>
                   <Pin Id="HcJMshFjVUCPVJZf15qEf3" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="D7xnsT7x2VUMhnU3JFoho6" Name="State Output" Kind="OutputPin" />
                   <Pin Id="FnkIJt1dOIeM9PoxD9lCvH" Name="Output" Kind="OutputPin" />
                   <Pin Id="LYSKtHbjRtpPCwmwAqcLoQ" Name="Mouse" Kind="OutputPin" />
                   <Pin Id="RZj5cMsGxcpLT3HVdSadgt" Name="Keyboard" Kind="OutputPin" />
@@ -15118,6 +15278,7 @@
                   <Pin Id="FsA4jdelDzOOsqMLUGX2kJ" Name="File Name" Kind="InputPin" DefaultValue="explorer.exe" />
                   <Pin Id="Lu5goPsceshPmJcvmvqOCP" Name="Arguments" Kind="InputPin" />
                   <Pin Id="LKarxutXFAeN0x8WqJ1tJr" Name="Working Directory" Kind="InputPin" />
+                  <Pin Id="IynPYit1C5QNprCw7MQyc0" Name="Environment Path Variable" Kind="InputPin" IsHidden="true" />
                   <Pin Id="T4FjSvX0l4yO5pM8vkLb0q" Name="Execute" Kind="InputPin" />
                   <Pin Id="GXXy3wd6QyuNXBW3uwDOIO" Name="State Output" Kind="StateOutputPin" />
                   <Pin Id="GJjqvNmDnylMKJmUQtqA0t" Name="Output" Kind="OutputPin" />
@@ -16686,6 +16847,7 @@
                 <Pin Id="PaHI1Vou0kOLymKkRQFuX1" Name="File Name" Kind="InputPin" />
                 <Pin Id="RZ60DygcMKGNAE3SBYPPJc" Name="Arguments" Kind="InputPin" />
                 <Pin Id="B5vr2Zko5rgMDpXTGtT8E6" Name="Working Directory" Kind="InputPin" />
+                <Pin Id="Pi8HuePGEJPPr0DrqbVm4x" Name="Environment Path Variable" Kind="InputPin" IsHidden="true" />
                 <Pin Id="JLmU4YzWSe7NF8ZHgQMS0L" Name="Execute" Kind="InputPin" />
                 <Pin Id="FaieA9io72PQPvje1I0Vrn" Name="State Output" Kind="OutputPin" />
                 <Pin Id="JILeWcF6iVqP0i9b3ajZ7c" Name="Output" Kind="OutputPin" />
@@ -16910,6 +17072,7 @@
                 <Pin Id="DBsaA6OYxGuLLBi7l03wG2" Name="Initial Directory" Kind="InputPin" />
                 <Pin Id="KWm6cQZyWtNP0WG3o7IXPf" Name="Show New Folder Button" Kind="InputPin" />
                 <Pin Id="Uf7KqunYQ8NNEghKjQMhIm" Name="Show" Kind="InputPin" />
+                <Pin Id="L6M0iB2ZwbAQdg6QYq6ehW" Name="Output" Kind="OutputPin" />
                 <Pin Id="AQGYTJ9XyPqPd9cy0CSIqf" Name="Result" Kind="OutputPin" />
                 <Pin Id="TP3ncK6yfOSMXi0LRbo7zS" Name="Ok" Kind="OutputPin" />
               </Node>
@@ -20672,6 +20835,7 @@
                           <Pin Id="OQtHFzc1GXnNykFI30qb3Z" Name="Node Context" Kind="InputPin" IsHidden="true" />
                           <Pin Id="JXHhulmAn9tOTZCMk0vFGa" Name="Messages" Kind="InputPin" />
                           <Pin Id="Q6cjNQeQkXLMFMLHjSIKNV" Name="Reset" Kind="InputPin" />
+                          <Pin Id="PNgWGp6sel6L2FsozInsPM" Name="Output" Kind="OutputPin" />
                           <Pin Id="AFeOeB0dLvDPvg4A41OcIy" Name="Result" Kind="OutputPin" />
                         </Node>
                         <Node Bounds="505,369,61,26" Id="QINhuMnd8aIOYANjlS4sCO">
@@ -20820,6 +20984,7 @@
                           <Pin Id="DDnOybzeILbQNteUIZNDNO" Name="Node Context" Kind="InputPin" IsHidden="true" />
                           <Pin Id="U8HU0RPsDcKLgi1lBxZPt0" Name="Messages" Kind="InputPin" />
                           <Pin Id="S4EUYTcCgzdMGNu4xvwZ7Z" Name="Reset" Kind="InputPin" />
+                          <Pin Id="NNBm3mi7drfPBvA0d2mw2G" Name="Output" Kind="OutputPin" />
                           <Pin Id="Oi5GhCuUk3oPQak1kth1IX" Name="Result" Kind="OutputPin" />
                         </Node>
                       </Patch>
@@ -20966,6 +21131,7 @@
                   <Pin Id="HIdCrCiN7VHME5R6aBmE7O" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="ETrgviuSlo1Mtl8vvrTpod" Name="Messages" Kind="InputPin" />
                   <Pin Id="JoDrGfQuIGFLaCCOJnxtC7" Name="Reset" Kind="InputPin" />
+                  <Pin Id="QIoFgcTRn93N98rIOswPqU" Name="Output" Kind="OutputPin" />
                   <Pin Id="MbNtJy0UOciOAUl70xQ2Wd" Name="Result" Kind="OutputPin" />
                 </Node>
                 <ControlPoint Id="StqCxrAB8KPNsSIU5WAK5H" Bounds="515,348" />
@@ -22703,6 +22869,7 @@
                   <Pin Id="BDOgicvzUK3PWnwg5LTJKM" Name="Loop Start Time" Kind="InputPin" />
                   <Pin Id="GAAvDJWqsF3M4g2SWNHlT0" Name="Loop End Time" Kind="InputPin" />
                   <Pin Id="CakXw6H0IIoL9VWUBjpysn" Name="Enabled" Kind="InputPin" />
+                  <Pin Id="AaEOZencMlTLWobNS2Ia64" Name="State Output" Kind="OutputPin" />
                   <Pin Id="AnQPO58JBUOPTTKjJ7o035" Name="Output" Kind="OutputPin" />
                   <Pin Id="Rvewc7BQjz4QYPgfjr1z08" Name="Version" Kind="OutputPin" />
                   <Pin Id="KZDDMVCtwkwPtdCPHfpkVC" Name="Original Size" Kind="OutputPin" />
@@ -22768,6 +22935,42 @@
             <Pin Id="Lw9O5JbB4XJMsdoNmBfAfU" Name="Application" Kind="InputPin" />
             <Pin Id="Q7BOO0RprLrLpZ96F1OLnv" Name="Output" Kind="OutputPin" />
           </Node>
+          <Node Bounds="480,480,77,19" Id="BZpL4xTNIISPzj4yP77phg">
+            <p:NodeReference LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="OperationCallFlag" Name="SystemFolder" />
+            </p:NodeReference>
+            <Pin Id="IzRypZLAQRXLoR5yey2G7C" Name="Special Folder" Kind="InputPin" DefaultValue="LocalApplicationData" />
+            <Pin Id="RgtwjabOL7SOWhRmsLktA9" Name="Result" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="480,580,60,19" Id="FvzqGbOcSxDMi1ddUZEpkl">
+            <p:NodeReference LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="OperationCallFlag" Name="MakePath" />
+            </p:NodeReference>
+            <Pin Id="BD0ng4cIl4hPHTPq6XeBiC" Name="Path" Kind="InputPin" IsHidden="true" />
+            <Pin Id="TgUyGOgFed0LPeOXN7gYTr" Name="Input" Kind="InputPin" />
+            <Pin Id="L31RJgD4lCMNmWM7SGuWXy" Name="Input 2" Kind="InputPin" />
+            <Pin Id="Cc9aQNZy5AHNfq4tQkRg7q" Name="Output" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="480,520,55,19" Id="Pc0cjGl4v1iOiDebRpUyJ1">
+            <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="OperationCallFlag" Name="ToString" />
+            </p:NodeReference>
+            <Pin Id="DhDI6XEoHa8P17Ljrjm0W2" Name="Input" Kind="InputPin" />
+            <Pin Id="IzM5EYJ72ZtLlt9jiOW8su" Name="Result" Kind="OutputPin" />
+          </Node>
+          <Pad Id="MUH5XFhwcn2N3s2aTA6YU7" Comment="" Bounds="537,550,152,15" ShowValueBox="true" isIOBox="true" Value="Temp\vvvv-package-cache">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+          </Pad>
+          <Pad Id="F8gm8lhXMWQPDhnP7Olg6O" Comment="" Bounds="482,450,144,15" ShowValueBox="true" isIOBox="true" Value="LocalApplicationData">
+            <p:TypeAnnotation LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="SpecialFolder" />
+            </p:TypeAnnotation>
+          </Pad>
         </Canvas>
         <Patch Id="KKnejguk59iOlItt5SMhF8" Name="Create" />
         <Patch Id="CKL6bDvGpbBMcPbl7oUMJl" Name="Update" />
@@ -22780,21 +22983,25 @@
         <Link Id="JyL7QuGqd5wLTQNjMNlILH" Ids="Q7BOO0RprLrLpZ96F1OLnv,C66dxMfii8eLTpXdFi2Z0a" />
         <Link Id="EDFh0Zc82h2PBIILqosifZ" Ids="VUqK419WdeSL73H3YcC0hP,Lw9O5JbB4XJMsdoNmBfAfU" />
         <Link Id="BdFXnNBECfsLvMOOc34cW6" Ids="PXt4MhFPF7sM49glNMIYkB,FOtvu5ptxnCMfy4a61eBXT" />
+        <Link Id="RnBepg1V8OEOACCxBDTnaq" Ids="RgtwjabOL7SOWhRmsLktA9,DhDI6XEoHa8P17Ljrjm0W2" />
+        <Link Id="L1Ig9IWgdE1O4iW4QaKgNI" Ids="IzM5EYJ72ZtLlt9jiOW8su,TgUyGOgFed0LPeOXN7gYTr" />
+        <Link Id="T0pPz4Pj5qZOiZ5kh2zAnx" Ids="MUH5XFhwcn2N3s2aTA6YU7,L31RJgD4lCMNmWM7SGuWXy" />
+        <Link Id="QccODdhlPpOO3Fh6jEP3Sz" Ids="F8gm8lhXMWQPDhnP7Olg6O,IzRypZLAQRXLoR5yey2G7C" />
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="Dx3hWrA5MJTP3PBl22Hc09" Location="VL.Skia" Version="2024.6.7-0145-g7866bdf1e8" />
+  <NugetDependency Id="Dx3hWrA5MJTP3PBl22Hc09" Location="VL.Skia" Version="2025.7.0-0200-g4a7221ecd9" />
   <PlatformDependency Id="PR2RZQLpnGKNZvYQVn3Ead" Location="mscorlib" />
   <PlatformDependency Id="Ow5sjuC3immNloZfvkN1g7" Location="System.Windows.Forms" />
   <PlatformDependency Id="HMEsYQpErI5OqaqpKnu53t" Location="System.Drawing" />
   <NugetDependency Id="A7QaxZnKLQBPrEoH3eQWQY" Location="RestSharp" Version="106.15.0" />
-  <NugetDependency Id="F8rLPob1tJWM13C9xxfQ3P" Location="VL.CoreLib.Windows" Version="2024.6.7-0145-g7866bdf1e8" />
+  <NugetDependency Id="F8rLPob1tJWM13C9xxfQ3P" Location="VL.CoreLib.Windows" Version="2025.7.0-0200-g4a7221ecd9" />
   <NugetDependency Id="Vnl8tgKwbGMP0yvGw64Adv" Location="Semver" Version="2.0.6" />
-  <NugetDependency Id="IscN5qIHnL6N2GQSwSz602" Location="VL.ImGui" Version="2024.6.7-0145-g7866bdf1e8" />
-  <NugetDependency Id="DueOVdpuzHRN7xQZ6gn9H6" Location="VL.ImGui.Skia" Version="2024.6.7-0145-g7866bdf1e8" />
+  <NugetDependency Id="IscN5qIHnL6N2GQSwSz602" Location="VL.ImGui" Version="2025.7.0-0200-g4a7221ecd9" />
+  <NugetDependency Id="DueOVdpuzHRN7xQZ6gn9H6" Location="VL.ImGui.Skia" Version="2025.7.0-0200-g4a7221ecd9" />
   <DocumentDependency Id="K4SG30vxDXFQCQQq5jLvaS" Location="./GammaLauncher.Proxies.vl" />
   <NugetDependency Id="ObULv8xpK0APMCczaZvh3u" Location="Downloader" Version="3.0.6" />
-  <NugetDependency Id="ExFUESH6MHIL8sAEZQOefx" Location="VL.WinFormsUtils" Version="1.0.9" />
+  <NugetDependency Id="ExFUESH6MHIL8sAEZQOefx" Location="VL.WinFormsUtils" Version="1.0.11" />
   <PlatformDependency Id="VR1jnqPcjfvLcoXBk3XpJ2" Location="System.Runtime" />
   <ProjectDependency Id="R4EKL4H4b3bNJt1ZkjFVpl" Location="./csharp/DeleteFolders.Utils/DeleteFolders.Utils.csproj" />
 </Document>


### PR DESCRIPTION
Currently I added only an option to the _Edit_ menu to show the package cache folder.
Thought about adding an additional entry  to  _Tools_ that deletes the whole cache. What do you think?


![image](https://github.com/user-attachments/assets/5b287893-76fc-44f7-8522-fb121eac32fc)
![image](https://github.com/user-attachments/assets/6423feff-65a8-4330-a459-f56b28f619da)

![image](https://github.com/user-attachments/assets/53439577-53f3-434a-8ba0-726eb42373cf)
