### PR TITLE
Superfluous stride references

### DIFF
--- a/GammaLauncher.vl
+++ b/GammaLauncher.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="PJSrtxvah1rPaRdkPeoySD" LanguageVersion="2025.7.1-0136-g42c85d3d1e" Version="0.128">
-  <NugetDependency Id="S7VWZeBsvN1PjJuK8xKPoa" Location="VL.CoreLib" Version="2025.7.1-0136-g42c85d3d1e" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="PJSrtxvah1rPaRdkPeoySD" LanguageVersion="2025.7.1-0140-gfee0e33407" Version="0.128">
+  <NugetDependency Id="S7VWZeBsvN1PjJuK8xKPoa" Location="VL.CoreLib" Version="2025.7.1-0140-gfee0e33407" />
   <Patch Id="VwtUUR3K9mbPm4q6fszgF3">
     <Canvas Id="Cn8FrGu71DtOiQColm6Utc" DefaultCategory="Main" CanvasType="FullCategory">
       <Canvas Id="A8kMw5cSAh9N9pwyyLzDKt" Name="Model" Position="92,129">
@@ -8031,7 +8031,7 @@
               <ControlPoint Id="AaicqeLftdTMKdWy1KhV7z" Bounds="368,1220" />
               <Pad Id="MxrPAx094ftQQyZlSPYf6r" SlotId="IBCfmCh4ARZMz3JReTqpRx" Bounds="408,1720" />
             </Canvas>
-            <Patch Id="Qbixy3pi0gWMxam2KVNapL" Name="Create" ParticipatingElements="Nm3cCG8r9yIPHsgblI8cZy,JlANtNYDIGrMKbvYyvwbTX,TR5llN47dAHPalZkD9DcTT,AsZeiz95lOlMunoNaeZTVA" />
+            <Patch Id="Qbixy3pi0gWMxam2KVNapL" Name="Create" ParticipatingElements="Nm3cCG8r9yIPHsgblI8cZy,TR5llN47dAHPalZkD9DcTT,JlANtNYDIGrMKbvYyvwbTX,AsZeiz95lOlMunoNaeZTVA" />
             <Patch Id="RvXW4bQrVLDN3zP0KEME7s" Name="Update">
               <Pin Id="EuG6ADqIgX8NZJa04iDcbg" Name="Launch Tab Runtime" Kind="InputPin" />
             </Patch>
@@ -21762,11 +21762,6 @@
                           <Patch Id="O3T5N2qzFl8PVcPCNWp8A9" Name="Update">
                             <Pin Id="L5M8elZeU3kOj5AE2Hg1Z6" Name="Output" Kind="OutputPin" />
                           </Patch>
-                          <!--
-
-    ************************  ************************
-
--->
                           <ProcessDefinition Id="A6zuK6TBj7OPUrBi6Dtx8M">
                             <Fragment Id="Od2NcS53bX3LwbRe5J9Jtq" Patch="AA8p8Wfbu0aLlGjXQ3MMJ0" Enabled="true" />
                             <Fragment Id="FLDnNbh601JLeOl7m1mXja" Patch="O3T5N2qzFl8PVcPCNWp8A9" Enabled="true" />
@@ -21797,11 +21792,6 @@
                     <Patch Id="H4LCtFMhYCSP8LWkvgrHPl" Name="Update">
                       <Pin Id="SAxQNsRyRPmNADxDbHkLyi" Name="Output" Kind="OutputPin" />
                     </Patch>
-                    <!--
-
-    ************************  ************************
-
--->
                     <ProcessDefinition Id="QrKtTPzIWwGPvMmQATobNc">
                       <Fragment Id="ApvQMcvywnvQR4YK5Hy7Tr" Patch="RDGUnAu57zrMHQWcMMrGma" Enabled="true" />
                       <Fragment Id="QRzExa1zj55Pr2ecwNXUCn" Patch="H4LCtFMhYCSP8LWkvgrHPl" Enabled="true" />
@@ -36009,24 +35999,22 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="Dx3hWrA5MJTP3PBl22Hc09" Location="VL.Skia" Version="2025.7.1-0136-g42c85d3d1e" />
+  <NugetDependency Id="Dx3hWrA5MJTP3PBl22Hc09" Location="VL.Skia" Version="2025.7.1-0140-gfee0e33407" />
   <PlatformDependency Id="PR2RZQLpnGKNZvYQVn3Ead" Location="mscorlib" />
   <PlatformDependency Id="Ow5sjuC3immNloZfvkN1g7" Location="System.Windows.Forms" />
   <PlatformDependency Id="HMEsYQpErI5OqaqpKnu53t" Location="System.Drawing" />
   <NugetDependency Id="A7QaxZnKLQBPrEoH3eQWQY" Location="RestSharp" Version="112.1.0" />
-  <NugetDependency Id="F8rLPob1tJWM13C9xxfQ3P" Location="VL.CoreLib.Windows" Version="2025.7.1-0136-g42c85d3d1e" />
+  <NugetDependency Id="F8rLPob1tJWM13C9xxfQ3P" Location="VL.CoreLib.Windows" Version="2025.7.1-0140-gfee0e33407" />
   <NugetDependency Id="Vnl8tgKwbGMP0yvGw64Adv" Location="Semver" Version="2.0.6" />
-  <NugetDependency Id="IscN5qIHnL6N2GQSwSz602" Location="VL.ImGui" Version="2025.7.1-0136-g42c85d3d1e" />
-  <NugetDependency Id="DueOVdpuzHRN7xQZ6gn9H6" Location="VL.ImGui.Skia" Version="2025.7.1-0136-g42c85d3d1e" />
+  <NugetDependency Id="IscN5qIHnL6N2GQSwSz602" Location="VL.ImGui" Version="2025.7.1-0140-gfee0e33407" />
+  <NugetDependency Id="DueOVdpuzHRN7xQZ6gn9H6" Location="VL.ImGui.Skia" Version="2025.7.1-0140-gfee0e33407" />
   <DocumentDependency Id="K4SG30vxDXFQCQQq5jLvaS" Location="./GammaLauncher.Proxies.vl" />
   <NugetDependency Id="ObULv8xpK0APMCczaZvh3u" Location="Downloader" Version="3.0.6" />
   <PlatformDependency Id="VR1jnqPcjfvLcoXBk3XpJ2" Location="System.Runtime" />
   <ProjectDependency Id="R4EKL4H4b3bNJt1ZkjFVpl" Location="./csharp/DeleteFolders.Utils/DeleteFolders.Utils.csproj" />
   <NugetDependency Id="NZGwfegHrHbLjsdyccCvnP" Location="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />
   <PlatformDependency Id="GGVavhARzFvOQaBB04eyWt" Location="System.Diagnostics.Process" />
-  <NugetDependency Id="BRcWT473G3sQFbJVK8Qfj4" Location="VL.LogView" Version="2025.7.1-0136-g42c85d3d1e" />
-  <NugetDependency Id="MUsPzwDVchLNBcLgrIiLum" Location="VL.TPL.Dataflow" Version="2025.7.1-0136-g42c85d3d1e" />
-  <NugetDependency Id="ULNYBaBNeNEO53VGMkMB6b" Location="VL.Stride" Version="2025.7.1-0136-g42c85d3d1e" />
-  <PlatformDependency Id="JIKKm2o2Pa0QRxoUl8xRPg" Location="Stride.Graphics.dll" />
+  <NugetDependency Id="BRcWT473G3sQFbJVK8Qfj4" Location="VL.LogView" Version="2025.7.1-0140-gfee0e33407" />
+  <NugetDependency Id="MUsPzwDVchLNBcLgrIiLum" Location="VL.TPL.Dataflow" Version="2025.7.1-0140-gfee0e33407" />
   <PlatformDependency Id="HMIG52yBLGINE4uKd70SXt" Location="System.dll" />
 </Document>

--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
 	<PropertyGroup>
-        <Version>5.4.0</Version>
+        <Version>5.4.1</Version>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
Removes superfluous references to VL.Stride nuget and Stride.Graphics.dll. Fixes #106 .